### PR TITLE
NMS-20263: Improve shipped OpenAPI/Swagger Docs

### DIFF
--- a/features/bsm/rest/api/pom.xml
+++ b/features/bsm/rest/api/pom.xml
@@ -20,6 +20,8 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <!-- Swagger annotations are compile-time only; Sentinel and Minion do not ship the bundle. -->
+            <Import-Package>io.swagger.v3.oas.annotations;resolution:=optional,io.swagger.v3.oas.annotations.*;resolution:=optional,*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/bsm/rest/api/pom.xml
+++ b/features/bsm/rest/api/pom.xml
@@ -45,6 +45,13 @@
     </plugins>
   </build>
   <dependencies>
+    <!-- Annotations only; swagger-annotations already ships in the webapp's WEB-INF/lib. -->
+    <dependency>
+      <groupId>io.swagger.core.v3</groupId>
+      <artifactId>swagger-annotations</artifactId>
+      <version>${swaggerVersion}</version>
+      <scope>provided</scope>
+    </dependency>
     <!-- All of this projects dependencies should have either a 'provided' or 'test' scope, since
          this .jar gets pull into jetty-webapps/opennmns/WEB-INF/lib -->
     <dependency>

--- a/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/BusinessServiceListDTO.java
+++ b/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/BusinessServiceListDTO.java
@@ -34,6 +34,7 @@ import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.map.annotate.JsonDeserialize;
 import org.codehaus.jackson.map.annotate.JsonRootName;
 import org.codehaus.jackson.map.annotate.JsonSerialize;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.opennms.netmgt.bsm.service.model.BusinessService;
 import org.opennms.web.rest.api.ResourceLocation;
 import org.opennms.web.rest.api.ResourceLocationFactory;
@@ -43,6 +44,7 @@ import org.opennms.web.rest.api.support.JsonResourceLocationListSerializationPro
 
 @XmlRootElement(name = "business-services")
 @JsonRootName("business-services")
+@Schema(description = "Resource locations of the defined business services, one link per service.")
 public class BusinessServiceListDTO {
     private List<ResourceLocation> services;
 

--- a/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/BusinessServiceRequestDTO.java
+++ b/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/BusinessServiceRequestDTO.java
@@ -35,6 +35,7 @@ import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import org.codehaus.jackson.annotate.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.opennms.web.rest.v2.bsm.model.edge.AbstractEdgeRequestDTO;
 import org.opennms.web.rest.v2.bsm.model.edge.ApplicationEdgeRequestDTO;
 import org.opennms.web.rest.v2.bsm.model.edge.ChildEdgeRequestDTO;
@@ -47,31 +48,42 @@ import com.google.common.collect.Maps;
 
 @XmlRootElement(name = "business-service")
 @XmlAccessorType(XmlAccessType.NONE)
+@Schema(description = """
+        A business service to create or replace. `child-edges`, `ip-service-edges` and
+        `reduction-key-edges` are applied; `application-edges` is accepted by the parser but not
+        applied.""")
 public class BusinessServiceRequestDTO {
 
+    @Schema(description = "Display name of the business service.", example = "Storefront")
     @XmlElement(name = "name")
     private String m_name;
 
+    @Schema(description = "Free-form key/value metadata. Serialized as `{\"attribute\":[{\"key\":\"...\",\"value\":\"...\"}]}`, not as a plain map; a plain map fails with a 500.")
     @XmlElement(name = "attributes", required = false)
     @XmlJavaTypeAdapter(JAXBMapAdapter.class)
     private Map<String, String> m_attributes = Maps.newLinkedHashMap();
 
+    @Schema(description = "Edges pointing at monitored IP services.")
     @XmlElement(name="ip-service-edge")
     @XmlElementWrapper(name="ip-service-edges")
     private List<IpServiceEdgeRequestDTO> m_ipServices = Lists.newArrayList();
 
+    @Schema(description = "Edges pointing at other business services. The resulting graph has to stay acyclic.")
     @XmlElement(name="child-edge")
     @XmlElementWrapper(name="child-edges")
     private List<ChildEdgeRequestDTO> m_childServices = Lists.newArrayList();
 
+    @Schema(description = "Edges listening on raw alarm reduction keys.")
     @XmlElement(name="reduction-key-edge")
     @XmlElementWrapper(name="reduction-key-edges")
     private List<ReductionKeyEdgeRequestDTO> reductionKeys = Lists.newArrayList();
 
+    @Schema(description = "Edges pointing at applications. Read back on the response; not applied from a request body.")
     @XmlElement(name="application-edge")
     @XmlElementWrapper(name="application-edges")
     private List<ApplicationEdgeRequestDTO> m_applications = Lists.newArrayList();
 
+    @Schema(description = "Function turning the mapped edge severities into this service's operational status.")
     @XmlElement(name="reduce-function")
     private ReduceFunctionDTO reduceFunction;
 

--- a/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/BusinessServiceResponseDTO.java
+++ b/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/BusinessServiceResponseDTO.java
@@ -47,46 +47,61 @@ import org.opennms.web.rest.v2.bsm.model.edge.ReductionKeyEdgeResponseDTO;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import com.google.common.collect.Sets;
 
 
 @XmlRootElement(name = "business-service")
 @XmlAccessorType(XmlAccessType.NONE)
+@Schema(description = "A business service with its edges grouped by kind and its current operational status.")
 public class BusinessServiceResponseDTO {
     
+    @Schema(description = "Business service id.", example = "23663")
     @XmlElement(name = "id")
     private Long m_id;
 
+    @Schema(description = "Display name of the business service.", example = "Storefront")
     @XmlElement(name = "name")
     private String m_name;
 
+    @Schema(description = "Free-form key/value metadata, serialized as `{\"attribute\":[{\"key\":\"...\",\"value\":\"...\"}]}`.")
     @XmlElement(name = "attributes", required = false)
     @XmlJavaTypeAdapter(JAXBMapAdapter.class)
     private Map<String, String> m_attributes = Maps.newLinkedHashMap();
 
+    @Schema(description = "Edges pointing at monitored IP services.")
     @XmlElement(name="ip-service-edge")
     @XmlElementWrapper(name="ip-service-edges")
     private List<IpServiceEdgeResponseDTO> m_ipServices = Lists.newArrayList();
 
+    @Schema(description = "Edges listening on raw alarm reduction keys.")
     @XmlElement(name="reduction-key-edge")
     @XmlElementWrapper(name="reduction-key-edges")
     private List<ReductionKeyEdgeResponseDTO> m_reductionKeys = Lists.newArrayList();
 
+    @Schema(description = "Edges pointing at other business services.")
     @XmlElement(name="child-edge")
     @XmlElementWrapper(name="child-edges")
     private List<ChildEdgeResponseDTO> m_children = Lists.newArrayList();;
 
+    @Schema(description = "Edges pointing at applications.")
     @XmlElement(name="application-edge")
     @XmlElementWrapper(name="application-edges")
     private List<ApplicationEdgeResponseDTO> m_applications = Lists.newArrayList();
 
+    @Schema(description = "Ids of the business services holding a child edge onto this one.")
     @XmlElement(name="parent-service")
     @XmlElementWrapper(name="parent-services")
     private Set<Long> m_parentServices = Sets.newLinkedHashSet();
 
+    @Schema(description = "Function turning the mapped edge severities into this service's operational status.")
     @XmlElement(name="reduce-function")
     private ReduceFunctionDTO m_reduceFunction;
 
+    @Schema(description = "Current status of the service. INDETERMINATE until the BSM daemon has "
+            + "evaluated it.",
+            example = "INDETERMINATE")
     @XmlElement(name="operational-status")
     private Status m_operationalStatus;
 

--- a/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/MapFunctionDTO.java
+++ b/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/MapFunctionDTO.java
@@ -35,8 +35,8 @@ import com.google.common.collect.Maps;
 @XmlRootElement(name = "map-function")
 @XmlAccessorType(XmlAccessType.NONE)
 @Schema(description = """
-        A map function applied to one edge's severity before the reduce function sees it. Take `type`
-        and the `properties` keys from `GET /business-services/functions/map`.""")
+        A map function applied to one edge's severity before the reduce function sees it. `type` and
+        the `properties` keys are those reported by `GET /business-services/functions/map`.""")
 public class MapFunctionDTO {
 
     @Schema(description = "Map function name.", example = "Identity", required = true,

--- a/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/MapFunctionDTO.java
+++ b/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/MapFunctionDTO.java
@@ -29,15 +29,24 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import com.google.common.collect.Maps;
 
 @XmlRootElement(name = "map-function")
 @XmlAccessorType(XmlAccessType.NONE)
+@Schema(description = """
+        A map function applied to one edge's severity before the reduce function sees it. Take `type`
+        and the `properties` keys from `GET /business-services/functions/map`.""")
 public class MapFunctionDTO {
 
+    @Schema(description = "Map function name.", example = "Identity", required = true,
+            allowableValues = {"Identity", "Increase", "Decrease", "Ignore", "SetTo"})
     @XmlElement(name="type", required = true)
     private String type;
 
+    @Schema(description = "Function parameters, keyed by the parameter `key` the metadata endpoint reports. "
+            + "Empty for functions that take none.",
+            example = "{}")
     @XmlElement(name="properties")
     private Map<String, String> properties = Maps.newHashMap();
 

--- a/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/ReduceFunctionDTO.java
+++ b/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/ReduceFunctionDTO.java
@@ -36,7 +36,7 @@ import com.google.common.collect.Maps;
 @XmlAccessorType(XmlAccessType.FIELD)
 @Schema(description = """
         A reduce function turning the mapped severities of a service's edges into the service's own
-        operational status. Take `type` and the `properties` keys from
+        operational status. `type` and the `properties` keys are those reported by
         `GET /business-services/functions/reduce`.""")
 public class ReduceFunctionDTO {
 

--- a/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/ReduceFunctionDTO.java
+++ b/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/ReduceFunctionDTO.java
@@ -29,15 +29,25 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import com.google.common.collect.Maps;
 
 @XmlRootElement(name = "reduce-function")
 @XmlAccessorType(XmlAccessType.FIELD)
+@Schema(description = """
+        A reduce function turning the mapped severities of a service's edges into the service's own
+        operational status. Take `type` and the `properties` keys from
+        `GET /business-services/functions/reduce`.""")
 public class ReduceFunctionDTO {
 
+    @Schema(description = "Reduce function name.", example = "HighestSeverity", required = true,
+            allowableValues = {"HighestSeverity", "HighestSeverityAbove", "ExponentialPropagation", "Threshold"})
     @XmlElement(name="type", required = true)
     private String type;
 
+    @Schema(description = "Function parameters, keyed by the parameter `key` the metadata endpoint reports. "
+            + "Empty for functions that take none.",
+            example = "{\"threshold\":\"0.26\"}")
     @XmlElement(name="properties")
     private Map<String, String> properties = Maps.newHashMap();
 

--- a/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/edge/AbstractEdgeRequestDTO.java
+++ b/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/edge/AbstractEdgeRequestDTO.java
@@ -27,14 +27,19 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.opennms.web.rest.v2.bsm.model.MapFunctionDTO;
 
 @XmlAccessorType(XmlAccessType.NONE)
+@Schema(description = "Fields shared by every edge request.")
 public abstract class AbstractEdgeRequestDTO {
 
+    @Schema(description = "Map function applied to this edge's severity.")
     @XmlElement(name="map-function")
     private MapFunctionDTO mapFunction;
 
+    @Schema(description = "Relative weight of this edge in the reduce function. Defaults to 1.",
+            example = "1")
     @XmlElement(name="weight", required = true)
     private int weight = 1;
 

--- a/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/edge/AbstractEdgeResponseDTO.java
+++ b/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/edge/AbstractEdgeResponseDTO.java
@@ -38,6 +38,7 @@ import org.opennms.web.rest.api.ResourceLocation;
 import org.opennms.web.rest.api.support.JAXBResourceLocationAdapter;
 import org.opennms.web.rest.api.support.JsonResourceLocationDeserializationProvider;
 import org.opennms.web.rest.api.support.JsonResourceLocationSerializationProvider;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.opennms.web.rest.v2.bsm.model.MapFunctionDTO;
 
 import com.google.common.base.MoreObjects;
@@ -45,12 +46,17 @@ import com.google.common.base.MoreObjects;
 @XmlAccessorType(XmlAccessType.NONE)
 public abstract class AbstractEdgeResponseDTO {
 
+    @Schema(description = "Edge id. Reassigned when the owning service is replaced with a PUT.",
+            example = "23667")
     @XmlElement(name="id")
     private long id;
 
+    @Schema(description = "Severity this edge currently contributes, after its map function.",
+            example = "INDETERMINATE")
     @XmlElement(name="operational-status")
     private Status operationalStatus;
 
+    @Schema(description = "Map function applied to this edge's severity.")
     @XmlElement(name="map-function")
     private MapFunctionDTO mapFunction;
 
@@ -60,6 +66,8 @@ public abstract class AbstractEdgeResponseDTO {
     @JsonDeserialize(using = JsonResourceLocationDeserializationProvider.class)
     private ResourceLocation location;
 
+    @Schema(description = "Reduction keys this edge listens on. Derived for IP-service and "
+            + "application edges; the supplied key for a reduction-key edge; empty for a child edge.")
     @XmlElement(name="reduction-key")
     @XmlElementWrapper(name="reduction-keys")
     private Set<String> reductionKeys = new HashSet<>();

--- a/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/edge/ApplicationEdgeRequestDTO.java
+++ b/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/edge/ApplicationEdgeRequestDTO.java
@@ -21,14 +21,18 @@
  */
 package org.opennms.web.rest.v2.bsm.model.edge;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name="application-edge")
+@Schema(description = "An edge pointing at an application.")
 public class ApplicationEdgeRequestDTO extends AbstractEdgeRequestDTO {
 
     private Integer applicationId;
 
+    @Schema(description = "Application id, as returned by `/api/v2/applications`.",
+            example = "1", required = true)
     @XmlElement(name="application-id",required = true)
     public Integer getApplicationId() {
         return applicationId;

--- a/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/edge/ApplicationEdgeResponseDTO.java
+++ b/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/edge/ApplicationEdgeResponseDTO.java
@@ -26,13 +26,16 @@ import java.util.Objects;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import io.swagger.v3.oas.annotations.media.Schema;
 import javax.xml.bind.annotation.XmlRootElement;
 
 
 @XmlRootElement(name = "application-edge")
 @XmlAccessorType(XmlAccessType.NONE)
+@Schema(description = "An edge pointing at an application.")
 public class ApplicationEdgeResponseDTO extends AbstractEdgeResponseDTO {
 
+    @Schema(description = "The application this edge points at.")
     @XmlElement(name = "application")
     private ApplicationResponseDTO application;
 

--- a/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/edge/ApplicationResponseDTO.java
+++ b/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/edge/ApplicationResponseDTO.java
@@ -34,6 +34,7 @@ import org.opennms.web.rest.api.support.JAXBResourceLocationAdapter;
 import org.opennms.web.rest.api.support.JsonResourceLocationDeserializationProvider;
 import org.opennms.web.rest.api.support.JsonResourceLocationSerializationProvider;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
@@ -41,9 +42,11 @@ import com.google.common.base.Objects;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class ApplicationResponseDTO {
 
+    @Schema(description = "Application id.", example = "1")
     @XmlElement(name="id")
     private int m_id;
 
+    @Schema(description = "Application name.", example = "Review Billing")
     @XmlElement(name="application-name")
     private String m_applicationName;
 

--- a/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/edge/ChildEdgeRequestDTO.java
+++ b/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/edge/ChildEdgeRequestDTO.java
@@ -21,14 +21,18 @@
  */
 package org.opennms.web.rest.v2.bsm.model.edge;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name="child-edge")
+@Schema(description = "An edge pointing at another business service.")
 public class ChildEdgeRequestDTO extends AbstractEdgeRequestDTO {
 
     private Long childId;
 
+    @Schema(description = "Id of the child business service. The resulting graph has to stay acyclic.",
+            example = "23641", required = true)
     @XmlElement(name="child-id",required = true)
     public Long getChildId() {
         return childId;

--- a/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/edge/ChildEdgeResponseDTO.java
+++ b/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/edge/ChildEdgeResponseDTO.java
@@ -24,12 +24,15 @@ package org.opennms.web.rest.v2.bsm.model.edge;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import io.swagger.v3.oas.annotations.media.Schema;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name="child-edge")
 @XmlAccessorType(XmlAccessType.NONE)
+@Schema(description = "An edge pointing at another business service.")
 public class ChildEdgeResponseDTO extends AbstractEdgeResponseDTO {
 
+    @Schema(description = "Id of the child business service.", example = "23641")
     @XmlElement(name="child-id")
     private Long childId;
 

--- a/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/edge/IpServiceEdgeRequestDTO.java
+++ b/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/edge/IpServiceEdgeRequestDTO.java
@@ -21,16 +21,21 @@
  */
 package org.opennms.web.rest.v2.bsm.model.edge;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name="ip-service-edge")
+@Schema(description = "An edge pointing at a monitored IP service. The edge listens on the node, "
+        + "interface and service reduction keys derived from that service.")
 public class IpServiceEdgeRequestDTO extends AbstractEdgeRequestDTO {
 
     private Integer ipServiceId;
 
     private String friendlyName;
 
+    @Schema(description = "Monitored service id, as returned by `/api/v2/ifservices`.",
+            example = "1017", required = true)
     @XmlElement(name="ip-service-id",required = true)
     public Integer getIpServiceId() {
         return ipServiceId;
@@ -40,6 +45,7 @@ public class IpServiceEdgeRequestDTO extends AbstractEdgeRequestDTO {
         this.ipServiceId = ipServiceId;
     }
 
+    @Schema(description = "Label shown for this edge in the UI.", example = "web front end")
     @XmlElement(name="friendly-name",required = false)
     public String getFriendlyName() {
         return friendlyName;

--- a/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/edge/IpServiceEdgeResponseDTO.java
+++ b/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/edge/IpServiceEdgeResponseDTO.java
@@ -26,15 +26,19 @@ import java.util.Objects;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import io.swagger.v3.oas.annotations.media.Schema;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "ip-service-edge")
 @XmlAccessorType(XmlAccessType.NONE)
+@Schema(description = "An edge pointing at a monitored IP service.")
 public class IpServiceEdgeResponseDTO extends AbstractEdgeResponseDTO {
 
+    @Schema(description = "The monitored IP service this edge points at.")
     @XmlElement(name="ip-service")
     private IpServiceResponseDTO ipService;
 
+    @Schema(description = "Label shown for this edge in the UI.", example = "web front end")
     @XmlElement(name="friendly-name",required = false)
     private String friendlyName;
 

--- a/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/edge/IpServiceResponseDTO.java
+++ b/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/edge/IpServiceResponseDTO.java
@@ -34,21 +34,28 @@ import org.opennms.web.rest.api.support.JAXBResourceLocationAdapter;
 import org.opennms.web.rest.api.support.JsonResourceLocationDeserializationProvider;
 import org.opennms.web.rest.api.support.JsonResourceLocationSerializationProvider;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import com.google.common.base.Objects;
 
 @XmlRootElement(name = "ip-service")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class IpServiceResponseDTO {
 
+    @Schema(description = "Monitored service id.", example = "1017")
     @XmlElement(name="id")
     private int m_id;
 
+    @Schema(description = "Service type name.", example = "HTTP-8080")
     @XmlElement(name="service-name")
     private String m_serviceName;
 
+    @Schema(description = "Label of the node the service is on.", example = "loopback-001")
     @XmlElement(name="node-label")
     private String m_nodeLabel;
 
+    @Schema(description = "Interface address the service is on. Carries the leading slash of "
+            + "InetAddress.toString().",
+            example = "/127.0.0.1")
     @XmlElement(name="ip-address")
     private String m_ipAddress;
 

--- a/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/edge/ReductionKeyEdgeRequestDTO.java
+++ b/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/edge/ReductionKeyEdgeRequestDTO.java
@@ -21,15 +21,20 @@
  */
 package org.opennms.web.rest.v2.bsm.model.edge;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name="reduction-key-edge")
+@Schema(description = "An edge listening on one raw alarm reduction key.")
 public class ReductionKeyEdgeRequestDTO extends AbstractEdgeRequestDTO {
     private String reductionKey;
 
     private String friendlyName;
 
+    @Schema(description = "Alarm reduction key to listen on. Matched as an opaque string and not "
+            + "validated against existing alarms.",
+            example = "uei.opennms.org/nodes/nodeDown::1", required = true)
     @XmlElement(name="reduction-key",required = true)
     public String getReductionKey() {
         return reductionKey;
@@ -39,6 +44,7 @@ public class ReductionKeyEdgeRequestDTO extends AbstractEdgeRequestDTO {
         this.reductionKey = reductionKey;
     }
 
+    @Schema(description = "Label shown for this edge in the UI.", example = "core switch down")
     @XmlElement(name="friendly-name",required = false)
     public String getFriendlyName() {
         return friendlyName;

--- a/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/edge/ReductionKeyEdgeResponseDTO.java
+++ b/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/edge/ReductionKeyEdgeResponseDTO.java
@@ -26,12 +26,15 @@ import java.util.Objects;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import io.swagger.v3.oas.annotations.media.Schema;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name="reduction-key-edge")
 @XmlAccessorType(XmlAccessType.NONE)
+@Schema(description = "An edge listening on one raw alarm reduction key.")
 public class ReductionKeyEdgeResponseDTO extends AbstractEdgeResponseDTO {
 
+    @Schema(description = "Label shown for this edge in the UI.", example = "core switch down")
     @XmlElement(name="friendly-name",required = false)
     private String friendlyName;
 

--- a/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/meta/FunctionMetaDTO.java
+++ b/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/meta/FunctionMetaDTO.java
@@ -47,7 +47,7 @@ public class FunctionMetaDTO {
     @XmlAttribute
     private FunctionType type;
 
-    @Schema(description = "Function name. Use it as the `type` of a `map-function` or "
+    @Schema(description = "Function name, used as the `type` of a `map-function` or "
             + "`reduce-function` object.",
             example = "Identity", required = true)
     @XmlAttribute(name="name", required=true)

--- a/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/meta/FunctionMetaDTO.java
+++ b/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/meta/FunctionMetaDTO.java
@@ -34,22 +34,30 @@ import javax.xml.bind.annotation.XmlRootElement;
 import org.opennms.netmgt.bsm.service.model.functions.annotations.Function;
 import org.opennms.netmgt.bsm.service.model.functions.annotations.Parameter;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
 @XmlRootElement(name="function")
 @XmlAccessorType(XmlAccessType.NONE)
+@Schema(description = "One map or reduce function and the parameters it takes.")
 public class FunctionMetaDTO {
 
+    @Schema(description = "Whether this is a map or a reduce function.", example = "MapFunction")
     @XmlAttribute
     private FunctionType type;
 
+    @Schema(description = "Function name. Use it as the `type` of a `map-function` or "
+            + "`reduce-function` object.",
+            example = "Identity", required = true)
     @XmlAttribute(name="name", required=true)
     private String name;
 
+    @Schema(description = "What the function does.", example = "Use the status as is")
     @XmlAttribute(name="description")
     private String description;
 
+    @Schema(description = "Parameters the function accepts in its `properties` map.")
     @XmlElement(name="parameter")
     private List<ParameterMetaDTO> parameters;
 

--- a/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/meta/FunctionMetaListDTO.java
+++ b/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/meta/FunctionMetaListDTO.java
@@ -26,10 +26,12 @@ import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import io.swagger.v3.oas.annotations.media.Schema;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "functions")
 @XmlAccessorType(XmlAccessType.NONE)
+@Schema(description = "The available map or reduce functions.")
 public class FunctionMetaListDTO {
     private List<FunctionMetaDTO> functions;
 

--- a/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/meta/ParameterMetaDTO.java
+++ b/features/bsm/rest/api/src/main/java/org/opennms/web/rest/v2/bsm/model/meta/ParameterMetaDTO.java
@@ -29,22 +29,31 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.opennms.netmgt.bsm.service.model.functions.annotations.Parameter;
 
 @XmlRootElement(name="parameter")
 @XmlAccessorType(XmlAccessType.NONE)
+@Schema(description = "One parameter of a map or reduce function.")
 public class ParameterMetaDTO {
 
+    @Schema(description = "Key to use in the function's `properties` map.", example = "threshold", required = true)
     @XmlAttribute(name="key", required=true)
     private String key;
 
+    @Schema(description = "Value type. `status` means a severity name; the numeric types are parsed "
+            + "from the string.",
+            example = "float", required = true,
+            allowableValues = {"status", "float", "double", "long", "int", "String"})
     @XmlAttribute(name="type", required=true)
     private String type;
 
+    @Schema(description = "What the parameter controls.", example = "The Threshold to use", required = true)
     @XmlAttribute(name="description", required=true)
     private String description;
 
     // At the moment we do not have an optional parameter, but we may get it in the future
+    @Schema(description = "Whether the parameter has to be supplied.", example = "true", required = true)
     @XmlAttribute(name="required", required=true)
     private boolean required = true;
 

--- a/features/bsm/rest/impl/pom.xml
+++ b/features/bsm/rest/impl/pom.xml
@@ -26,6 +26,13 @@
     </plugins>
   </build>
   <dependencies>
+    <!-- Annotations only; swagger-annotations already ships in the webapp's WEB-INF/lib. -->
+    <dependency>
+      <groupId>io.swagger.core.v3</groupId>
+      <artifactId>swagger-annotations</artifactId>
+      <version>${swaggerVersion}</version>
+      <scope>provided</scope>
+    </dependency>
     <!-- All of this projects dependencies should have either a 'provided' or 'test' scope, since
          this .jar gets pull into jetty-webapps/opennmns/WEB-INF/lib -->
     <dependency>

--- a/features/bsm/rest/impl/pom.xml
+++ b/features/bsm/rest/impl/pom.xml
@@ -20,6 +20,8 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <!-- Swagger annotations are compile-time only; Sentinel and Minion do not ship the bundle. -->
+            <Import-Package>io.swagger.v3.oas.annotations;resolution:=optional,io.swagger.v3.oas.annotations.*;resolution:=optional,*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/bsm/rest/impl/src/main/java/org/opennms/web/rest/v2/bsm/BusinessServiceRestService.java
+++ b/features/bsm/rest/impl/src/main/java/org/opennms/web/rest/v2/bsm/BusinessServiceRestService.java
@@ -109,8 +109,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
         `{"attribute":[{"key":"...","value":"..."}]}`, and sending a plain map fails with a 500.
 
         `POST /business-services` and `PUT /business-services/{id}` apply the child, IP-service and
-        reduction-key edges in the body. Application edges are read back on the response but are not
-        applied from a request body, and there is no per-edge endpoint for them.
+        reduction-key edges in the body. `application-edges` is parsed and discarded: application edges
+        are read back on responses only, and have no per-edge endpoint.
 
         A `{id}` or `{edgeId}` that does not exist is a 404 whose body is a `text/plain` entity
         description such as `BusinessServiceEntity with id 42`. Requests that would not change anything
@@ -163,7 +163,7 @@ public class BusinessServiceRestService {
             summary = "List business services",
             description = """
         Return a link per business service. The list carries resource locations, not the services
-        themselves; follow each one to `GET /business-services/{id}` for the detail.""",
+        themselves; the detail is at `GET /business-services/{id}`.""",
             operationId = "listBusinessServices"
     )
     @ApiResponses(value = {
@@ -512,7 +512,7 @@ public class BusinessServiceRestService {
             description = """
         Add one IP-service edge to an existing business service, leaving its other edges alone. An edge
         that already matches the request adds nothing and answers 304. A successful response carries no
-        body; read the new edge id back from `GET /business-services/{id}`.""",
+        body; the new edge id is readable from `GET /business-services/{id}`.""",
             operationId = "addBusinessServiceIpServiceEdge"
     )
     @RequestBody(
@@ -686,8 +686,8 @@ public class BusinessServiceRestService {
             summary = "Reload the BSM daemon",
             description = """
         Ask the BSM daemon to rebuild its in-memory graph from the database and recompute every
-        operational status. Use it after editing business services outside this API. The call returns as
-        soon as the reload is triggered and carries no body.""",
+        operational status. The call returns as soon as the reload is triggered and carries no
+        body.""",
             operationId = "reloadBusinessServiceDaemon"
     )
     @ApiResponses(value = {
@@ -704,8 +704,8 @@ public class BusinessServiceRestService {
             summary = "List map functions",
             description = """
         Return every available map function with its parameters. A map function transforms the severity
-        an edge reports before the reduce function sees it. Use the `name` as the `type` of a
-        `map-function` object, and the `parameter` keys as its `properties`.""",
+        an edge reports before the reduce function sees it. The `name` is the `type` of a `map-function`
+        object; the `parameter` keys are its `properties`.""",
             operationId = "listBusinessServiceMapFunctions"
     )
     @ApiResponses(value = {
@@ -770,8 +770,8 @@ public class BusinessServiceRestService {
             summary = "List reduce functions",
             description = """
         Return every available reduce function with its parameters. A reduce function turns the mapped
-        severities of a service's edges into the service's own operational status. Use the `name` as the
-        `type` of a `reduce-function` object, and the `parameter` keys as its `properties`.""",
+        severities of a service's edges into the service's own operational status. The `name` is the
+        `type` of a `reduce-function` object; the `parameter` keys are its `properties`.""",
             operationId = "listBusinessServiceReduceFunctions"
     )
     @ApiResponses(value = {

--- a/features/bsm/rest/impl/src/main/java/org/opennms/web/rest/v2/bsm/BusinessServiceRestService.java
+++ b/features/bsm/rest/impl/src/main/java/org/opennms/web/rest/v2/bsm/BusinessServiceRestService.java
@@ -79,12 +79,77 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.google.common.collect.Sets;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 @Component
 @Path("business-services")
 @Transactional
 @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
 @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
+@Tag(name = "BusinessServices", description = """
+        Business Service Monitoring API.
+
+        A business service carries a reduce function and a set of edges. Each edge points at an IP
+        service, an application, a reduction key, or another business service, and carries a map function
+        and a weight. The reduce function turns the mapped severities of the edges into the service's own
+        operational status.
+
+        Bodies are JAXB beans serialized through the codehaus Jackson provider, so JSON field names come
+        from the `@XmlElement` names: `reduce-function`, `map-function`, `ip-service-edges`,
+        `child-edges`, `reduction-key-edges`, `ip-service-id`, `child-id`, `reduction-key`,
+        `friendly-name`. `attributes` is not a plain map: it serializes as
+        `{"attribute":[{"key":"...","value":"..."}]}`, and sending a plain map fails with a 500.
+
+        `POST /business-services` and `PUT /business-services/{id}` apply the child, IP-service and
+        reduction-key edges in the body. Application edges are read back on the response but are not
+        applied from a request body, and there is no per-edge endpoint for them.
+
+        A `{id}` or `{edgeId}` that does not exist is a 404 whose body is a `text/plain` entity
+        description such as `BusinessServiceEntity with id 42`. Requests that would not change anything
+        answer 304.""")
+// The response DTOs carrying a custom @JsonSerialize (BusinessServiceListDTO,
+// BusinessServiceResponseDTO, AbstractEdgeResponseDTO) are documented by example only:
+// swagger-core 2.1.12 introspects custom serializers through BeanDescription.findJsonValueMethod(),
+// which Jackson dropped after 2.12, so referencing them as a schema fails document generation.
 public class BusinessServiceRestService {
+
+    private static final String BUSINESS_SERVICE_REQUEST_EXAMPLE = """
+            {
+              "name": "Storefront",
+              "attributes": { "attribute": [ { "key": "dc", "value": "RDU" } ] },
+              "reduce-function": { "type": "Threshold", "properties": { "threshold": "0.26" } },
+              "ip-service-edges": [
+                {
+                  "ip-service-id": 1017,
+                  "friendly-name": "web front end",
+                  "map-function": { "type": "Identity", "properties": {} },
+                  "weight": 1
+                }
+              ],
+              "reduction-key-edges": [
+                {
+                  "reduction-key": "uei.opennms.org/nodes/nodeDown::1",
+                  "friendly-name": "core switch down",
+                  "map-function": { "type": "Increase", "properties": {} },
+                  "weight": 2
+                }
+              ],
+              "child-edges": [
+                {
+                  "child-id": 23641,
+                  "map-function": { "type": "Identity", "properties": {} },
+                  "weight": 1
+                }
+              ]
+            }""";
 
     @Autowired
     private BusinessServiceManager businessServiceManager;
@@ -94,6 +159,20 @@ public class BusinessServiceRestService {
     }
 
     @GET
+    @Operation(
+            summary = "List business services",
+            description = """
+        Return a link per business service. The list carries resource locations, not the services
+        themselves; follow each one to `GET /business-services/{id}` for the detail.""",
+            operationId = "listBusinessServices"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Business service locations returned",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            examples = @ExampleObject(value = """
+                    {"business-services":["/api/v2/business-services/23641","/api/v2/business-services/23663"]}"""))),
+            @ApiResponse(responseCode = "204", description = "No business service is defined.")
+    })
     public Response list() {
         List<BusinessService> services = getManager().getAllBusinessServices();
         if (services == null || services.isEmpty()) {
@@ -105,7 +184,60 @@ public class BusinessServiceRestService {
 
     @GET
     @Path("{id}")
-    public Response getById(@PathParam("id") Long id) {
+    @Operation(
+            summary = "Get a business service",
+            description = """
+        Return one business service with its reduce function, its edges grouped by kind, its parent
+        services and its current operational status. Each edge carries the reduction keys it listens on,
+        which for an IP-service edge are derived from the node, interface and service.""",
+            operationId = "getBusinessServiceById"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Business service returned",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            examples = @ExampleObject(value = """
+                    {
+                      "location": "/api/v2/business-services/23663",
+                      "id": 23663,
+                      "name": "Storefront",
+                      "attributes": { "attribute": [ { "key": "dc", "value": "RDU" } ] },
+                      "ip-service-edges": [
+                        {
+                          "id": 23667,
+                          "location": "/api/v2/business-services/23663/edges/23667",
+                          "weight": 1,
+                          "operational-status": "INDETERMINATE",
+                          "map-function": { "type": "Identity", "properties": {} },
+                          "reduction-keys": [
+                            "uei.opennms.org/nodes/nodeDown::2",
+                            "uei.opennms.org/nodes/nodeLostService::2:127.0.0.1:HTTP-8080",
+                            "uei.opennms.org/nodes/interfaceDown::2:127.0.0.1"
+                          ],
+                          "ip-service": {
+                            "location": "/rest/ifservices/1017",
+                            "id": 1017,
+                            "service-name": "HTTP-8080",
+                            "node-label": "loopback-001",
+                            "ip-address": "/127.0.0.1"
+                          },
+                          "friendly-name": "web front end"
+                        }
+                      ],
+                      "reduction-key-edges": [],
+                      "child-edges": [],
+                      "application-edges": [],
+                      "parent-services": [],
+                      "reduce-function": { "type": "HighestSeverity", "properties": {} },
+                      "operational-status": "INDETERMINATE"
+                    }"""))),
+            @ApiResponse(responseCode = "404", description = "No business service carries that id.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "BusinessServiceEntity with id 42")))
+    })
+    public Response getById(
+            @Parameter(description = "Business service id.", example = "23663", required = true)
+            @PathParam("id") Long id) {
         BusinessService service = getManager().getBusinessServiceById(id);
 
         final BusinessServiceResponseDTO response = new BusinessServiceResponseDTO();
@@ -146,6 +278,34 @@ public class BusinessServiceRestService {
     }
 
     @POST
+    @Operation(
+            summary = "Create a business service",
+            description = """
+        Create a business service from the supplied name, attributes, reduce function and edges. The
+        `Location` header of the 201 points at the new service. Referenced ids have to exist: an unknown
+        `child-id`, `ip-service-id` or `application-id` is reported as a 404 naming the missing entity.
+        A `child-edges` entry that would make the graph cyclic fails with a 500.
+        Application edges in the body are not applied.""",
+            operationId = "createBusinessService"
+    )
+    @RequestBody(
+            required = true,
+            description = "Business service to create.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = BusinessServiceRequestDTO.class),
+                    examples = @ExampleObject(value = BUSINESS_SERVICE_REQUEST_EXAMPLE))
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Business service created. No response body; `Location` points at the new service."),
+            @ApiResponse(responseCode = "404", description = "A referenced child service, IP service or application does not exist.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "OnmsMonitoredService with id 99999999"))),
+            @ApiResponse(responseCode = "500", description = "The edges would form a loop, or `attributes` was sent as a plain map instead of the `{\"attribute\":[...]}` wrapper.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Service will form a loop")))
+    })
     public Response create(@Context final UriInfo uriInfo, final BusinessServiceRequestDTO request) {
         final BusinessService service = getManager().createBusinessService();
         service.setName(request.getName());
@@ -194,7 +354,23 @@ public class BusinessServiceRestService {
 
     @DELETE
     @Path("{id}")
-    public Response delete(@PathParam("id") Long id) {
+    @Operation(
+            summary = "Delete a business service",
+            description = """
+        Delete one business service along with its edges. Edges in other services that pointed at it as a
+        child are removed with it. A successful response carries no body.""",
+            operationId = "deleteBusinessService"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Business service deleted. No response body."),
+            @ApiResponse(responseCode = "404", description = "No business service carries that id.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "BusinessServiceEntity with id 42")))
+    })
+    public Response delete(
+            @Parameter(description = "Business service id.", example = "23663", required = true)
+            @PathParam("id") Long id) {
         final BusinessService service = getManager().getBusinessServiceById(id);
         getManager().deleteBusinessService(service);
 
@@ -203,7 +379,36 @@ public class BusinessServiceRestService {
 
     @PUT
     @Path("{id}")
-    public Response update(@PathParam("id") final Long id, final BusinessServiceRequestDTO request) {
+    @Operation(
+            summary = "Replace a business service",
+            description = """
+        Replace a business service in full. The four edge collections are cleared before the body's edges
+        are applied, so an edge left out of the body is deleted and an edge that survives is recreated
+        with a new edge id. Application edges in the body are not applied.
+        A successful response carries no body.""",
+            operationId = "updateBusinessService"
+    )
+    @RequestBody(
+            required = true,
+            description = "Replacement business service.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = BusinessServiceRequestDTO.class),
+                    examples = @ExampleObject(value = BUSINESS_SERVICE_REQUEST_EXAMPLE))
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Business service replaced. No response body."),
+            @ApiResponse(responseCode = "404", description = "The business service, or a referenced child service, IP service or application, does not exist.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "BusinessServiceEntity with id 42"))),
+            @ApiResponse(responseCode = "500", description = "The edges would form a loop, or `attributes` was sent as a plain map instead of the `{\"attribute\":[...]}` wrapper.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Service will form a loop")))
+    })
+    public Response update(
+            @Parameter(description = "Business service id.", example = "23663", required = true)
+            @PathParam("id") final Long id, final BusinessServiceRequestDTO request) {
         final BusinessService service = getManager().getBusinessServiceById(id);
         service.setName(request.getName());
         service.setAttributes(request.getAttributes());
@@ -259,7 +464,42 @@ public class BusinessServiceRestService {
 
     @GET
     @Path("/edges/{edgeId}")
-    public Response getEdgeById(@PathParam("edgeId") final Long edgeId) {
+    @Operation(
+            summary = "Get an edge",
+            description = """
+        Return one edge by id, regardless of which business service owns it. The response shape depends
+        on the edge kind: an IP-service edge carries `ip-service`, a child edge carries `child-id`, a
+        reduction-key edge carries `reduction-key`, an application edge carries `application`.""",
+            operationId = "getBusinessServiceEdgeById"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Edge returned",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            examples = @ExampleObject(value = """
+                    {
+                      "id": 23667,
+                      "location": "/api/v2/business-services/23663/edges/23667",
+                      "weight": 1,
+                      "operational-status": "INDETERMINATE",
+                      "map-function": { "type": "Identity", "properties": {} },
+                      "reduction-keys": [ "uei.opennms.org/nodes/nodeDown::2" ],
+                      "ip-service": {
+                        "location": "/rest/ifservices/1017",
+                        "id": 1017,
+                        "service-name": "HTTP-8080",
+                        "node-label": "loopback-001",
+                        "ip-address": "/127.0.0.1"
+                      },
+                      "friendly-name": "web front end"
+                    }"""))),
+            @ApiResponse(responseCode = "404", description = "No edge carries that id.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "BusinessServiceEdgeEntity with id 42")))
+    })
+    public Response getEdgeById(
+            @Parameter(description = "Edge id.", example = "23667", required = true)
+            @PathParam("edgeId") final Long edgeId) {
         Edge edge = getManager().getEdgeById(edgeId);
         AbstractEdgeResponseDTO edgeDTO = transform(edge);
         return Response.ok().entity(edgeDTO).build();
@@ -267,8 +507,39 @@ public class BusinessServiceRestService {
 
     @POST
     @Path("{id}/ip-service-edge")
+    @Operation(
+            summary = "Add an IP service edge",
+            description = """
+        Add one IP-service edge to an existing business service, leaving its other edges alone. An edge
+        that already matches the request adds nothing and answers 304. A successful response carries no
+        body; read the new edge id back from `GET /business-services/{id}`.""",
+            operationId = "addBusinessServiceIpServiceEdge"
+    )
+    @RequestBody(
+            required = true,
+            description = "IP service edge to add.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = IpServiceEdgeRequestDTO.class),
+                    examples = @ExampleObject(value = """
+                    {
+                      "ip-service-id": 1017,
+                      "friendly-name": "web front end",
+                      "map-function": { "type": "Identity", "properties": {} },
+                      "weight": 1
+                    }"""))
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Edge added. No response body."),
+            @ApiResponse(responseCode = "304", description = "An identical edge is already present; nothing changed."),
+            @ApiResponse(responseCode = "404", description = "The business service or the IP service does not exist.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "OnmsMonitoredService with id 99999999")))
+    })
     // Add IpService
-    public Response addIpServiceEdge(@PathParam("id") final Long serviceId,
+    public Response addIpServiceEdge(
+            @Parameter(description = "Business service id the edge is added to.", example = "23663", required = true)
+            @PathParam("id") final Long serviceId,
                             final IpServiceEdgeRequestDTO edgeRequest) {
         final BusinessService businessService = getManager().getBusinessServiceById(serviceId);
         final IpService ipService = getManager().getIpServiceById(edgeRequest.getIpServiceId());
@@ -282,8 +553,40 @@ public class BusinessServiceRestService {
 
     @POST
     @Path("{id}/reduction-key-edge")
+    @Operation(
+            summary = "Add a reduction key edge",
+            description = """
+        Add one reduction-key edge to an existing business service, leaving its other edges alone. The
+        reduction key is matched against alarms as an opaque string and is not validated here. An edge
+        that already matches the request adds nothing and answers 304. A successful response carries no
+        body.""",
+            operationId = "addBusinessServiceReductionKeyEdge"
+    )
+    @RequestBody(
+            required = true,
+            description = "Reduction key edge to add.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = ReductionKeyEdgeRequestDTO.class),
+                    examples = @ExampleObject(value = """
+                    {
+                      "reduction-key": "uei.opennms.org/nodes/nodeDown::1",
+                      "friendly-name": "core switch down",
+                      "map-function": { "type": "Increase", "properties": {} },
+                      "weight": 2
+                    }"""))
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Edge added. No response body."),
+            @ApiResponse(responseCode = "304", description = "An identical edge is already present; nothing changed."),
+            @ApiResponse(responseCode = "404", description = "The business service does not exist.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "BusinessServiceEntity with id 42")))
+    })
     // Add Reduction Key
-    public Response addReductionKeyEdge(@PathParam("id") final Long serviceId,
+    public Response addReductionKeyEdge(
+            @Parameter(description = "Business service id the edge is added to.", example = "23663", required = true)
+            @PathParam("id") final Long serviceId,
                             final ReductionKeyEdgeRequestDTO edgeRequest) {
         final BusinessService businessService = getManager().getBusinessServiceById(serviceId);
         boolean changed = getManager().addReductionKeyEdge(businessService, edgeRequest.getReductionKey(), transform(edgeRequest.getMapFunction()), edgeRequest.getWeight(), edgeRequest.getFriendlyName());
@@ -296,8 +599,43 @@ public class BusinessServiceRestService {
 
     @POST
     @Path("{id}/child-edge")
+    @Operation(
+            summary = "Add a child service edge",
+            description = """
+        Add one child-service edge to an existing business service, leaving its other edges alone. An
+        edge that already matches the request adds nothing and answers 304. An edge that would make the
+        graph cyclic, including a service pointing at itself, fails with a 500. A successful response
+        carries no body.""",
+            operationId = "addBusinessServiceChildEdge"
+    )
+    @RequestBody(
+            required = true,
+            description = "Child service edge to add.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = ChildEdgeRequestDTO.class),
+                    examples = @ExampleObject(value = """
+                    {
+                      "child-id": 23641,
+                      "map-function": { "type": "Identity", "properties": {} },
+                      "weight": 1
+                    }"""))
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Edge added. No response body."),
+            @ApiResponse(responseCode = "304", description = "An identical edge is already present; nothing changed."),
+            @ApiResponse(responseCode = "404", description = "The parent or the child business service does not exist.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "BusinessServiceEntity with id 42"))),
+            @ApiResponse(responseCode = "500", description = "The edge would form a loop.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Service will form a loop")))
+    })
     // Add Child Service
-    public Response addChildServiceEdge(@PathParam("id") final Long serviceId,
+    public Response addChildServiceEdge(
+            @Parameter(description = "Parent business service id the edge is added to.", example = "23663", required = true)
+            @PathParam("id") final Long serviceId,
                             final ChildEdgeRequestDTO edgeRequest) {
         final BusinessService parentService = getManager().getBusinessServiceById(serviceId);
         final BusinessService childService = getManager().getBusinessServiceById(edgeRequest.getChildId());
@@ -311,8 +649,27 @@ public class BusinessServiceRestService {
 
     @DELETE
     @Path("{id}/edges/{edgeId}")
-    public Response removeEdge(@PathParam("id") final Long serviceId,
-                               @PathParam("edgeId") final Long edgeId) {
+    @Operation(
+            summary = "Remove an edge from a business service",
+            description = """
+        Delete one edge from the given business service. An edge that exists but belongs to a different
+        service is left alone and answers 304; an edge id that does not exist at all is a 404. A
+        successful response carries no body.""",
+            operationId = "removeBusinessServiceEdge"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Edge removed. No response body."),
+            @ApiResponse(responseCode = "304", description = "The edge does not belong to that business service; nothing changed."),
+            @ApiResponse(responseCode = "404", description = "The business service or the edge does not exist.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "BusinessServiceEdgeEntity with id 42")))
+    })
+    public Response removeEdge(
+            @Parameter(description = "Business service id owning the edge.", example = "23663", required = true)
+            @PathParam("id") final Long serviceId,
+            @Parameter(description = "Edge id to remove.", example = "23667", required = true)
+            @PathParam("edgeId") final Long edgeId) {
         final BusinessService service = getManager().getBusinessServiceById(serviceId);
         final Edge edge = getManager().getEdgeById(edgeId);
         boolean changed = getManager().deleteEdge(service, edge);
@@ -325,6 +682,17 @@ public class BusinessServiceRestService {
 
     @POST
     @Path("daemon/reload")
+    @Operation(
+            summary = "Reload the BSM daemon",
+            description = """
+        Ask the BSM daemon to rebuild its in-memory graph from the database and recompute every
+        operational status. Use it after editing business services outside this API. The call returns as
+        soon as the reload is triggered and carries no body.""",
+            operationId = "reloadBusinessServiceDaemon"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Reload triggered. No response body.")
+    })
     public Response reload() {
         getManager().triggerDaemonReload();
         return Response.ok().build();
@@ -332,13 +700,63 @@ public class BusinessServiceRestService {
 
     @GET
     @Path("functions/map")
+    @Operation(
+            summary = "List map functions",
+            description = """
+        Return every available map function with its parameters. A map function transforms the severity
+        an edge reports before the reduce function sees it. Use the `name` as the `type` of a
+        `map-function` object, and the `parameter` keys as its `properties`.""",
+            operationId = "listBusinessServiceMapFunctions"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Map function metadata returned",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = FunctionMetaListDTO.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "function": [
+                        { "type": "MapFunction", "name": "Identity", "description": "Use the status as is", "parameter": [] },
+                        { "type": "MapFunction", "name": "Increase", "description": "Increase the status by one level", "parameter": [] },
+                        { "type": "MapFunction", "name": "Ignore", "description": "Ignores the status", "parameter": [] },
+                        {
+                          "type": "MapFunction", "name": "SetTo", "description": "Sets the status to a defined value",
+                          "parameter": [ { "key": "status", "type": "status", "description": "The status value to set the status to", "required": true } ]
+                        },
+                        { "type": "MapFunction", "name": "Decrease", "description": "Decreases the status by one level", "parameter": [] }
+                      ]
+                    }"""))),
+            @ApiResponse(responseCode = "204", description = "No map function is registered.")
+    })
     public Response listMapFunctions() {
        return createFunctionMetaListDTO(new FunctionsManager().getMapFunctions(), FunctionType.MapFunction);
     }
 
     @GET
     @Path("functions/map/{name}")
-    public Response getMapFunctionMetaData(@PathParam("name") final String name) {
+    @Operation(
+            summary = "Get one map function's metadata",
+            description = "Return the parameters of one map function. The name is matched exactly and is case-sensitive.",
+            operationId = "getBusinessServiceMapFunctionMetaData"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Map function metadata returned",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = FunctionMetaDTO.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "type": "MapFunction",
+                      "name": "SetTo",
+                      "description": "Sets the status to a defined value",
+                      "parameter": [ { "key": "status", "type": "status", "description": "The status value to set the status to", "required": true } ]
+                    }"""))),
+            @ApiResponse(responseCode = "404", description = "No map function carries that name.",
+                    content = @Content(schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "No map function with name 'NoSuch' found.")))
+    })
+    public Response getMapFunctionMetaData(
+            @Parameter(description = "Map function name, case-sensitive.", example = "Identity", required = true,
+                    schema = @Schema(allowableValues = {"Identity", "Increase", "Decrease", "Ignore", "SetTo"}))
+            @PathParam("name") final String name) {
         FunctionMetaDTO metaData = new FunctionsManager().getMapFunctionMetaData(name);
         if (metaData == null) {
             return Response.status(Response.Status.NOT_FOUND).entity("No map function with name '" + name + "' found.").build();
@@ -348,13 +766,71 @@ public class BusinessServiceRestService {
 
     @GET
     @Path("functions/reduce")
+    @Operation(
+            summary = "List reduce functions",
+            description = """
+        Return every available reduce function with its parameters. A reduce function turns the mapped
+        severities of a service's edges into the service's own operational status. Use the `name` as the
+        `type` of a `reduce-function` object, and the `parameter` keys as its `properties`.""",
+            operationId = "listBusinessServiceReduceFunctions"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Reduce function metadata returned",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = FunctionMetaListDTO.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "function": [
+                        { "type": "ReduceFunction", "name": "HighestSeverity", "description": "Uses the value of the highest severity", "parameter": [] },
+                        {
+                          "type": "ReduceFunction", "name": "HighestSeverityAbove",
+                          "description": "Uses the highest severity greater than the given threshold severity",
+                          "parameter": [ { "key": "threshold", "type": "status", "description": "The status value to use as threshold", "required": true } ]
+                        },
+                        {
+                          "type": "ReduceFunction", "name": "ExponentialPropagation",
+                          "description": "Propagate severities using a given base number",
+                          "parameter": [ { "key": "base", "type": "double", "description": "The base used to calculate the required elements for propagation", "required": true } ]
+                        },
+                        {
+                          "type": "ReduceFunction", "name": "Threshold",
+                          "description": "Uses the highest severity found more often than the given threshold.",
+                          "parameter": [ { "key": "threshold", "type": "float", "description": "The Threshold to use", "required": true } ]
+                        }
+                      ]
+                    }"""))),
+            @ApiResponse(responseCode = "204", description = "No reduce function is registered.")
+    })
     public Response listReduceFunctions() {
         return createFunctionMetaListDTO(new FunctionsManager().getReduceFunctions(), FunctionType.ReduceFunction);
     }
 
     @GET
     @Path("functions/reduce/{name}")
-    public Response getReduceFunctionMetaData(@PathParam("name") final String name) {
+    @Operation(
+            summary = "Get one reduce function's metadata",
+            description = "Return the parameters of one reduce function. The name is matched exactly and is case-sensitive.",
+            operationId = "getBusinessServiceReduceFunctionMetaData"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Reduce function metadata returned",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = FunctionMetaDTO.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "type": "ReduceFunction",
+                      "name": "Threshold",
+                      "description": "Uses the highest severity found more often than the given threshold.",
+                      "parameter": [ { "key": "threshold", "type": "float", "description": "The Threshold to use", "required": true } ]
+                    }"""))),
+            @ApiResponse(responseCode = "404", description = "No reduce function carries that name.",
+                    content = @Content(schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "No reduce function with name 'NoSuch' found.")))
+    })
+    public Response getReduceFunctionMetaData(
+            @Parameter(description = "Reduce function name, case-sensitive.", example = "HighestSeverity", required = true,
+                    schema = @Schema(allowableValues = {"HighestSeverity", "HighestSeverityAbove", "ExponentialPropagation", "Threshold"}))
+            @PathParam("name") final String name) {
         FunctionMetaDTO metaData = new FunctionsManager().getReduceFunctionMetaData(name);
         if (metaData == null) {
             return Response.status(Response.Status.NOT_FOUND).entity("No reduce function with name '" + name + "' found.").build();

--- a/features/geolocation/rest/pom.xml
+++ b/features/geolocation/rest/pom.xml
@@ -17,6 +17,13 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <dependencies>
+    <!-- Annotations only; swagger-annotations already ships in the webapp's WEB-INF/lib. -->
+    <dependency>
+      <groupId>io.swagger.core.v3</groupId>
+      <artifactId>swagger-annotations</artifactId>
+      <version>${swaggerVersion}</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.opennms.dependencies</groupId>
       <artifactId>spring-dependencies</artifactId>

--- a/features/geolocation/rest/pom.xml
+++ b/features/geolocation/rest/pom.xml
@@ -16,6 +16,21 @@
     <bundle.namespace>org.opennms.web.rest.v2</bundle.namespace>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <!-- Swagger annotations are compile-time only; Sentinel and Minion do not ship the bundle. -->
+            <Import-Package>io.swagger.v3.oas.annotations;resolution:=optional,io.swagger.v3.oas.annotations.*;resolution:=optional,*</Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
   <dependencies>
     <!-- Annotations only; swagger-annotations already ships in the webapp's WEB-INF/lib. -->
     <dependency>

--- a/features/geolocation/rest/src/main/java/org/opennms/web/rest/v2/GeolocationQueryDTO.java
+++ b/features/geolocation/rest/src/main/java/org/opennms/web/rest/v2/GeolocationQueryDTO.java
@@ -29,12 +29,27 @@ import org.codehaus.jackson.map.TypeDeserializer;
 import org.codehaus.jackson.map.annotate.JsonDeserialize;
 import org.codehaus.jackson.map.deser.std.StdScalarDeserializer;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import javax.xml.bind.annotation.XmlRootElement;
 import java.io.IOException;
 
 @XmlRootElement
+@Schema(description = "Query for the geolocation endpoint. Every member is optional.")
 public class GeolocationQueryDTO {
+    @Schema(description = """
+            How to calculate each node's status. Matched case-insensitively. `Alarms` and `Outages` are \
+            the values the endpoint can act on; `None` is accepted by validation and then rejected with \
+            500, so omit the member to skip the calculation.""",
+            allowableValues = {"Alarms", "Outages"}, example = "Alarms")
     private String strategy;
+
+    @Schema(description = """
+            Lowest calculated severity a node must have to be returned. Read only when `strategy` is \
+            also given. Validation accepts any `OnmsSeverity` name, but only `Normal`, `Warning`, \
+            `Minor`, `Major` and `Critical` can be converted; `Indeterminate` and `Cleared` are \
+            rejected with 500.""",
+            allowableValues = {"Normal", "Warning", "Minor", "Major", "Critical"}, example = "Normal")
     private String severityFilter;
 
     static public class CustomBooleanSerializer extends StdScalarDeserializer<Boolean> {
@@ -64,6 +79,10 @@ public class GeolocationQueryDTO {
      * Use of a custom deserializer to prevent the incorrect value from being returned to the requester. See NMS-18052.
      */
     @JsonDeserialize(using = CustomBooleanSerializer.class)
+    @Schema(description = """
+            Whether acknowledged alarms count towards the status when `strategy` is `Alarms`. Defaults \
+            to false. A value that is not a boolean is answered with 500.""",
+            example = "false")
     private boolean includeAcknowledgedAlarms;
 
     public String getStrategy() {

--- a/features/geolocation/rest/src/main/java/org/opennms/web/rest/v2/GeolocationQueryDTO.java
+++ b/features/geolocation/rest/src/main/java/org/opennms/web/rest/v2/GeolocationQueryDTO.java
@@ -40,7 +40,7 @@ public class GeolocationQueryDTO {
     @Schema(description = """
             How to calculate each node's status. Matched case-insensitively. `Alarms` and `Outages` are \
             the values the endpoint can act on; `None` is accepted by validation and then rejected with \
-            500, so omit the member to skip the calculation.""",
+            500. Omitting the member skips the calculation.""",
             allowableValues = {"Alarms", "Outages"}, example = "Alarms")
     private String strategy;
 

--- a/features/geolocation/rest/src/main/java/org/opennms/web/rest/v2/GeolocationRestService.java
+++ b/features/geolocation/rest/src/main/java/org/opennms/web/rest/v2/GeolocationRestService.java
@@ -33,6 +33,16 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import org.opennms.core.soa.ServiceRegistry;
 import org.opennms.core.spring.BeanUtils;
 import org.opennms.core.utils.WebSecurityUtils;
@@ -52,6 +62,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
 @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
+@Tag(name = "Geolocation", description = """
+        Geolocation API.
+
+        Backs the geographical map. `POST /geolocation` returns the nodes that have usable coordinates,
+        optionally with a status derived from their alarms or outages, and `GET /geolocation/config`
+        returns the tile-server settings the map front end needs.
+
+        Both operations are served by whatever provider is registered in the OSGi service registry, and
+        both answer 503 while none is. The class declares XML and Atom alongside JSON, but no XML writer
+        is registered for either response type, so a request that asks for XML fails with 500. Send and
+        accept JSON.""")
 public class GeolocationRestService {
 
     /**
@@ -61,6 +82,111 @@ public class GeolocationRestService {
 
     @POST
     @Path("/")
+    @Operation(
+            summary = "Query node geolocations",
+            description = """
+                    Return one entry per node that has usable coordinates, with the node's identity, its
+                    address, its unacknowledged alarm count and, when a strategy is given, a computed
+                    severity. Nodes whose asset record holds no coordinates and no resolvable address are
+                    left out.
+
+                    `strategy` selects how the status is calculated and is matched case-insensitively.
+                    Validation accepts `None`, `Alarms` and `Outages`, but the value is then converted
+                    against a narrower set of `Alarms` and `Outages`, so `None` passes validation and
+                    fails afterwards with 500. Omitting `strategy` skips the calculation and leaves
+                    `severityInfo` null, which is the supported way to ask for no status.
+
+                    `severityFilter` keeps only the nodes whose calculated severity is at least the one
+                    named. Validation accepts every `OnmsSeverity` name, but conversion accepts only
+                    `Normal`, `Warning`, `Minor`, `Major` and `Critical`, so `Indeterminate` and
+                    `Cleared` pass validation and fail afterwards with 500.
+
+                    Only `application/json` is produced. A request that accepts XML or Atom is answered
+                    with 500, because no writer is registered for the returned list.""",
+            operationId = "geolocationQuery")
+    @RequestBody(description = """
+            The query. An empty object is valid and returns every node with coordinates, with no status
+            calculated.""",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = GeolocationQueryDTO.class),
+                            examples = {
+                                    @ExampleObject(name = "everything", value = """
+                    {}"""),
+                                    @ExampleObject(name = "alarmStatus", value = """
+                    {
+                      "strategy": "Alarms",
+                      "severityFilter": "Normal",
+                      "includeAcknowledgedAlarms": false
+                    }""")
+                            }),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = GeolocationQueryDTO.class),
+                            examples = @ExampleObject(value = """
+                    <geolocationQueryDTO>
+                      <strategy>Alarms</strategy>
+                      <severityFilter>Normal</severityFilter>
+                      <includeAcknowledgedAlarms>false</includeAcknowledgedAlarms>
+                    </geolocationQueryDTO>"""))
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The matching nodes and their coordinates.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            array = @ArraySchema(schema = @Schema(implementation = GeolocationInfo.class)),
+                            examples = @ExampleObject(value = """
+                    [
+                      {
+                        "nodeInfo": {
+                          "nodeId": 9001,
+                          "nodeLabel": "esx-01.lab",
+                          "foreignSource": "review-vmware",
+                          "foreignId": "esx-01.lab",
+                          "description": null,
+                          "maintcontract": null,
+                          "ipAddress": "10.20.0.11",
+                          "location": "Default",
+                          "categories": []
+                        },
+                        "coordinates": { "longitude": -84.3892, "latitude": 33.7466 },
+                        "severityInfo": { "id": 3, "label": "Normal" },
+                        "addressInfo": {
+                          "address1": null,
+                          "address2": null,
+                          "city": "Atlanta",
+                          "state": "GA",
+                          "zip": null,
+                          "country": "US"
+                        },
+                        "alarmUnackedCount": 0
+                      }
+                    ]"""))),
+            @ApiResponse(responseCode = "204", description = "No node matched. No body is returned."),
+            @ApiResponse(responseCode = "400", description = """
+                    `strategy` or `severityFilter` is not one of the accepted names. The body is the \
+                    message as a bare string, even though the response is labelled JSON.""",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "strategy", value = "Strategy 'bogus' is not supported"),
+                                    @ExampleObject(name = "severity", value = "Severity ' bogus' is not valid. Supported values are: [INDETERMINATE, CLEARED, NORMAL, WARNING, MINOR, MAJOR, CRITICAL]")
+                            })),
+            @ApiResponse(responseCode = "500", description = """
+                    A value passed validation but could not be converted, the body was absent or could \
+                    not be deserialised, or the request asked for a media type the list cannot be \
+                    written as.""",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "strategyNone", value = "No enum with value 'None' found in [Alarms, Outages]"),
+                                    @ExampleObject(name = "severityCleared", value = "No enum with value 'Cleared' found in [Normal, Warning, Minor, Major, Critical]"),
+                                    @ExampleObject(name = "noBody", value = "No content to map to Object due to end of input"),
+                                    @ExampleObject(name = "xmlRequested", value = "No message body writer has been found for class java.util.ArrayList, ContentType: application/xml")
+                            })),
+            @ApiResponse(responseCode = "503", description = "No geolocation service is registered yet.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "No service registered to handle your query. This is a temporary issue. Please try again later.")))
+    })
     public Response getLocations(GeolocationQueryDTO queryDTO) {
         final GeolocationService service = getServiceRegistry().findProvider(GeolocationService.class);
         if (service == null) {
@@ -81,6 +207,40 @@ public class GeolocationRestService {
 
     @GET
     @Path("/config")
+    @Operation(
+            summary = "Get the map configuration",
+            description = """
+                    Return the tile-server settings the geographical map uses: the tile URL template, a
+                    display name for the server, and the Leaflet tile-layer options, which carry the
+                    attribution the tile provider requires.
+
+                    The values come from `opennms.properties`; the response shows the built-in defaults
+                    when none are set.
+
+                    Only `application/json` is produced. A request that accepts XML or Atom is answered
+                    with 500, because no writer is registered for the configuration type.""",
+            operationId = "geolocationConfiguration")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The map configuration.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = GeolocationConfiguration.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "tileServerUrl": "https://tiles.opennms.org/{z}/{x}/{y}.png",
+                      "tileServerName": "OpenNMS Default",
+                      "options": {
+                        "attribution": "Map data &copy; OpenStreetMap contributors under ODbL, CC BY-SA 2.0"
+                      }
+                    }"""))),
+            @ApiResponse(responseCode = "500", description = "The request asked for a media type the configuration cannot be written as.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "No message body writer has been found for class org.opennms.features.geolocation.services.DefaultGeolocationConfiguration, ContentType: application/xml"))),
+            @ApiResponse(responseCode = "503", description = "No geolocation configuration service is registered yet.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "No service registered to handle your query. This is a temporary issue. Please try again later.")))
+    })
     public Response getConfiguration() {
         GeolocationConfiguration config = getServiceRegistry().findProvider(GeolocationConfiguration.class);
         if (config == null) {

--- a/features/geolocation/rest/src/main/java/org/opennms/web/rest/v2/GeolocationRestService.java
+++ b/features/geolocation/rest/src/main/java/org/opennms/web/rest/v2/GeolocationRestService.java
@@ -65,14 +65,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Tag(name = "Geolocation", description = """
         Geolocation API.
 
-        Backs the geographical map. `POST /geolocation` returns the nodes that have usable coordinates,
-        optionally with a status derived from their alarms or outages, and `GET /geolocation/config`
-        returns the tile-server settings the map front end needs.
+        `POST /geolocation` returns the nodes that have usable coordinates, optionally with a status
+        derived from their alarms or outages. `GET /geolocation/config` returns the tile-server settings
+        the geographical map uses.
 
         Both operations are served by whatever provider is registered in the OSGi service registry, and
         both answer 503 while none is. The class declares XML and Atom alongside JSON, but no XML writer
-        is registered for either response type, so a request that asks for XML fails with 500. Send and
-        accept JSON.""")
+        is registered for either response type, so a request that asks for XML fails with 500.""")
 public class GeolocationRestService {
 
     /**
@@ -94,7 +93,7 @@ public class GeolocationRestService {
                     Validation accepts `None`, `Alarms` and `Outages`, but the value is then converted
                     against a narrower set of `Alarms` and `Outages`, so `None` passes validation and
                     fails afterwards with 500. Omitting `strategy` skips the calculation and leaves
-                    `severityInfo` null, which is the supported way to ask for no status.
+                    `severityInfo` null.
 
                     `severityFilter` keeps only the nodes whose calculated severity is at least the one
                     named. Validation accepts every `OnmsSeverity` name, but conversion accepts only
@@ -163,7 +162,7 @@ public class GeolocationRestService {
             @ApiResponse(responseCode = "204", description = "No node matched. No body is returned."),
             @ApiResponse(responseCode = "400", description = """
                     `strategy` or `severityFilter` is not one of the accepted names. The body is the \
-                    message as a bare string, even though the response is labelled JSON.""",
+                    message as a bare string under a JSON content type.""",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON,
                             schema = @Schema(type = "string"),
                             examples = {
@@ -212,7 +211,7 @@ public class GeolocationRestService {
             description = """
                     Return the tile-server settings the geographical map uses: the tile URL template, a
                     display name for the server, and the Leaflet tile-layer options, which carry the
-                    attribution the tile provider requires.
+                    tile provider's attribution string.
 
                     The values come from `opennms.properties`; the response shows the built-in defaults
                     when none are set.

--- a/features/measurements/api/pom.xml
+++ b/features/measurements/api/pom.xml
@@ -44,6 +44,13 @@
     </plugins>
   </build>
   <dependencies>
+    <!-- Annotations only; swagger-annotations already ships in the webapp's WEB-INF/lib. -->
+    <dependency>
+      <groupId>io.swagger.core.v3</groupId>
+      <artifactId>swagger-annotations</artifactId>
+      <version>${swaggerVersion}</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.opennms.core</groupId>
       <artifactId>org.opennms.core.lib</artifactId>

--- a/features/measurements/api/pom.xml
+++ b/features/measurements/api/pom.xml
@@ -39,7 +39,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <!-- Swagger annotations are compile-time only; Sentinel and Minion do not ship the bundle. -->
-            <Import-Package>io.swagger.v3.oas.annotations;resolution:=optional,io.swagger.v3.oas.annotations.*;resolution:=optional,*</Import-Package>
+            <Import-Package>io.swagger.v3.oas.annotations;resolution:=optional,io.swagger.v3.oas.annotations.*;resolution:=optional,com.fasterxml.jackson.annotation;resolution:=optional,*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/measurements/api/pom.xml
+++ b/features/measurements/api/pom.xml
@@ -38,6 +38,8 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <!-- Swagger annotations are compile-time only; Sentinel and Minion do not ship the bundle. -->
+            <Import-Package>io.swagger.v3.oas.annotations;resolution:=optional,io.swagger.v3.oas.annotations.*;resolution:=optional,*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/Expression.java
+++ b/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/Expression.java
@@ -83,11 +83,11 @@ public class Expression {
         this.label = label;
     }
 
-    // The bare Jackson 2 @JsonProperty is only there to keep the property in the generated OpenAPI
+    // The Jackson 2 @JsonProperty is only there to keep the property in the generated OpenAPI
     // document: swagger's ModelResolver drops members of an XmlAccessType.NONE class that carry none
     // of @XmlElement, @XmlAttribute, @XmlElementRef(s) or a Jackson 2 @JsonProperty, and @XmlValue is
-    // not one of them. The wire name is "value" rather than the bean name.
-    @com.fasterxml.jackson.annotation.JsonProperty
+    // not one of them. Named explicitly so a Jackson 2 consumer serializes the wire name "value".
+    @com.fasterxml.jackson.annotation.JsonProperty("value")
     @Schema(name = "value",
             description = "JEXL expression evaluated once per row. Source and expression labels are in scope as "
                     + "variables, as are the string constants returned in the response.",

--- a/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/Expression.java
+++ b/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/Expression.java
@@ -21,6 +21,8 @@
  */
 package org.opennms.netmgt.measurements.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -67,6 +69,10 @@ public class Expression {
         this.isTransient = isTransient;
     }
 
+    @Schema(name = "label",
+            description = "Identifies the result column produced by this expression. Must be unique across "
+                    + "every source label and expression label in the request.",
+            example = "doubled")
     @XmlAttribute(name = "label")
     @JsonProperty("label")
     public String getLabel() {
@@ -77,6 +83,15 @@ public class Expression {
         this.label = label;
     }
 
+    // The bare Jackson 2 @JsonProperty is only there to keep the property in the generated OpenAPI
+    // document: swagger's ModelResolver drops members of an XmlAccessType.NONE class that carry none
+    // of @XmlElement, @XmlAttribute, @XmlElementRef(s) or a Jackson 2 @JsonProperty, and @XmlValue is
+    // not one of them. The wire name is "value" rather than the bean name.
+    @com.fasterxml.jackson.annotation.JsonProperty
+    @Schema(name = "value",
+            description = "JEXL expression evaluated once per row. Source and expression labels are in scope as "
+                    + "variables, as are the string constants returned in the response.",
+            example = "resp * 2")
     @XmlValue
     @JsonProperty("value")
     public String getExpression() {
@@ -87,6 +102,10 @@ public class Expression {
         this.expression = expression;
     }
 
+    @Schema(name = "transient",
+            description = "When true the expression is evaluated but its column is left out of the response, so "
+                    + "later expressions can still reference it.",
+            example = "false")
     @XmlAttribute(name = "transient")
     @JsonProperty("transient")
     public boolean getTransient() {

--- a/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/FilterDef.java
+++ b/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/FilterDef.java
@@ -23,6 +23,8 @@ package org.opennms.netmgt.measurements.model;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -72,10 +74,17 @@ public class FilterDef {
         this.parameters = parameters;
     }
 
+    @Schema(name = "name", required = true,
+            description = "Filter name as reported by GET /measurements/filters, for example Chomp or HoltWinters.",
+            example = "Chomp")
     public String getName() {
         return name;
     }
 
+    // Wire name is "parameter", not the bean name: a body using "parameters" is rejected.
+    @Schema(name = "parameter",
+            description = "Values for the filter's parameters. Keys come from the filter's metadata; parameters left "
+                    + "out take their documented default.")
     public List<FilterParamDef> getParameters() {
         return parameters;
     }

--- a/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/FilterMetaData.java
+++ b/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/FilterMetaData.java
@@ -24,6 +24,8 @@ package org.opennms.netmgt.measurements.model;
 import java.lang.reflect.Field;
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -89,22 +91,38 @@ public class FilterMetaData {
         }
     }
 
+    @Schema(name = "canonicalName", required = true,
+            description = "Fully qualified class name of the filter implementation.",
+            example = "org.opennms.netmgt.measurements.filters.impl.Chomp")
     public String getCanonicalName() {
         return canonicalName;
     }
 
+    @Schema(name = "name", required = true,
+            description = "Filter name, the value to put in a query request's filter[].name.",
+            example = "Chomp")
     public String getName() {
         return name;
     }
 
+    @Schema(name = "description",
+            description = "Human readable summary of what the filter does.",
+            example = "Strips leading and trailing rows that contain nothing but NaNs/null values.")
     public String getDescription() {
         return description;
     }
 
+    @Schema(name = "backend",
+            description = "Engine the filter runs on. The shipped filters report Java or R, and the R ones need "
+                    + "Rserve reachable to run.",
+            example = "Java")
     public String getBackend() {
         return backend;
     }
 
+    // Wire name is "parameter", not the bean name.
+    @Schema(name = "parameter",
+            description = "Parameters the filter accepts.")
     public List<FilterParamMetaData> getParameters() {
         return parameters;
     }

--- a/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/FilterParamDef.java
+++ b/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/FilterParamDef.java
@@ -21,6 +21,10 @@
  */
 package org.opennms.netmgt.measurements.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -55,10 +59,20 @@ public class FilterParamDef {
         this.value = Preconditions.checkNotNull(value, "value argument");
     }
 
+    @Schema(name = "key", required = true,
+            description = "Parameter name, as reported in the filter's metadata.",
+            example = "cutoffDate")
     public String getKey() {
         return key;
     }
 
+    // @XmlValue alone leaves the property out of the generated OpenAPI document, because swagger's
+    // ModelResolver drops members of an XmlAccessType.NONE class that carry none of @XmlElement,
+    // @XmlAttribute, @XmlElementRef(s) or a Jackson 2 @JsonProperty. The wire name is "value".
+    @JsonProperty
+    @Schema(name = "value", required = true,
+            description = "Parameter value, always sent as a string and coerced to the parameter's declared type.",
+            example = "0")
     public String getValue() {
         return value;
     }

--- a/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/FilterParamDef.java
+++ b/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/FilterParamDef.java
@@ -68,8 +68,9 @@ public class FilterParamDef {
 
     // @XmlValue alone leaves the property out of the generated OpenAPI document, because swagger's
     // ModelResolver drops members of an XmlAccessType.NONE class that carry none of @XmlElement,
-    // @XmlAttribute, @XmlElementRef(s) or a Jackson 2 @JsonProperty. The wire name is "value".
-    @JsonProperty
+    // @XmlAttribute, @XmlElementRef(s) or a Jackson 2 @JsonProperty. Named explicitly so a Jackson 2
+    // consumer serializes the wire name "value".
+    @JsonProperty("value")
     @Schema(name = "value", required = true,
             description = "Parameter value, always sent as a string and coerced to the parameter's declared type.",
             example = "0")

--- a/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/FilterParamMetaData.java
+++ b/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/FilterParamMetaData.java
@@ -23,6 +23,8 @@ package org.opennms.netmgt.measurements.model;
 
 import java.lang.reflect.Field;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -77,26 +79,48 @@ public class FilterParamMetaData {
         }
     }
 
+    @Schema(name = "key", required = true,
+            description = "Parameter name, the value to put in a filter's parameter[].key.",
+            example = "cutoffDate")
     public String getKey() {
         return key;
     }
 
+    // Derived by reflection from the filter field, so the set is open rather than an enumeration.
+    @Schema(name = "type", required = true,
+            description = "Declared type the value is coerced to, the lower-cased simple name of the filter field's "
+                    + "type. The shipped filters use boolean, double, int, long and string.",
+            example = "double")
     public String getType() {
         return type;
     }
 
+    @Schema(name = "displayName", required = true,
+            description = "Short label suitable for a form field.",
+            example = "Cutoff")
     public String getDisplayName() {
         return displayName;
     }
 
+    @Schema(name = "description", required = true,
+            description = "Human readable description of the parameter.",
+            example = "Timestamp in milliseconds. Any rows before this time will be removed.")
     public String getDescription() {
         return description;
     }
 
+    // Wire name is "default", not the bean name. Null for a required parameter.
+    @Schema(name = "default",
+            description = "Value used when the parameter is left out of the request. Null when the parameter is "
+                    + "required.",
+            example = "0")
     public String getDefaultValue() {
         return defaultValue;
     }
 
+    @Schema(name = "required", required = true,
+            description = "Whether the filter fails when this parameter is absent.",
+            example = "false")
     public boolean isRequired() {
         return required;
     }

--- a/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/QueryMetadata.java
+++ b/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/QueryMetadata.java
@@ -27,6 +27,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -67,10 +69,14 @@ public class QueryMetadata {
         }
     }
 
+    @Schema(name = "resources",
+            description = "One entry per resource resolved from the request's sources.")
     public List<QueryResource> getResources() {
         return this.resources == null? new ArrayList<QueryResource>() : this.resources;
     }
 
+    @Schema(name = "nodes",
+            description = "Distinct nodes owning the resolved resources.")
     public Set<QueryNode> getNodes() {
         return this.nodes == null? new HashSet<QueryNode>() : this.nodes;
     }

--- a/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/QueryNode.java
+++ b/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/QueryNode.java
@@ -23,6 +23,8 @@ package org.opennms.netmgt.measurements.model;
 
 import java.util.Objects;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -50,15 +52,26 @@ public class QueryNode implements Comparable<QueryNode> {
         this.label = label;
     }
 
+    @Schema(name = "id", description = "Database ID of the node.", example = "2")
     public Integer getId() {
         return id;
     }
+    // Wire name is "foreign-source", not the bean name.
+    @Schema(name = "foreign-source",
+            description = "Requisition the node was provisioned from. Null for a node discovered outside a "
+                    + "requisition.",
+            example = "loopback-lab")
     public String getForeignSource() {
         return foreignSource;
     }
+    // Wire name is "foreign-id", not the bean name.
+    @Schema(name = "foreign-id",
+            description = "Identifier of the node within its requisition.",
+            example = "lb-001")
     public String getForeignId() {
         return foreignId;
     }
+    @Schema(name = "label", description = "Node label.", example = "loopback-001")
     public String getLabel() {
         return label;
     }

--- a/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/QueryRequest.java
+++ b/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/QueryRequest.java
@@ -126,8 +126,8 @@ public class QueryRequest {
 
     // Wire name is "maxrows", not the bean name: a body using "maxRows" is rejected.
     @Schema(name = "maxrows",
-            description = "Upper bound on the number of rows returned, typically the pixel width of the graph being "
-                    + "drawn. 0 leaves the row count to the step size.",
+            description = "Upper bound on the number of rows returned. The step is widened until the window fits "
+                    + "rather than the series being truncated. 0 leaves the row count to the step size.",
             example = "0")
     @XmlAttribute(name = "maxrows")
     public int getMaxRows() {
@@ -139,8 +139,8 @@ public class QueryRequest {
     }
 
     @Schema(name = "interval",
-            description = "Collection interval in milliseconds. Used by the Newts-style fetch strategies when "
-                    + "deciding how to align samples.",
+            description = "Collection interval in milliseconds, used by the Newts-style fetch strategies to align "
+                    + "samples.",
             example = "300000")
     @XmlAttribute(name = "interval")
     public Long getInterval() {
@@ -152,8 +152,7 @@ public class QueryRequest {
     }
 
     @Schema(name = "heartbeat",
-            description = "Heartbeat in milliseconds, the age at which a sample is treated as stale. Usually a small "
-                    + "multiple of interval.",
+            description = "Heartbeat in milliseconds, the age at which a sample is treated as stale.",
             example = "600000")
     @XmlAttribute(name = "heartbeat")
     public Long getHeartbeat() {

--- a/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/QueryRequest.java
+++ b/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/QueryRequest.java
@@ -23,6 +23,8 @@ package org.opennms.netmgt.measurements.model;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -85,6 +87,9 @@ public class QueryRequest {
 
     private List<FilterDef> filters = Lists.newArrayListWithCapacity(0);
 
+    @Schema(name = "start", required = true,
+            description = "Start of the query window, in milliseconds since the epoch.",
+            example = "1787728079000")
     @XmlAttribute(name = "start")
     public long getStart() {
         return start;
@@ -94,6 +99,9 @@ public class QueryRequest {
         this.start = start;
     }
 
+    @Schema(name = "end", required = true,
+            description = "End of the query window, in milliseconds since the epoch.",
+            example = "1787731679000")
     @XmlAttribute(name = "end")
     public long getEnd() {
         return end;
@@ -103,6 +111,10 @@ public class QueryRequest {
         this.end = end;
     }
 
+    @Schema(name = "step", required = true,
+            description = "Requested step size in milliseconds. The response reports the step actually used, which "
+                    + "may be coarser if the underlying archives cannot satisfy the request.",
+            example = "300000")
     @XmlAttribute(name = "step")
     public long getStep() {
         return step;
@@ -112,6 +124,11 @@ public class QueryRequest {
         this.step = step;
     }
 
+    // Wire name is "maxrows", not the bean name: a body using "maxRows" is rejected.
+    @Schema(name = "maxrows",
+            description = "Upper bound on the number of rows returned, typically the pixel width of the graph being "
+                    + "drawn. 0 leaves the row count to the step size.",
+            example = "0")
     @XmlAttribute(name = "maxrows")
     public int getMaxRows() {
         return maxrows;
@@ -121,6 +138,10 @@ public class QueryRequest {
         this.maxrows = maxrows;
     }
 
+    @Schema(name = "interval",
+            description = "Collection interval in milliseconds. Used by the Newts-style fetch strategies when "
+                    + "deciding how to align samples.",
+            example = "300000")
     @XmlAttribute(name = "interval")
     public Long getInterval() {
         return interval;
@@ -130,6 +151,10 @@ public class QueryRequest {
         this.interval = interval;
     }
 
+    @Schema(name = "heartbeat",
+            description = "Heartbeat in milliseconds, the age at which a sample is treated as stale. Usually a small "
+                    + "multiple of interval.",
+            example = "600000")
     @XmlAttribute(name = "heartbeat")
     public Long getHeartbeat() {
         return heartbeat;
@@ -139,6 +164,10 @@ public class QueryRequest {
         this.heartbeat = heartbeat;
     }
 
+    // Wire name is "source", not the bean name: a body using "sources" is rejected.
+    @Schema(name = "source",
+            description = "Measurement series to fetch. At least one source or expression is required for the "
+                    + "response to carry any column.")
     @XmlElement(name = "source")
     @JsonProperty("source")
     public List<Source> getSources() {
@@ -149,6 +178,10 @@ public class QueryRequest {
         this.sources = sources;
     }
 
+    // Wire name is "expression", not the bean name: a body using "expressions" is rejected.
+    @Schema(name = "expression",
+            description = "JEXL expressions derived from the fetched sources, evaluated after the fetch and before "
+                    + "the filters.")
     @XmlElement(name = "expression")
     @JsonProperty("expression")
     public List<Expression> getExpressions() {
@@ -159,6 +192,10 @@ public class QueryRequest {
         this.expressions = expressions;
     }
 
+    // Wire name is "filter", not the bean name: a body using "filters" is rejected.
+    @Schema(name = "filter",
+            description = "Filters applied to the result table, in order. Names come from "
+                    + "GET /measurements/filters.")
     @XmlElement(name = "filter")
     public List<FilterDef> getFilters() {
         return filters;
@@ -173,6 +210,10 @@ public class QueryRequest {
         this.relaxed = relaxed;
     }
 
+    @Schema(name = "relaxed",
+            description = "When false a source whose attribute cannot be found makes the request fail with 404. "
+                    + "When true the missing series is filled with NaN instead.",
+            example = "false")
     public boolean isRelaxed() {
         return relaxed;
     }

--- a/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/QueryResource.java
+++ b/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/QueryResource.java
@@ -23,6 +23,8 @@ package org.opennms.netmgt.measurements.model;
 
 import java.util.Objects;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -56,18 +58,31 @@ public class QueryResource {
         this.node = node;
     }
 
+    @Schema(name = "id",
+            description = "Resource ID, matching the resourceId given in the request's source.",
+            example = "node[loopback-lab:lb-001].responseTime[127.0.0.1]")
     public String getId() {
         return this.id;
     }
 
+    // Wire name is "parent-id", not the bean name.
+    @Schema(name = "parent-id",
+            description = "ID of the resource this one hangs off, normally the node resource.",
+            example = "node[loopback-lab:lb-001]")
     public String getParentId() {
         return this.parentId;
     }
 
+    @Schema(name = "label",
+            description = "Display label of the resource.",
+            example = "Response Time for 127.0.0.1")
     public String getLabel() {
         return this.label;
     }
 
+    @Schema(name = "name",
+            description = "Resource name, the instance part of the resource ID.",
+            example = "127.0.0.1")
     public String getName() {
         return this.name;
     }
@@ -76,6 +91,10 @@ public class QueryResource {
         return this.node;
     }
 
+    // Wire name is "node-id", not the bean name.
+    @Schema(name = "node-id",
+            description = "Database ID of the node owning this resource. Cross-references metadata.nodes[].id.",
+            example = "2")
     @XmlAttribute(name="node-id")
     public Integer getNodeId() {
         return this.node == null? null : this.node.getId();

--- a/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/QueryResponse.java
+++ b/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/QueryResponse.java
@@ -21,6 +21,8 @@
  */
 package org.opennms.netmgt.measurements.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import com.google.common.collect.Maps;
 import org.codehaus.jackson.annotate.JsonProperty;
 
@@ -41,6 +43,11 @@ import java.util.Map;
  * @author Jesse White <jesse@opennms.org>
  * @author Dustin Frisch <fooker@lab.sh>
  */
+@Schema(name = "QueryResponse",
+        description = "Result of a measurements query. The response is column oriented: labels, columns and "
+                + "timestamps are parallel arrays, so columns[i] holds the series named labels[i] and "
+                + "columns[i].values[j] is that series' value at timestamps[j]. A sample with no data is rendered "
+                + "as the JSON string \"NaN\", not as null and not as a number.")
 @XmlRootElement(name = "query-response")
 public class QueryResponse {
 
@@ -84,6 +91,10 @@ public class QueryResponse {
      */
     private QueryMetadata metadata;
 
+    @Schema(name = "step",
+            description = "Step size in milliseconds actually used, which may be coarser than the step requested "
+                    + "when the underlying archives cannot supply the finer resolution.",
+            example = "300000")
     @XmlAttribute(name = "step")
     public long getStep() {
         return step;
@@ -93,6 +104,11 @@ public class QueryResponse {
         this.step = step;
     }
 
+    @Schema(name = "start",
+            description = "Start of the window as echoed back from the request, in milliseconds since the epoch. "
+                    + "The first entry in timestamps is normally later than this, since timestamps are aligned to "
+                    + "the step.",
+            example = "1787728079000")
     @XmlAttribute(name = "start")
     public long getStart() {
         return start;
@@ -102,6 +118,9 @@ public class QueryResponse {
         this.start = start;
     }
 
+    @Schema(name = "end",
+            description = "End of the window as echoed back from the request, in milliseconds since the epoch.",
+            example = "1787731679000")
     @XmlAttribute(name = "end")
     public long getEnd() {
         return end;
@@ -111,6 +130,10 @@ public class QueryResponse {
         this.end = end;
     }
 
+    @Schema(name = "timestamps",
+            description = "Row timestamps in milliseconds since the epoch, aligned to step and ascending. Element j "
+                    + "labels row j of every entry in columns.",
+            example = "[1787728200000, 1787728500000, 1787728800000]")
     @XmlElement(name = "timestamps")
     @JsonProperty("timestamps")
     public long[] getTimestamps() {
@@ -133,6 +156,9 @@ public class QueryResponse {
         this.timestamps = timestamps;
     }
 
+    @Schema(name = "labels",
+            description = "Series names, in the same order as columns. Holds the label of every non-transient source "
+                    + "and expression in the request.")
     @XmlElement(name="labels")
     public String[] getLabels() {
         return labels;
@@ -142,6 +168,9 @@ public class QueryResponse {
         this.labels = labels;
     }
 
+    @Schema(name = "columns",
+            description = "One entry per series, positionally matching labels. Each entry wraps a values array of "
+                    + "the same length as timestamps.")
     @XmlElement(name="columns")
     @JsonProperty("columns")
     public WrappedPrimitive[] getColumns() {
@@ -172,6 +201,9 @@ public class QueryResponse {
         }
     }
 
+    @Schema(name = "constants",
+            description = "String properties of the queried resources, taken from their strings.properties. Empty "
+                    + "when no queried resource carries any. Available to expressions as variables.")
     @XmlElement(name="constants")
     public List<QueryConstant> getConstants() {
         return this.constants;
@@ -190,6 +222,8 @@ public class QueryResponse {
         this.constants = c;
     }
 
+    @Schema(name = "metadata",
+            description = "Resources and nodes the request's sources resolved to.")
     @XmlElement(name="metadata")
     public QueryMetadata getMetadata() {
         return this.metadata;
@@ -256,6 +290,8 @@ public class QueryResponse {
      * Used to wrap an array of primitive doubles in order
      * to avoid boxing for marshaling.
      */
+    @Schema(name = "WrappedPrimitive",
+            description = "One series of the result table.")
     @XmlRootElement
     public static class WrappedPrimitive {
         private double[] values;
@@ -267,6 +303,12 @@ public class QueryResponse {
             this.values = values;
         }
 
+        // Wire name is "values", not the bean name.
+        @Schema(name = "values",
+                description = "Values of this series, one per entry in the response's timestamps array and in the "
+                        + "same order. A sample with no data appears as the JSON string \"NaN\" rather than a "
+                        + "number or null, so a strict numeric decoder will reject it.",
+                example = "[9.85957792, 11.960674583333336, \"NaN\"]")
         @XmlElement(name="values")
         @JsonProperty("values")
         public double[] getList() {
@@ -305,6 +347,8 @@ public class QueryResponse {
         }
     }
 
+    @Schema(name = "QueryConstant",
+            description = "One string property of a queried resource.")
     @XmlAccessorType(XmlAccessType.NONE)
     @XmlRootElement(name="constant")
     public static class QueryConstant {
@@ -319,9 +363,18 @@ public class QueryResponse {
             this.key = key;
             this.value = value;
         }
+        @Schema(name = "key",
+                description = "Property name, prefixed with the label of the source it was fetched for.",
+                example = "resp.ifName")
         public String getKey() {
             return this.key;
         }
+        // The bare Jackson 2 @JsonProperty only keeps the property in the generated OpenAPI document;
+        // swagger's ModelResolver drops @XmlValue members of an XmlAccessType.NONE class. Wire name is "value".
+        @com.fasterxml.jackson.annotation.JsonProperty
+        @Schema(name = "value",
+                description = "Property value.",
+                example = "eth0")
         public String getValue() {
             return this.value;
         }

--- a/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/QueryResponse.java
+++ b/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/QueryResponse.java
@@ -307,7 +307,7 @@ public class QueryResponse {
         @Schema(name = "values",
                 description = "Values of this series, one per entry in the response's timestamps array and in the "
                         + "same order. A sample with no data appears as the JSON string \"NaN\" rather than a "
-                        + "number or null, so a strict numeric decoder will reject it.",
+                        + "number or null.",
                 example = "[9.85957792, 11.960674583333336, \"NaN\"]")
         @XmlElement(name="values")
         @JsonProperty("values")

--- a/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/QueryResponse.java
+++ b/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/QueryResponse.java
@@ -369,9 +369,10 @@ public class QueryResponse {
         public String getKey() {
             return this.key;
         }
-        // The bare Jackson 2 @JsonProperty only keeps the property in the generated OpenAPI document;
-        // swagger's ModelResolver drops @XmlValue members of an XmlAccessType.NONE class. Wire name is "value".
-        @com.fasterxml.jackson.annotation.JsonProperty
+        // The Jackson 2 @JsonProperty only keeps the property in the generated OpenAPI document;
+        // swagger's ModelResolver drops @XmlValue members of an XmlAccessType.NONE class. Named
+        // explicitly so a Jackson 2 consumer serializes the wire name "value".
+        @com.fasterxml.jackson.annotation.JsonProperty("value")
         @Schema(name = "value",
                 description = "Property value.",
                 example = "eth0")

--- a/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/Source.java
+++ b/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/Source.java
@@ -21,6 +21,8 @@
  */
 package org.opennms.netmgt.measurements.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -97,6 +99,10 @@ public class Source {
         this.isTransient = isTransient;
     }
 
+    @Schema(name = "label", required = true,
+            description = "Identifies the result column produced by this source. Must be unique across every source "
+                    + "label and expression label in the request.",
+            example = "resp")
     @XmlAttribute(name = "label")
     public String getLabel() {
         return this.label;
@@ -106,6 +112,10 @@ public class Source {
         this.label = label;
     }
 
+    @Schema(name = "resourceId", required = true,
+            description = "Resource ID the attribute is read from, in the same form the resources ReST endpoint "
+                    + "reports.",
+            example = "node[loopback-lab:lb-001].responseTime[127.0.0.1]")
     @XmlAttribute(name = "resourceId")
     public String getResourceId() {
         return this.resourceId;
@@ -115,6 +125,9 @@ public class Source {
         this.resourceId = resourceId;
     }
 
+    @Schema(name = "attribute", required = true,
+            description = "Name of the attribute to read from the resource.",
+            example = "http-8080")
     @XmlAttribute(name = "attribute")
     public String getAttribute() {
         return this.attribute;
@@ -124,6 +137,11 @@ public class Source {
         this.attribute = attribute;
     }
 
+    // Wire name is "fallback-attribute", not the bean name: a body using "fallbackAttribute" is rejected.
+    @Schema(name = "fallback-attribute",
+            description = "Attribute tried when attribute is absent on the resource, which helps when a metric has "
+                    + "been renamed.",
+            example = "icmp")
     @XmlAttribute(name = "fallback-attribute")
     public String getFallbackAttribute() {
         return this.fallbackAttribute;
@@ -133,6 +151,11 @@ public class Source {
         this.fallbackAttribute = fallbackAttribute;
     }
 
+    // Wire name is "datasource", not the bean name: a body using "dataSource" is rejected.
+    @Schema(name = "datasource",
+            description = "Data source within the attribute. Defaults to the attribute name, and only needs setting "
+                    + "when one attribute holds several data sources.",
+            example = "http-8080")
     @XmlAttribute(name = "datasource")
     public String getDataSource() {
         return this.datasource;
@@ -150,6 +173,11 @@ public class Source {
         return this.datasource != null ? this.datasource : this.attribute;
     }
 
+    @Schema(name = "aggregation",
+            description = "Consolidation function applied when samples are rolled up to the step size.",
+            allowableValues = {"AVERAGE", "MIN", "MAX", "LAST"},
+            defaultValue = "AVERAGE",
+            example = "AVERAGE")
     @XmlAttribute(name = "aggregation")
     public String getAggregation() {
         return this.aggregation;
@@ -159,6 +187,10 @@ public class Source {
         this.aggregation = aggregation;
     }
 
+    @Schema(name = "transient",
+            description = "When true the series is fetched but its column is left out of the response, so "
+                    + "expressions can still reference it.",
+            example = "false")
     @XmlAttribute(name = "transient")
     public boolean getTransient() {
         return isTransient;

--- a/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/Source.java
+++ b/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/Source.java
@@ -139,8 +139,7 @@ public class Source {
 
     // Wire name is "fallback-attribute", not the bean name: a body using "fallbackAttribute" is rejected.
     @Schema(name = "fallback-attribute",
-            description = "Attribute tried when attribute is absent on the resource, which helps when a metric has "
-                    + "been renamed.",
+            description = "Attribute tried when attribute is absent on the resource.",
             example = "icmp")
     @XmlAttribute(name = "fallback-attribute")
     public String getFallbackAttribute() {
@@ -153,8 +152,8 @@ public class Source {
 
     // Wire name is "datasource", not the bean name: a body using "dataSource" is rejected.
     @Schema(name = "datasource",
-            description = "Data source within the attribute. Defaults to the attribute name, and only needs setting "
-                    + "when one attribute holds several data sources.",
+            description = "Data source within the attribute. Defaults to the attribute name; an attribute holding "
+                    + "several data sources needs it set explicitly.",
             example = "http-8080")
     @XmlAttribute(name = "datasource")
     public String getDataSource() {

--- a/features/measurements/rest/pom.xml
+++ b/features/measurements/rest/pom.xml
@@ -12,6 +12,13 @@
   <name>OpenNMS :: Features :: Measurements :: ReST</name>
 
   <dependencies>
+    <!-- Annotations only; swagger-annotations already ships in the webapp's WEB-INF/lib. -->
+    <dependency>
+      <groupId>io.swagger.core.v3</groupId>
+      <artifactId>swagger-annotations</artifactId>
+      <version>${swaggerVersion}</version>
+      <scope>provided</scope>
+    </dependency>
     <!-- Core -->
     <dependency>
       <groupId>org.opennms.core</groupId>

--- a/features/measurements/rest/src/main/java/org/opennms/web/rest/v1/MeasurementsRestService.java
+++ b/features/measurements/rest/src/main/java/org/opennms/web/rest/v1/MeasurementsRestService.java
@@ -40,6 +40,17 @@ import javax.ws.rs.core.Response.Status;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import org.opennms.netmgt.measurements.api.FilterEngine;
 import org.opennms.netmgt.measurements.api.MeasurementsService;
 import org.opennms.netmgt.measurements.api.exceptions.ExpressionException;
@@ -80,6 +91,20 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @Scope("prototype")
 @Path("measurements")
+@Tag(name = "Measurements", description = """
+        Read-only access to the values persisted by the collectors.
+
+        A measurement is addressed by the combination of a resource id and an attribute name. JEXL
+        expressions and filters can be layered on top of the fetched series. Every unit of time in
+        this API, in requests and in responses alike, is milliseconds, and every timestamp is epoch
+        milliseconds.
+
+        Both `application/json` and `application/xml` are accepted and produced. The two are not
+        interchangeable: the JSON and XML spellings of a query body differ, and where they differ it
+        is called out on the operation. When the request carries no `Accept` header the response comes
+        back as XML, since that is the first entry in the produced list.
+
+        Error bodies on this resource are `text/plain`, whatever the request asked for.""")
 public class MeasurementsRestService {
 
     private static final Logger LOG = LoggerFactory.getLogger(MeasurementsRestService.class);
@@ -93,6 +118,48 @@ public class MeasurementsRestService {
     @GET
     @Path("filters")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "List the available filters",
+            description = """
+        Metadata for every filter the engine has registered, including the parameters each one takes
+        and their defaults. `name` is the value a query body puts in `filter[].name`; `canonicalName`
+        is the implementing class and is informational. `backend` is `Java` for filters evaluated
+        in-process and `R` for filters that hand off to an R installation, which has to be present for
+        those to run.""",
+            operationId = "getMeasurementFilters"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The registered filters. The list is never empty in a default installation.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            array = @ArraySchema(schema = @Schema(implementation = FilterMetaData.class)),
+                            examples = @ExampleObject(value = """
+                    [
+                      {
+                        "canonicalName": "org.opennms.netmgt.measurements.filters.impl.Chomp",
+                        "name": "Chomp",
+                        "description": "Strips leading and trailing rows that contain nothing but NaNs/null values.",
+                        "backend": "Java",
+                        "parameter": [
+                          {
+                            "key": "stripNaNs",
+                            "type": "boolean",
+                            "displayName": "Strip",
+                            "description": "When set, leading and trailing rows containing NaNs will be removed",
+                            "required": false,
+                            "default": "true"
+                          },
+                          {
+                            "key": "cutoffDate",
+                            "type": "double",
+                            "displayName": "Cutoff",
+                            "description": "Timestamp in milliseconds. Any rows before this time will be removed.",
+                            "required": false,
+                            "default": "0"
+                          }
+                        ]
+                      }
+                    ]""")))
+    })
     public List<FilterMetaData> getFilterMetadata() {
         return filterEngine.getFilterMetaData();
     }
@@ -100,7 +167,44 @@ public class MeasurementsRestService {
     @GET
     @Path("filters/{name}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    public FilterMetaData getFilterMetadata(@PathParam("name") final String name) {
+    @Operation(
+            summary = "Get one filter's metadata",
+            description = """
+        Metadata for a single filter, looked up by its registered name. The lookup is on `name`, not on
+        the implementing class, so `HoltWinters` resolves while
+        `org.opennms.netmgt.measurements.filters.impl.HWForecast` does not.""",
+            operationId = "getMeasurementFilterByName"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Metadata for the named filter.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = FilterMetaData.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "canonicalName": "org.opennms.netmgt.measurements.filters.impl.Chomp",
+                      "name": "Chomp",
+                      "description": "Strips leading and trailing rows that contain nothing but NaNs/null values.",
+                      "backend": "Java",
+                      "parameter": [
+                        {
+                          "key": "stripNaNs",
+                          "type": "boolean",
+                          "displayName": "Strip",
+                          "description": "When set, leading and trailing rows containing NaNs will be removed",
+                          "required": false,
+                          "default": "true"
+                        }
+                      ]
+                    }"""))),
+            @ApiResponse(responseCode = "404", description = "No filter is registered under that name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "No filter with name 'Nope' was found.")))
+    })
+    public FilterMetaData getFilterMetadata(
+            @Parameter(description = "Registered filter name, as returned in the `name` field of the filter list.",
+                    example = "Chomp", required = true)
+            @PathParam("name") final String name) {
         FilterMetaData metaData = filterEngine.getFilterMetaData(name);
         if (metaData == null) {
             throw getException(Status.NOT_FOUND, "No filter with name '{}' was found.", name);
@@ -116,14 +220,125 @@ public class MeasurementsRestService {
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional(readOnly=true)
-    public QueryResponse simpleQuery(@PathParam("resourceId") final String resourceId,
+    @Operation(
+            summary = "Query a single attribute",
+            description = """
+        Fetches one attribute of one resource as a single-column series. This is the query-string form
+        of `POST /measurements` with exactly one source, and it is limited to what that source can
+        express: no expressions, no filters, no second series.
+
+        The resource id is one path segment even though it contains `[`, `]`, `:` and `.`. Percent-encode
+        it, since those characters are reserved in a URI:
+        `node[loopback-lab:lb-001].responseTime[127.0.0.1]` becomes
+        `node%5Bloopback-lab%3Alb-001%5D.responseTime%5B127.0.0.1%5D`. The instance under test also
+        accepted the literal, unencoded form, but that is servlet-container behaviour rather than a
+        guarantee of this API.
+
+        `end` defaults to 0, which is read as "now". `start` defaults to -14400000, and a negative
+        `start` is an offset back from `end`, so the default window is the last four hours. A resulting
+        start below zero is clamped to zero.
+
+        The response is the same `QueryResponse` shape the POST form returns, with a single label equal
+        to the attribute name. Missing samples come back as the JSON string `"NaN"`, not as `null`.
+
+        A query-string value that will not parse as the declared type (`step=abc`, for instance) is
+        rejected by the JAX-RS layer as a 404 rather than a 400.""",
+            operationId = "getMeasurementsForAttribute"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "One column of samples for the attribute.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = QueryResponse.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "step": 300000,
+                      "start": 1787715836087,
+                      "end": 1787730236087,
+                      "timestamps": [1787729700000, 1787730000000, 1787730300000],
+                      "labels": ["http-8080"],
+                      "columns": [
+                        {"values": [14.329565633333331, 10.33385595, "NaN"]}
+                      ],
+                      "constants": [],
+                      "metadata": {
+                        "resources": [
+                          {
+                            "id": "node[loopback-lab:lb-001].responseTime[127.0.0.1]",
+                            "label": "Response Time for 127.0.0.1",
+                            "name": "127.0.0.1",
+                            "parent-id": "node[loopback-lab:lb-001]",
+                            "node-id": 2
+                          }
+                        ],
+                        "nodes": [
+                          {"id": 2, "label": "loopback-001", "foreign-source": "loopback-lab", "foreign-id": "lb-001"}
+                        ]
+                      }
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = QueryResponse.class),
+                                    examples = @ExampleObject(value = """
+                    <query-response end="1787730236087" start="1787715836087" step="300000">
+                      <columns>
+                        <values>14.329565633333331</values>
+                        <values>10.33385595</values>
+                        <values>NaN</values>
+                      </columns>
+                      <labels>http-8080</labels>
+                      <metadata>
+                        <resources>
+                          <resource id="node[loopback-lab:lb-001].responseTime[127.0.0.1]"
+                                    parent-id="node[loopback-lab:lb-001]"
+                                    label="Response Time for 127.0.0.1" name="127.0.0.1" node-id="2"/>
+                        </resources>
+                        <nodes>
+                          <node id="2" foreign-source="loopback-lab" foreign-id="lb-001" label="loopback-001"/>
+                        </nodes>
+                      </metadata>
+                      <timestamps>1787729700000</timestamps>
+                      <timestamps>1787730000000</timestamps>
+                      <timestamps>1787730300000</timestamps>
+                    </query-response>"""))
+                    }),
+            @ApiResponse(responseCode = "204", description = "The query produced no columns. Reached with `relaxed=true` and an attribute that does not exist."),
+            @ApiResponse(responseCode = "404", description = "The resource or the attribute does not exist and `relaxed` is false, or a query-string value did not parse.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Resource or attribute not found for QueryRequest{Step=300000, Start=1787715836162, End=1787730236162, Relaxed=false, Max Rows=0, Interval=null, Heartbeat=null, Sources=[Source{Label=bogus, Resource ID=node[loopback-lab:lb-001].responseTime[127.0.0.1], Attribute=bogus, Datasource=bogus, Transient=false}], Expressions=[], Filters=[]}"))),
+            @ApiResponse(responseCode = "500", description = "The fetch itself failed. Observed with an unknown `aggregation`, and with a `maxrows` too small for the requested window.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Fetch failed: Xport failed.")))
+    })
+    public QueryResponse simpleQuery(
+            @Parameter(description = "Resource id of the resource holding the attribute, percent-encoded. Resource ids are listed by `GET /resources`.",
+                    example = "node%5Bloopback-lab%3Alb-001%5D.responseTime%5B127.0.0.1%5D", required = true)
+            @PathParam("resourceId") final String resourceId,
+            @Parameter(description = "Name of the attribute on that resource. Also used as the datasource and as the column label.",
+                    example = "http-8080", required = true)
             @PathParam("attribute") final String attribute,
+            @Parameter(description = "Start of the window, epoch milliseconds. A negative value is an offset back from `end`; the default of -14400000 means four hours before `end`.",
+                    example = "-14400000")
             @DefaultValue("-14400000") @QueryParam("start") final long start,
+            @Parameter(description = "End of the window, epoch milliseconds. Zero or negative means now.",
+                    example = "0")
             @DefaultValue("0") @QueryParam("end") final long end,
+            @Parameter(description = "Requested sample interval in milliseconds. May be widened by the persistence layer or by `maxrows`.",
+                    example = "300000")
             @DefaultValue("300000") @QueryParam("step") final long step,
+            @Parameter(description = "Upper bound on the number of rows returned. The step is widened until the window fits. Zero disables the bound. Values far below what the window can be reduced to make the fetch fail with a 500.",
+                    example = "0")
             @DefaultValue("0") @QueryParam("maxrows") final int maxrows,
+            @Parameter(description = "Attribute to fall back to when `attribute` is not present on the resource. Empty disables the fallback. This form hard-wires the datasource to `attribute`, so a fallback to a differently named attribute was observed to fail the fetch with a 500; the POST form, where `datasource` can be set alongside `fallback-attribute`, handles that case.",
+                    example = "")
             @DefaultValue("") @QueryParam("fallback-attribute") final String fallbackAttribute,
+            @Parameter(description = "Consolidation function applied when several stored samples fall into one step. The accepted set is whatever the persistence layer defines; a value it does not know fails the fetch with a 500 rather than a 400.",
+                    example = "AVERAGE",
+                    schema = @Schema(type = "string", allowableValues = {"AVERAGE", "MIN", "MAX", "LAST", "TOTAL"}, defaultValue = "AVERAGE"))
             @DefaultValue("AVERAGE") @QueryParam("aggregation") final String aggregation,
+            @Parameter(description = "When false, an attribute that does not exist is a 404. When true it is tolerated and filled with NaN, which for a single-source query leaves no columns and so yields a 204.",
+                    example = "false")
             @DefaultValue("false") @QueryParam("relaxed") final boolean relaxed) {
 
         QueryRequest request = new QueryRequest();
@@ -161,6 +376,160 @@ public class MeasurementsRestService {
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional(readOnly=true)
+    @Operation(
+            summary = "Query measurements",
+            description = """
+        Fetches one or more series, optionally derives further series from them with JEXL expressions,
+        and optionally runs filters over the result. A POST is used for what is a read-only query only
+        because the request does not fit comfortably in a query string.
+
+        The JSON body keys for the three collections are singular: `source`, `expression` and `filter`,
+        each an array. The plural spellings are not accepted, and an unknown key is not ignored: sending
+        `sources` fails with a 500 carrying a Jackson `Unrecognized field` message, as does any body
+        Jackson cannot parse. The scalars are `start`, `end`, `step`, `maxrows`, `interval`,
+        `heartbeat` and `relaxed`, all at the top level, and all times are epoch milliseconds.
+
+        Each `source` needs `resourceId`, `attribute` and `label`; a source missing one of them is a
+        400. `aggregation` defaults to `AVERAGE` and `transient` to false. A transient source is
+        fetched and made available to expressions but is left out of the response. When a source sets
+        `fallback-attribute`, set `datasource` to the datasource the fallback is stored under as well,
+        otherwise the fetch fails with a 500.
+
+        The response holds `timestamps` and `columns` as parallel arrays: `columns[i].values[j]` is the
+        sample of series `labels[i]` at `timestamps[j]`, so the two always have the same length. A
+        missing sample is the JSON string `"NaN"`, not `null` and not a number, which means the values
+        array is not uniformly typed. `constants` was empty in every response observed, with and without
+        a filter applied.
+
+        The XML form of the body is not a transliteration of the JSON. The scalars are attributes on
+        `<query-request>`, each source is a `<source/>` element carrying its fields as attributes, an
+        expression's JEXL text is the element body rather than a `value` attribute, and a filter
+        parameter's value is likewise the body of `<parameter key="...">`. A filter parameter written as
+        `<parameter key="stripNaNs" value="true"/>` binds nothing and the filter silently runs with its
+        default, which was confirmed on the instance.""",
+            operationId = "queryMeasurements"
+    )
+    @RequestBody(
+            required = true,
+            description = "The query. Sources, expressions and filters are evaluated in that order.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = QueryRequest.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "start": 1787726591000,
+                      "end": 1787730191000,
+                      "step": 300000,
+                      "relaxed": false,
+                      "source": [
+                        {
+                          "aggregation": "AVERAGE",
+                          "attribute": "http-8080",
+                          "label": "resp",
+                          "resourceId": "node[loopback-lab:lb-001].responseTime[127.0.0.1]",
+                          "transient": true
+                        }
+                      ],
+                      "expression": [
+                        {"label": "respSeconds", "value": "resp / 1000.0", "transient": false}
+                      ],
+                      "filter": [
+                        {"name": "Chomp", "parameter": [{"key": "stripNaNs", "value": "true"}]}
+                      ]
+                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = QueryRequest.class),
+                            examples = @ExampleObject(value = """
+                    <query-request start="1787726591000" end="1787730191000" step="300000" relaxed="false">
+                      <source label="resp" resourceId="node[loopback-lab:lb-001].responseTime[127.0.0.1]"
+                              attribute="http-8080" aggregation="AVERAGE" transient="true"/>
+                      <expression label="respSeconds" transient="false">resp / 1000.0</expression>
+                      <filter name="Chomp">
+                        <parameter key="stripNaNs">true</parameter>
+                      </filter>
+                    </query-request>"""))
+            })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The requested series. One entry in `labels` and `columns` per non-transient source and expression.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = QueryResponse.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "step": 300000,
+                      "start": 1787726591000,
+                      "end": 1787730191000,
+                      "timestamps": [1787729700000, 1787730000000, 1787730300000],
+                      "labels": ["resp"],
+                      "columns": [
+                        {"values": [14.329565633333331, 10.33385595, "NaN"]}
+                      ],
+                      "constants": [],
+                      "metadata": {
+                        "resources": [
+                          {
+                            "id": "node[loopback-lab:lb-001].responseTime[127.0.0.1]",
+                            "label": "Response Time for 127.0.0.1",
+                            "name": "127.0.0.1",
+                            "parent-id": "node[loopback-lab:lb-001]",
+                            "node-id": 2
+                          }
+                        ],
+                        "nodes": [
+                          {"id": 2, "label": "loopback-001", "foreign-source": "loopback-lab", "foreign-id": "lb-001"}
+                        ]
+                      }
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = QueryResponse.class),
+                                    examples = @ExampleObject(value = """
+                    <query-response end="1787730191000" start="1787726591000" step="300000">
+                      <columns>
+                        <values>14.329565633333331</values>
+                        <values>10.33385595</values>
+                        <values>NaN</values>
+                      </columns>
+                      <labels>resp</labels>
+                      <metadata>
+                        <resources>
+                          <resource id="node[loopback-lab:lb-001].responseTime[127.0.0.1]"
+                                    parent-id="node[loopback-lab:lb-001]"
+                                    label="Response Time for 127.0.0.1" name="127.0.0.1" node-id="2"/>
+                        </resources>
+                        <nodes>
+                          <node id="2" foreign-source="loopback-lab" foreign-id="lb-001" label="loopback-001"/>
+                        </nodes>
+                      </metadata>
+                      <timestamps>1787729700000</timestamps>
+                      <timestamps>1787730000000</timestamps>
+                      <timestamps>1787730300000</timestamps>
+                    </query-response>"""))
+                    }),
+            @ApiResponse(responseCode = "204", description = "The query produced no columns. Reached with `relaxed=true` and a source whose attribute does not exist."),
+            @ApiResponse(responseCode = "400", description = "A source is incomplete, an expression will not parse, or a named filter is not registered.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "source missing resourceId",
+                                            value = "Query source fields must be set: Source{Label=resp, Resource ID=null, Attribute=http-8080, Datasource=null, Transient=false}"),
+                                    @ExampleObject(name = "unparsable expression",
+                                            value = "An error occurred while evaluating an expression: Failed to parse expression. Label = 'x', Expression'resp / '. Please check also the Jexl documentation for details: https://commons.apache.org/proper/commons-jexl/reference/syntax.html"),
+                                    @ExampleObject(name = "unknown filter",
+                                            value = "No filter implementation found for NoSuchFilter")
+                            })),
+            @ApiResponse(responseCode = "404", description = "A source names a resource or attribute that does not exist and `relaxed` is false.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Resource or attribute not found for QueryRequest{Step=300000, Start=1787726604000, End=1787730204000, Relaxed=false, Max Rows=0, Interval=null, Heartbeat=null, Sources=[Source{Label=resp, Resource ID=node[loopback-lab:nope].responseTime[9.9.9.9], Attribute=http-8080, Datasource=null, Transient=false}], Expressions=[], Filters=[]}"))),
+            @ApiResponse(responseCode = "500", description = "The body could not be deserialized, or the fetch failed. An empty `source` array reaches this rather than a 400.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "empty source array", value = "Fetch failed: Xport failed."),
+                                    @ExampleObject(name = "unknown body key",
+                                            value = "Unrecognized field \"sources\" (Class org.opennms.netmgt.measurements.model.QueryRequest), not marked as ignorable")
+                            }))
+    })
     public QueryResponse query(final QueryRequest request) {
         Preconditions.checkState(service != null);
         LOG.debug("Executing query with {}", request);

--- a/features/measurements/rest/src/main/java/org/opennms/web/rest/v1/MeasurementsRestService.java
+++ b/features/measurements/rest/src/main/java/org/opennms/web/rest/v1/MeasurementsRestService.java
@@ -99,10 +99,9 @@ import org.springframework.transaction.annotation.Transactional;
         this API, in requests and in responses alike, is milliseconds, and every timestamp is epoch
         milliseconds.
 
-        Both `application/json` and `application/xml` are accepted and produced. The two are not
-        interchangeable: the JSON and XML spellings of a query body differ, and where they differ it
-        is called out on the operation. When the request carries no `Accept` header the response comes
-        back as XML, since that is the first entry in the produced list.
+        Both `application/json` and `application/xml` are accepted and produced. The JSON and XML
+        spellings of a query body differ. With no `Accept` header the response comes back as XML, the
+        first entry in the produced list.
 
         Error bodies on this resource are `text/plain`, whatever the request asked for.""")
 public class MeasurementsRestService {
@@ -123,9 +122,8 @@ public class MeasurementsRestService {
             description = """
         Metadata for every filter the engine has registered, including the parameters each one takes
         and their defaults. `name` is the value a query body puts in `filter[].name`; `canonicalName`
-        is the implementing class and is informational. `backend` is `Java` for filters evaluated
-        in-process and `R` for filters that hand off to an R installation, which has to be present for
-        those to run.""",
+        is the implementing class. `backend` is `Java` for filters evaluated in-process and `R` for
+        filters that hand off to an R installation, which has to be present for those to run.""",
             operationId = "getMeasurementFilters"
     )
     @ApiResponses(value = {
@@ -171,7 +169,7 @@ public class MeasurementsRestService {
             summary = "Get one filter's metadata",
             description = """
         Metadata for a single filter, looked up by its registered name. The lookup is on `name`, not on
-        the implementing class, so `HoltWinters` resolves while
+        the implementing class: `HoltWinters` resolves,
         `org.opennms.netmgt.measurements.filters.impl.HWForecast` does not.""",
             operationId = "getMeasurementFilterByName"
     )
@@ -223,16 +221,14 @@ public class MeasurementsRestService {
     @Operation(
             summary = "Query a single attribute",
             description = """
-        Fetches one attribute of one resource as a single-column series. This is the query-string form
-        of `POST /measurements` with exactly one source, and it is limited to what that source can
-        express: no expressions, no filters, no second series.
+        Fetches one attribute of one resource as a single-column series. The query-string form of
+        `POST /measurements` with exactly one source: no expressions, no filters, no second series.
 
-        The resource id is one path segment even though it contains `[`, `]`, `:` and `.`. Percent-encode
-        it, since those characters are reserved in a URI:
+        The resource id is one path segment even though it contains `[`, `]`, `:` and `.`, which are
+        reserved in a URI, so it has to be percent-encoded:
         `node[loopback-lab:lb-001].responseTime[127.0.0.1]` becomes
-        `node%5Bloopback-lab%3Alb-001%5D.responseTime%5B127.0.0.1%5D`. The instance under test also
-        accepted the literal, unencoded form, but that is servlet-container behaviour rather than a
-        guarantee of this API.
+        `node%5Bloopback-lab%3Alb-001%5D.responseTime%5B127.0.0.1%5D`. The literal, unencoded form was
+        also accepted on the instance under test.
 
         `end` defaults to 0, which is read as "now". `start` defaults to -14400000, and a negative
         `start` is an offset back from `end`, so the default window is the last four hours. A resulting
@@ -241,7 +237,7 @@ public class MeasurementsRestService {
         The response is the same `QueryResponse` shape the POST form returns, with a single label equal
         to the attribute name. Missing samples come back as the JSON string `"NaN"`, not as `null`.
 
-        A query-string value that will not parse as the declared type (`step=abc`, for instance) is
+        A query-string value that will not parse as its declared type, `step=abc` for instance, is
         rejected by the JAX-RS layer as a 404 rather than a 400.""",
             operationId = "getMeasurementsForAttribute"
     )
@@ -330,10 +326,10 @@ public class MeasurementsRestService {
             @Parameter(description = "Upper bound on the number of rows returned. The step is widened until the window fits. Zero disables the bound. Values far below what the window can be reduced to make the fetch fail with a 500.",
                     example = "0")
             @DefaultValue("0") @QueryParam("maxrows") final int maxrows,
-            @Parameter(description = "Attribute to fall back to when `attribute` is not present on the resource. Empty disables the fallback. This form hard-wires the datasource to `attribute`, so a fallback to a differently named attribute was observed to fail the fetch with a 500; the POST form, where `datasource` can be set alongside `fallback-attribute`, handles that case.",
+            @Parameter(description = "Attribute to fall back to when `attribute` is not present on the resource. Empty disables the fallback. This form hard-wires the datasource to `attribute`, so a fallback to a differently named attribute fails the fetch with a 500. The POST form takes `datasource` alongside `fallback-attribute`.",
                     example = "")
             @DefaultValue("") @QueryParam("fallback-attribute") final String fallbackAttribute,
-            @Parameter(description = "Consolidation function applied when several stored samples fall into one step. The accepted set is whatever the persistence layer defines; a value it does not know fails the fetch with a 500 rather than a 400.",
+            @Parameter(description = "Consolidation function applied when several stored samples fall into one step. The accepted set is defined by the persistence layer; a value it does not know fails the fetch with a 500 rather than a 400.",
                     example = "AVERAGE",
                     schema = @Schema(type = "string", allowableValues = {"AVERAGE", "MIN", "MAX", "LAST", "TOTAL"}, defaultValue = "AVERAGE"))
             @DefaultValue("AVERAGE") @QueryParam("aggregation") final String aggregation,
@@ -380,8 +376,7 @@ public class MeasurementsRestService {
             summary = "Query measurements",
             description = """
         Fetches one or more series, optionally derives further series from them with JEXL expressions,
-        and optionally runs filters over the result. A POST is used for what is a read-only query only
-        because the request does not fit comfortably in a query string.
+        and optionally runs filters over the result. The query is read-only.
 
         The JSON body keys for the three collections are singular: `source`, `expression` and `filter`,
         each an array. The plural spellings are not accepted, and an unknown key is not ignored: sending
@@ -391,22 +386,21 @@ public class MeasurementsRestService {
 
         Each `source` needs `resourceId`, `attribute` and `label`; a source missing one of them is a
         400. `aggregation` defaults to `AVERAGE` and `transient` to false. A transient source is
-        fetched and made available to expressions but is left out of the response. When a source sets
-        `fallback-attribute`, set `datasource` to the datasource the fallback is stored under as well,
-        otherwise the fetch fails with a 500.
+        fetched and made available to expressions but is left out of the response. A source that sets
+        `fallback-attribute` also needs `datasource` set to the datasource the fallback is stored
+        under, otherwise the fetch fails with a 500.
 
         The response holds `timestamps` and `columns` as parallel arrays: `columns[i].values[j]` is the
         sample of series `labels[i]` at `timestamps[j]`, so the two always have the same length. A
-        missing sample is the JSON string `"NaN"`, not `null` and not a number, which means the values
-        array is not uniformly typed. `constants` was empty in every response observed, with and without
-        a filter applied.
+        missing sample is the JSON string `"NaN"`, not `null` and not a number. `constants` was empty in
+        every response observed, with and without a filter applied.
 
-        The XML form of the body is not a transliteration of the JSON. The scalars are attributes on
-        `<query-request>`, each source is a `<source/>` element carrying its fields as attributes, an
-        expression's JEXL text is the element body rather than a `value` attribute, and a filter
-        parameter's value is likewise the body of `<parameter key="...">`. A filter parameter written as
-        `<parameter key="stripNaNs" value="true"/>` binds nothing and the filter silently runs with its
-        default, which was confirmed on the instance.""",
+        In the XML body the scalars are attributes on `<query-request>`, each source is a `<source/>`
+        element carrying its fields as attributes, an expression's JEXL text is the element body rather
+        than a `value` attribute, and a filter parameter's value is likewise the body of
+        `<parameter key="...">`. A filter parameter written as
+        `<parameter key="stripNaNs" value="true"/>` binds nothing and the filter runs with its
+        default.""",
             operationId = "queryMeasurements"
     )
     @RequestBody(

--- a/features/measurements/rest/src/main/java/org/opennms/web/rest/v1/MeasurementsRestService.java
+++ b/features/measurements/rest/src/main/java/org/opennms/web/rest/v1/MeasurementsRestService.java
@@ -454,9 +454,9 @@ public class MeasurementsRestService {
                       "start": 1787726591000,
                       "end": 1787730191000,
                       "timestamps": [1787729700000, 1787730000000, 1787730300000],
-                      "labels": ["resp"],
+                      "labels": ["respSeconds"],
                       "columns": [
-                        {"values": [14.329565633333331, 10.33385595, "NaN"]}
+                        {"values": [0.014329565633333331, 0.01033385595, "NaN"]}
                       ],
                       "constants": [],
                       "metadata": {
@@ -479,11 +479,11 @@ public class MeasurementsRestService {
                                     examples = @ExampleObject(value = """
                     <query-response end="1787730191000" start="1787726591000" step="300000">
                       <columns>
-                        <values>14.329565633333331</values>
-                        <values>10.33385595</values>
+                        <values>0.014329565633333331</values>
+                        <values>0.01033385595</values>
                         <values>NaN</values>
                       </columns>
-                      <labels>resp</labels>
+                      <labels>respSeconds</labels>
                       <metadata>
                         <resources>
                           <resource id="node[loopback-lab:lb-001].responseTime[127.0.0.1]"

--- a/features/rest/model/pom.xml
+++ b/features/rest/model/pom.xml
@@ -29,6 +29,13 @@
   </build>
 
   <dependencies>
+    <!-- Annotations only; swagger-annotations already ships in the webapp's WEB-INF/lib. -->
+    <dependency>
+      <groupId>io.swagger.core.v3</groupId>
+      <artifactId>swagger-annotations</artifactId>
+      <version>${swaggerVersion}</version>
+      <scope>provided</scope>
+    </dependency>
     <!-- Keep these dependencies to a minimal in order to allow 3rd party application
          to leverage this artifact in their projects. -->
     <dependency>

--- a/features/rest/model/pom.xml
+++ b/features/rest/model/pom.xml
@@ -22,6 +22,8 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <!-- Swagger annotations are compile-time only; Sentinel and Minion do not ship the bundle. -->
+            <Import-Package>io.swagger.v3.oas.annotations;resolution:=optional,io.swagger.v3.oas.annotations.*;resolution:=optional,*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/BridgeElementNodeDTO.java
+++ b/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/BridgeElementNodeDTO.java
@@ -34,7 +34,7 @@ import org.codehaus.jackson.annotate.JsonProperty;
 
 @XmlRootElement(name="bridgeElementNode")
 @XmlAccessorType(XmlAccessType.NONE)
-@Schema(description = "One bridge element of the node, one per VLAN. Most fields carry the raw dot1dBase and dot1dStp values; the two timestamp fields are never populated by the v2 mapper.")
+@Schema(description = "One bridge element of the node, one per discovered VLAN, with a single null-`vlan` entry when the device has no VLAN table. Most fields carry the raw dot1dBase and dot1dStp values; the two timestamp fields are never populated by the v2 mapper.")
 public class BridgeElementNodeDTO {
 
     private String  baseBridgeAddress;
@@ -212,7 +212,7 @@ public class BridgeElementNodeDTO {
 
     @XmlElement(name="bridgeNodeCreateTime")
     @JsonProperty("bridgeNodeCreateTime")
-    @Schema(description = "Intended as the create timestamp in the same locale-formatted display form as the other time fields. The v2 mapper never assigns it, so it is absent from every response.", example = "8/18/26, 1:16:57\u202fPM")
+    @Schema(description = "Create timestamp in the same locale-formatted display form as the other time fields. The v2 mapper never assigns it, so it is absent from every response.", example = "8/18/26, 1:16:57\u202fPM")
     public String getBridgeNodeCreateTime() {
         return bridgeNodeCreateTime;
     }
@@ -228,7 +228,7 @@ public class BridgeElementNodeDTO {
 
     @XmlElement(name="bridgeNodeLastPollTime")
     @JsonProperty("bridgeNodeLastPollTime")
-    @Schema(description = "Intended as the last-poll timestamp in the same locale-formatted display form as the other time fields. The v2 mapper never assigns it, so it is absent from every response.", example = "8/18/26, 1:16:57\u202fPM")
+    @Schema(description = "Last-poll timestamp in the same locale-formatted display form as the other time fields. The v2 mapper never assigns it, so it is absent from every response.", example = "8/18/26, 1:16:57\u202fPM")
     public String getBridgeNodeLastPollTime() {
         return bridgeNodeLastPollTime;
     }

--- a/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/BridgeElementNodeDTO.java
+++ b/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/BridgeElementNodeDTO.java
@@ -25,6 +25,8 @@ import java.util.Objects;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -32,6 +34,7 @@ import org.codehaus.jackson.annotate.JsonProperty;
 
 @XmlRootElement(name="bridgeElementNode")
 @XmlAccessorType(XmlAccessType.NONE)
+@Schema(description = "One bridge element of the node, one per VLAN. Most fields carry the raw dot1dBase and dot1dStp values; the two timestamp fields are never populated by the v2 mapper.")
 public class BridgeElementNodeDTO {
 
     private String  baseBridgeAddress;
@@ -49,6 +52,7 @@ public class BridgeElementNodeDTO {
 
     @XmlElement(name="baseBridgeAddress")
     @JsonProperty("baseBridgeAddress")
+    @Schema(description = "dot1dBaseBridgeAddress of the bridge, as reported.", example = "001b213c4d5e")
     public String getBaseBridgeAddress() {
         return baseBridgeAddress;
     }
@@ -64,6 +68,7 @@ public class BridgeElementNodeDTO {
 
     @XmlElement(name="baseNumPorts")
     @JsonProperty("baseNumPorts")
+    @Schema(description = "dot1dBaseNumPorts. Numeric, not a display label.", example = "24")
     public Integer getBaseNumPorts() {
         return baseNumPorts;
     }
@@ -79,6 +84,7 @@ public class BridgeElementNodeDTO {
 
     @XmlElement(name="baseType")
     @JsonProperty("baseType")
+    @Schema(description = "dot1dBaseType, as a word rather than the SNMP integer.", example = "transparent-only", allowableValues = {"unknown", "transparent-only", "sourceroute-only", "srt"})
     public String getBaseType() {
         return baseType;
     }
@@ -94,6 +100,7 @@ public class BridgeElementNodeDTO {
 
     @XmlElement(name="stpProtocolSpecification")
     @JsonProperty("stpProtocolSpecification")
+    @Schema(description = "dot1dStpProtocolSpecification, as a word rather than the SNMP integer. Omitted when the bridge does not report it.", example = "ieee802.1d", allowableValues = {"unknown", "decLb100", "ieee802.1d", "ieee802.1m", "ieee802.1aq"})
     public String getStpProtocolSpecification() {
         return stpProtocolSpecification;
     }
@@ -109,6 +116,7 @@ public class BridgeElementNodeDTO {
 
     @XmlElement(name="stpPriority")
     @JsonProperty("stpPriority")
+    @Schema(description = "dot1dStpPriority.", example = "32768")
     public Integer getStpPriority() {
         return stpPriority;
     }
@@ -124,6 +132,7 @@ public class BridgeElementNodeDTO {
 
     @XmlElement(name="stpDesignatedRoot")
     @JsonProperty("stpDesignatedRoot")
+    @Schema(description = "dot1dStpDesignatedRoot, as reported.", example = "8000001b213c4d5e")
     public String getStpDesignatedRoot() {
         return stpDesignatedRoot;
     }
@@ -139,6 +148,7 @@ public class BridgeElementNodeDTO {
 
     @XmlElement(name="stpRootCost")
     @JsonProperty("stpRootCost")
+    @Schema(description = "dot1dStpRootCost.", example = "0")
     public Integer getStpRootCost() {
         return stpRootCost;
     }
@@ -154,6 +164,7 @@ public class BridgeElementNodeDTO {
 
     @XmlElement(name="stpRootPort")
     @JsonProperty("stpRootPort")
+    @Schema(description = "dot1dStpRootPort.", example = "1")
     public Integer getStpRootPort() {
         return stpRootPort;
     }
@@ -169,6 +180,7 @@ public class BridgeElementNodeDTO {
 
     @XmlElement(name="vlan")
     @JsonProperty("vlan")
+    @Schema(description = "VLAN id this bridge element was collected for.", example = "1")
     public Integer getVlan() {
         return vlan;
     }
@@ -184,6 +196,7 @@ public class BridgeElementNodeDTO {
 
     @XmlElement(name="vlanname")
     @JsonProperty("vlanname")
+    @Schema(description = "Name of that VLAN.", example = "default")
     public String getVlanname() {
         return vlanname;
     }
@@ -199,6 +212,7 @@ public class BridgeElementNodeDTO {
 
     @XmlElement(name="bridgeNodeCreateTime")
     @JsonProperty("bridgeNodeCreateTime")
+    @Schema(description = "Intended as the create timestamp in the same locale-formatted display form as the other time fields. The v2 mapper never assigns it, so it is absent from every response.", example = "8/18/26, 1:16:57\u202fPM")
     public String getBridgeNodeCreateTime() {
         return bridgeNodeCreateTime;
     }
@@ -214,6 +228,7 @@ public class BridgeElementNodeDTO {
 
     @XmlElement(name="bridgeNodeLastPollTime")
     @JsonProperty("bridgeNodeLastPollTime")
+    @Schema(description = "Intended as the last-poll timestamp in the same locale-formatted display form as the other time fields. The v2 mapper never assigns it, so it is absent from every response.", example = "8/18/26, 1:16:57\u202fPM")
     public String getBridgeNodeLastPollTime() {
         return bridgeNodeLastPollTime;
     }

--- a/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/BridgeLinkNodeDTO.java
+++ b/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/BridgeLinkNodeDTO.java
@@ -25,6 +25,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -33,6 +35,7 @@ import org.codehaus.jackson.map.annotate.JsonRootName;
 
 @XmlRootElement(name="bridgeLinkNode")
 @JsonRootName("bridgeLinkNode")
+@Schema(description = "One shared bridge segment the node takes part in, with the node's own end in bridgeLocalPort and the other ends in BridgeLinkRemoteNodes. Note that one field name is capitalised where the rest are not.")
 public class BridgeLinkNodeDTO {
     private String bridgeLocalPort;
 
@@ -48,6 +51,7 @@ public class BridgeLinkNodeDTO {
 
     @XmlElement(name="bridgeLocalPort")
     @JsonProperty("bridgeLocalPort")
+    @Schema(description = "Local end of the shared segment as a display label. Depending on what resolved this is a bridge port ((bridgeport:N)), a MAC ((mac:...)), or a port string with (ifindex:N) embedded.", example = "GigabitEthernet0/1(ifindex:2)(bridgeport:1)")
     public String getBridgeLocalPort() {
         return bridgeLocalPort;
     }
@@ -63,6 +67,7 @@ public class BridgeLinkNodeDTO {
 
     @XmlElement(name="bridgeLocalPortUrl")
     @JsonProperty("bridgeLocalPortUrl")
+    @Schema(description = "Relative URL of the local SNMP or IP interface page. Omitted when nothing resolved.", example = "element/snmpinterface.jsp?node=1&ifindex=2")
     public String getBridgeLocalPortUrl() {
         return bridgeLocalPortUrl;
     }
@@ -78,6 +83,7 @@ public class BridgeLinkNodeDTO {
 
     @XmlElement(name="BridgeLinkRemoteNodes")
     @JsonProperty("BridgeLinkRemoteNodes")
+    @Schema(name = "BridgeLinkRemoteNodes", description = "Other ends of the shared segment. Note the wire name is capitalised: BridgeLinkRemoteNodes, unlike every other field here. Always present, empty when the segment has no resolved remote end.")
     public List<BridgeLinkRemoteNodeDTO> getBridgeLinkRemoteNodes() {
         return bridgeLinkRemoteNodes;
     }
@@ -93,6 +99,7 @@ public class BridgeLinkNodeDTO {
 
     @XmlElement(name="bridgeInfo")
     @JsonProperty("bridgeInfo")
+    @Schema(description = "VLAN name of the bridge element behind the local port, when one was found.", example = "default")
     public String getBridgeInfo() {
         return bridgeInfo;
     }
@@ -108,6 +115,7 @@ public class BridgeLinkNodeDTO {
 
     @XmlElement(name="bridgeLinkCreateTime")
     @JsonProperty("bridgeLinkCreateTime")
+    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
     public String getBridgeLinkCreateTime() {
         return bridgeLinkCreateTime;
     }
@@ -123,6 +131,7 @@ public class BridgeLinkNodeDTO {
 
     @XmlElement(name="bridgeLinkLastPollTime")
     @JsonProperty("bridgeLinkLastPollTime")
+    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
     public String getBridgeLinkLastPollTime() {
         return bridgeLinkLastPollTime;
     }

--- a/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/BridgeLinkNodeDTO.java
+++ b/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/BridgeLinkNodeDTO.java
@@ -35,7 +35,7 @@ import org.codehaus.jackson.map.annotate.JsonRootName;
 
 @XmlRootElement(name="bridgeLinkNode")
 @JsonRootName("bridgeLinkNode")
-@Schema(description = "One shared bridge segment the node takes part in, with the node's own end in bridgeLocalPort and the other ends in BridgeLinkRemoteNodes. Note that one field name is capitalised where the rest are not.")
+@Schema(description = "One shared bridge segment the node takes part in, with the node's own end in bridgeLocalPort and the other ends in BridgeLinkRemoteNodes.")
 public class BridgeLinkNodeDTO {
     private String bridgeLocalPort;
 
@@ -83,7 +83,7 @@ public class BridgeLinkNodeDTO {
 
     @XmlElement(name="BridgeLinkRemoteNodes")
     @JsonProperty("BridgeLinkRemoteNodes")
-    @Schema(name = "BridgeLinkRemoteNodes", description = "Other ends of the shared segment. Note the wire name is capitalised: BridgeLinkRemoteNodes, unlike every other field here. Always present, empty when the segment has no resolved remote end.")
+    @Schema(name = "BridgeLinkRemoteNodes", description = "Other ends of the shared segment. The wire name is BridgeLinkRemoteNodes. Always present, empty when the segment has no resolved remote end.")
     public List<BridgeLinkRemoteNodeDTO> getBridgeLinkRemoteNodes() {
         return bridgeLinkRemoteNodes;
     }
@@ -115,7 +115,7 @@ public class BridgeLinkNodeDTO {
 
     @XmlElement(name="bridgeLinkCreateTime")
     @JsonProperty("bridgeLinkCreateTime")
-    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
+    @Schema(description = "Create timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space.", example = "8/18/26, 1:16:57\u202fPM")
     public String getBridgeLinkCreateTime() {
         return bridgeLinkCreateTime;
     }
@@ -131,7 +131,7 @@ public class BridgeLinkNodeDTO {
 
     @XmlElement(name="bridgeLinkLastPollTime")
     @JsonProperty("bridgeLinkLastPollTime")
-    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
+    @Schema(description = "Last-poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space.", example = "8/18/26, 1:16:57\u202fPM")
     public String getBridgeLinkLastPollTime() {
         return bridgeLinkLastPollTime;
     }

--- a/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/BridgeLinkRemoteNodeDTO.java
+++ b/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/BridgeLinkRemoteNodeDTO.java
@@ -23,6 +23,8 @@ package org.opennms.web.rest.model.v2;
 
 import java.util.Objects;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -31,6 +33,7 @@ import org.codehaus.jackson.map.annotate.JsonRootName;
 
 @XmlRootElement(name="bridgeLinkRemoteNode")
 @JsonRootName("bridgeLinkRemoteNode")
+@Schema(description = "The far end of a shared bridge segment. Every field is a display string built for the JSP UI.")
 public class BridgeLinkRemoteNodeDTO {
 
     private String bridgeRemote;
@@ -40,6 +43,7 @@ public class BridgeLinkRemoteNodeDTO {
 
     @XmlElement(name="bridgeRemote")
     @JsonProperty("bridgeRemote")
+    @Schema(description = "Remote end as a display label: the node label followed by (bridge base address:...) or (mac:...) when it resolves to a node, otherwise (nodeid:N) or (mac:...) alone.", example = "acc-sw-04(bridge base address:001b213c4d5e)")
     public String getBridgeRemote() {
         return bridgeRemote;
     }
@@ -55,6 +59,7 @@ public class BridgeLinkRemoteNodeDTO {
 
     @XmlElement(name="bridgeRemoteUrl")
     @JsonProperty("bridgeRemoteUrl")
+    @Schema(description = "Relative URL of the remote node's linked-node page.", example = "element/linkednode.jsp?node=12")
     public String getBridgeRemoteUrl() {
         return bridgeRemoteUrl;
     }
@@ -70,6 +75,7 @@ public class BridgeLinkRemoteNodeDTO {
 
     @XmlElement(name="bridgeRemotePort")
     @JsonProperty("bridgeRemotePort")
+    @Schema(description = "Remote port as a display label, with the bridge port number or ifIndex embedded in the string.", example = "GigabitEthernet0/24(ifindex:24)(bridgeport:24)")
     public String getBridgeRemotePort() {
         return bridgeRemotePort;
     }
@@ -85,6 +91,7 @@ public class BridgeLinkRemoteNodeDTO {
 
     @XmlElement(name="bridgeRemotePortUrl")
     @JsonProperty("bridgeRemotePortUrl")
+    @Schema(description = "Relative URL of the remote SNMP interface page. Omitted when the remote ifIndex could not be resolved.", example = "element/snmpinterface.jsp?node=12&ifindex=24")
     public String getBridgeRemotePortUrl() {
         return bridgeRemotePortUrl;
     }

--- a/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/BridgeLinkRemoteNodeDTO.java
+++ b/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/BridgeLinkRemoteNodeDTO.java
@@ -33,7 +33,7 @@ import org.codehaus.jackson.map.annotate.JsonRootName;
 
 @XmlRootElement(name="bridgeLinkRemoteNode")
 @JsonRootName("bridgeLinkRemoteNode")
-@Schema(description = "The far end of a shared bridge segment. Every field is a display string built for the JSP UI.")
+@Schema(description = "The far end of a shared bridge segment. Every field is a display string.")
 public class BridgeLinkRemoteNodeDTO {
 
     private String bridgeRemote;

--- a/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/CdpElementNodeDTO.java
+++ b/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/CdpElementNodeDTO.java
@@ -23,6 +23,8 @@ package org.opennms.web.rest.model.v2;
 
 import java.util.Objects;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -31,6 +33,7 @@ import org.codehaus.jackson.map.annotate.JsonRootName;
 
 @XmlRootElement(name="cdpElementNode")
 @JsonRootName("cdpElementNode")
+@Schema(description = "The CDP process on the node itself. Omitted from EnlinkdDTO entirely, not serialized as null, when the node has no CDP element.")
 public class CdpElementNodeDTO {
     private String cdpGlobalRun;
 
@@ -44,6 +47,7 @@ public class CdpElementNodeDTO {
 
     @XmlElement(name="cdpGlobalRun")
     @JsonProperty("cdpGlobalRun")
+    @Schema(description = "Whether the CDP protocol is running on the node, as the word form of the SNMP TruthValue.", example = "true", allowableValues = {"true", "false"})
     public String getCdpGlobalRun() {
         return cdpGlobalRun;
     }
@@ -59,6 +63,7 @@ public class CdpElementNodeDTO {
 
     @XmlElement(name="cdpGlobalDeviceId")
     @JsonProperty("cdpGlobalDeviceId")
+    @Schema(description = "cdpGlobalDeviceId as reported by the device.", example = "SEP001B213C4D5E")
     public String getCdpGlobalDeviceId() {
         return cdpGlobalDeviceId;
     }
@@ -74,6 +79,7 @@ public class CdpElementNodeDTO {
 
     @XmlElement(name="cdpGlobalDeviceIdFormat")
     @JsonProperty("cdpGlobalDeviceIdFormat")
+    @Schema(description = "Format of cdpGlobalDeviceId. The v2 mapper never sets this field, so it is absent from every response even when the underlying element has it; the JSP UI shows serialNumber, macAddress or other.", example = "macAddress", allowableValues = {"serialNumber", "macAddress", "other"})
     public String getCdpGlobalDeviceIdFormat() {
         return cdpGlobalDeviceIdFormat;
     }
@@ -89,6 +95,7 @@ public class CdpElementNodeDTO {
 
     @XmlElement(name="cdpCreateTime")
     @JsonProperty("cdpCreateTime")
+    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
     public String getCdpCreateTime() {
         return cdpCreateTime;
     }
@@ -104,6 +111,7 @@ public class CdpElementNodeDTO {
 
     @XmlElement(name="cdpLastPollTime")
     @JsonProperty("cdpLastPollTime")
+    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
     public String getCdpLastPollTime() {
         return cdpLastPollTime;
     }

--- a/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/CdpElementNodeDTO.java
+++ b/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/CdpElementNodeDTO.java
@@ -95,7 +95,7 @@ public class CdpElementNodeDTO {
 
     @XmlElement(name="cdpCreateTime")
     @JsonProperty("cdpCreateTime")
-    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
+    @Schema(description = "Create timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space.", example = "8/18/26, 1:16:57\u202fPM")
     public String getCdpCreateTime() {
         return cdpCreateTime;
     }
@@ -111,7 +111,7 @@ public class CdpElementNodeDTO {
 
     @XmlElement(name="cdpLastPollTime")
     @JsonProperty("cdpLastPollTime")
-    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
+    @Schema(description = "Last-poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space.", example = "8/18/26, 1:16:57\u202fPM")
     public String getCdpLastPollTime() {
         return cdpLastPollTime;
     }

--- a/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/CdpLinkNodeDTO.java
+++ b/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/CdpLinkNodeDTO.java
@@ -23,6 +23,8 @@ package org.opennms.web.rest.model.v2;
 
 import java.util.Objects;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -31,6 +33,7 @@ import org.codehaus.jackson.map.annotate.JsonRootName;
 
 @XmlRootElement(name="cdpLinkNode")
 @JsonRootName("cdpLinkNode")
+@Schema(description = "One discovered CDP neighbour of the node. Every field is a display string built for the JSP UI, with ifIndexes embedded in the port labels and the timestamps locale-formatted rather than epoch milliseconds.")
 public class CdpLinkNodeDTO {
 
     private String  cdpLocalPort;
@@ -53,6 +56,7 @@ public class CdpLinkNodeDTO {
 
     @XmlElement(name="cdpLocalPort")
     @JsonProperty("cdpLocalPort")
+    @Schema(description = "Local port as a display label built from the CDP interface name, the SNMP ifName, (ifindex:N) and the interface address, whichever of those resolved.", example = "GigabitEthernet0/1(ifindex:2)(10.10.1.1)")
     public String getCdpLocalPort() {
         return cdpLocalPort;
     }
@@ -68,6 +72,7 @@ public class CdpLinkNodeDTO {
 
     @XmlElement(name="cdpLocalPortUrl")
     @JsonProperty("cdpLocalPortUrl")
+    @Schema(description = "Relative URL of the local SNMP interface page. Omitted when the ifIndex could not be resolved.", example = "element/snmpinterface.jsp?node=1&ifindex=2")
     public String getCdpLocalPortUrl() {
         return cdpLocalPortUrl;
     }
@@ -83,6 +88,7 @@ public class CdpLinkNodeDTO {
 
     @XmlElement(name="cdpCacheDevice")
     @JsonProperty("cdpCacheDevice")
+    @Schema(description = "Neighbour device as a display label: the raw cdpCacheDeviceId, or the node label followed by (Cisco Device Id:...) once the neighbour resolves to a node.", example = "core-sw-01(Cisco Device Id:SEP001B213C4D5E)")
     public String getCdpCacheDevice() {
         return cdpCacheDevice;
     }
@@ -98,6 +104,7 @@ public class CdpLinkNodeDTO {
 
     @XmlElement(name="cdpCacheDeviceUrl")
     @JsonProperty("cdpCacheDeviceUrl")
+    @Schema(description = "Relative URL of the neighbour's linked-node page. Omitted when the neighbour does not resolve to a node.", example = "element/linkednode.jsp?node=7")
     public String getCdpCacheDeviceUrl() {
         return cdpCacheDeviceUrl;
     }
@@ -113,6 +120,7 @@ public class CdpLinkNodeDTO {
 
     @XmlElement(name="cdpCacheDevicePort")
     @JsonProperty("cdpCacheDevicePort")
+    @Schema(description = "Neighbour port as a display label, in the same form as cdpLocalPort.", example = "GigabitEthernet0/24(ifindex:24)")
     public String getCdpCacheDevicePort() {
         return cdpCacheDevicePort;
     }
@@ -128,6 +136,7 @@ public class CdpLinkNodeDTO {
 
     @XmlElement(name="cdpCacheDevicePortUrl")
     @JsonProperty("cdpCacheDevicePortUrl")
+    @Schema(description = "Relative URL of the neighbour's SNMP interface page. Omitted when the remote ifIndex could not be resolved.", example = "element/snmpinterface.jsp?node=7&ifindex=24")
     public String getCdpCacheDevicePortUrl() {
         return cdpCacheDevicePortUrl;
     }
@@ -143,6 +152,7 @@ public class CdpLinkNodeDTO {
 
     @XmlElement(name="cdpCachePlatform")
     @JsonProperty("cdpCachePlatform")
+    @Schema(description = "Neighbour platform and software version joined by an arrow, built as cdpCacheDevicePlatform + space-arrow-space + cdpCacheVersion. Both halves come from the neighbour's own advertisement.", example = "cisco WS-C3750G-24TS -> Cisco IOS Software, C3750 Software")
     public String getCdpCachePlatform() {
         return cdpCachePlatform;
     }
@@ -158,6 +168,7 @@ public class CdpLinkNodeDTO {
 
     @XmlElement(name="cdpCreateTime")
     @JsonProperty("cdpCreateTime")
+    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
     public String getCdpCreateTime() {
         return cdpCreateTime;
     }
@@ -173,6 +184,7 @@ public class CdpLinkNodeDTO {
 
     @XmlElement(name="cdpLastPollTime")
     @JsonProperty("cdpLastPollTime")
+    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
     public String getCdpLastPollTime() {
         return cdpLastPollTime;
     }

--- a/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/CdpLinkNodeDTO.java
+++ b/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/CdpLinkNodeDTO.java
@@ -33,7 +33,7 @@ import org.codehaus.jackson.map.annotate.JsonRootName;
 
 @XmlRootElement(name="cdpLinkNode")
 @JsonRootName("cdpLinkNode")
-@Schema(description = "One discovered CDP neighbour of the node. Every field is a display string built for the JSP UI, with ifIndexes embedded in the port labels and the timestamps locale-formatted rather than epoch milliseconds.")
+@Schema(description = "One discovered CDP neighbour of the node. Every field is a display string, with ifIndexes embedded in the port labels and the timestamps locale-formatted rather than epoch milliseconds.")
 public class CdpLinkNodeDTO {
 
     private String  cdpLocalPort;
@@ -152,7 +152,7 @@ public class CdpLinkNodeDTO {
 
     @XmlElement(name="cdpCachePlatform")
     @JsonProperty("cdpCachePlatform")
-    @Schema(description = "Neighbour platform and software version joined by an arrow, built as cdpCacheDevicePlatform + space-arrow-space + cdpCacheVersion. Both halves come from the neighbour's own advertisement.", example = "cisco WS-C3750G-24TS -> Cisco IOS Software, C3750 Software")
+    @Schema(description = "Neighbour platform and software version joined by an arrow, built as cdpCacheDevicePlatform + space-arrow-space + cdpCacheVersion.", example = "cisco WS-C3750G-24TS -> Cisco IOS Software, C3750 Software")
     public String getCdpCachePlatform() {
         return cdpCachePlatform;
     }
@@ -168,7 +168,7 @@ public class CdpLinkNodeDTO {
 
     @XmlElement(name="cdpCreateTime")
     @JsonProperty("cdpCreateTime")
-    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
+    @Schema(description = "Create timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space.", example = "8/18/26, 1:16:57\u202fPM")
     public String getCdpCreateTime() {
         return cdpCreateTime;
     }
@@ -184,7 +184,7 @@ public class CdpLinkNodeDTO {
 
     @XmlElement(name="cdpLastPollTime")
     @JsonProperty("cdpLastPollTime")
-    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
+    @Schema(description = "Last-poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space.", example = "8/18/26, 1:16:57\u202fPM")
     public String getCdpLastPollTime() {
         return cdpLastPollTime;
     }

--- a/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/EnlinkdDTO.java
+++ b/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/EnlinkdDTO.java
@@ -157,7 +157,7 @@ public class EnlinkdDTO {
 
     @XmlElement(name="bridgeElementNodes")
     @JsonProperty("bridgeElementNodes")
-    @Schema(name = "bridgeElementNodes", description = "The node's bridge elements, one per VLAN. Always present, empty when there are none.")
+    @Schema(name = "bridgeElementNodes", description = "The node's bridge elements, one per discovered VLAN, with a single null-`vlan` entry when the device has no VLAN table. Always present, empty when there are none.")
     public List<BridgeElementNodeDTO> getBridgeElementNodeDTOS() {
         return bridgeElementNodeDTOS;
     }

--- a/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/EnlinkdDTO.java
+++ b/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/EnlinkdDTO.java
@@ -24,6 +24,8 @@ package org.opennms.web.rest.model.v2;
 import java.util.List;
 import java.util.Objects;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -32,6 +34,7 @@ import org.codehaus.jackson.map.annotate.JsonRootName;
 
 @XmlRootElement(name="enlinkd")
 @JsonRootName("enlinkd")
+@Schema(description = "Every link-layer and routing-protocol neighbour discovered for one node, grouped by protocol. The five list fields are always present, empty when nothing was discovered; the four single-element fields are omitted from the response entirely rather than serialized as null.")
 public class EnlinkdDTO {
 
     List<LldpLinkNodeDTO> lldpLinkNodeDTOs;
@@ -57,6 +60,7 @@ public class EnlinkdDTO {
 
     @XmlElement(name="lldpLinkNodes")
     @JsonProperty("lldpLinkNodes")
+    @Schema(name = "lldpLinkNodes", description = "LLDP links discovered on this node. Always present, empty when there are none.")
     public List<LldpLinkNodeDTO> getLldpLinkNodeDTOs() {
         return lldpLinkNodeDTOs;
     }
@@ -72,6 +76,7 @@ public class EnlinkdDTO {
 
     @XmlElement(name="bridgeLinkNodes")
     @JsonProperty("bridgeLinkNodes")
+    @Schema(name = "bridgeLinkNodes", description = "Bridge-forwarding links discovered on this node. Always present, empty when there are none.")
     public List<BridgeLinkNodeDTO> getBridgeLinkNodeDTOS() {
         return bridgeLinkNodeDTOS;
     }
@@ -87,6 +92,7 @@ public class EnlinkdDTO {
 
     @XmlElement(name="cdpLinkNodes")
     @JsonProperty("cdpLinkNodes")
+    @Schema(name = "cdpLinkNodes", description = "CDP links discovered on this node. Always present, empty when there are none.")
     public List<CdpLinkNodeDTO> getCdpLinkNodeDTOS() {
         return cdpLinkNodeDTOS;
     }
@@ -102,6 +108,7 @@ public class EnlinkdDTO {
 
     @XmlElement(name="ospfLinkNodes")
     @JsonProperty("ospfLinkNodes")
+    @Schema(name = "ospfLinkNodes", description = "OSPF links discovered on this node. Always present, empty when there are none.")
     public List<OspfLinkNodeDTO> getOspfLinkNodeDTOS() {
         return ospfLinkNodeDTOS;
     }
@@ -117,6 +124,7 @@ public class EnlinkdDTO {
 
     @XmlElement(name="isisLinkNodes")
     @JsonProperty("isisLinkNodes")
+    @Schema(name = "isisLinkNodes", description = "IS-IS adjacencies discovered on this node. Always present, empty when there are none.")
     public List<IsisLinkNodeDTO> getIsisLinkNodeDTOS() {
         return isisLinkNodeDTOS;
     }
@@ -132,6 +140,7 @@ public class EnlinkdDTO {
 
     @XmlElement(name="lldpElementNode")
     @JsonProperty("lldpElementNode")
+    @Schema(name = "lldpElementNode", description = "The node's own LLDP element. Single-valued, and omitted from the response entirely rather than serialized as null when the node has no LLDP element.")
     public LldpElementNodeDTO getLldpElementNodeDTO() {
         return lldpElementNodeDTO;
     }
@@ -148,6 +157,7 @@ public class EnlinkdDTO {
 
     @XmlElement(name="bridgeElementNodes")
     @JsonProperty("bridgeElementNodes")
+    @Schema(name = "bridgeElementNodes", description = "The node's bridge elements, one per VLAN. Always present, empty when there are none.")
     public List<BridgeElementNodeDTO> getBridgeElementNodeDTOS() {
         return bridgeElementNodeDTOS;
     }
@@ -163,6 +173,7 @@ public class EnlinkdDTO {
 
     @XmlElement(name="cdpElementNode")
     @JsonProperty("cdpElementNode")
+    @Schema(name = "cdpElementNode", description = "The node's own CDP element. Single-valued, and omitted from the response entirely rather than serialized as null when the node has no CDP element.")
     public CdpElementNodeDTO getCdpElementNodeDTO() {
         return cdpElementNodeDTO;
     }
@@ -178,6 +189,7 @@ public class EnlinkdDTO {
 
     @XmlElement(name="ospfElementNode")
     @JsonProperty("ospfElementNode")
+    @Schema(name = "ospfElementNode", description = "The node's own OSPF element. Single-valued, and omitted from the response entirely rather than serialized as null when the node has no OSPF element.")
     public OspfElementNodeDTO getOspfElementNodeDTO() {
         return ospfElementNodeDTO;
     }
@@ -193,6 +205,7 @@ public class EnlinkdDTO {
 
     @XmlElement(name="isisElementNode")
     @JsonProperty("isisElementNode")
+    @Schema(name = "isisElementNode", description = "The node's own IS-IS element. Single-valued, and omitted from the response entirely rather than serialized as null when the node has no IS-IS element.")
     public IsisElementNodeDTO getIsisElementNodeDTO() {
         return isisElementNodeDTO;
     }

--- a/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/IsisElementNodeDTO.java
+++ b/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/IsisElementNodeDTO.java
@@ -23,6 +23,8 @@ package org.opennms.web.rest.model.v2;
 
 import java.util.Objects;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -31,6 +33,7 @@ import org.codehaus.jackson.map.annotate.JsonRootName;
 
 @XmlRootElement(name="isisElementNode")
 @JsonRootName("isisElementNode")
+@Schema(description = "The IS-IS process on the node itself. Omitted from EnlinkdDTO entirely, not serialized as null, when the node has no IS-IS element.")
 public class IsisElementNodeDTO {
     private String isisSysID;
 
@@ -42,6 +45,7 @@ public class IsisElementNodeDTO {
 
     @XmlElement(name="isisSysID")
     @JsonProperty("isisSysID")
+    @Schema(description = "isisSysID of the node, as reported.", example = "0000.0000.0001")
     public String getIsisSysID() {
         return isisSysID;
     }
@@ -57,6 +61,7 @@ public class IsisElementNodeDTO {
 
     @XmlElement(name="isisSysAdminState")
     @JsonProperty("isisSysAdminState")
+    @Schema(description = "Administrative state of the IS-IS process, as a word rather than the SNMP integer.", example = "on", allowableValues = {"on", "off"})
     public String getIsisSysAdminState() {
         return isisSysAdminState;
     }
@@ -72,6 +77,7 @@ public class IsisElementNodeDTO {
 
     @XmlElement(name="isisCreateTime")
     @JsonProperty("isisCreateTime")
+    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
     public String getIsisCreateTime() {
         return isisCreateTime;
     }
@@ -87,6 +93,7 @@ public class IsisElementNodeDTO {
 
     @XmlElement(name="isisLastPollTime")
     @JsonProperty("isisLastPollTime")
+    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
     public String getIsisLastPollTime() {
         return isisLastPollTime;
     }

--- a/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/IsisElementNodeDTO.java
+++ b/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/IsisElementNodeDTO.java
@@ -77,7 +77,7 @@ public class IsisElementNodeDTO {
 
     @XmlElement(name="isisCreateTime")
     @JsonProperty("isisCreateTime")
-    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
+    @Schema(description = "Create timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space.", example = "8/18/26, 1:16:57\u202fPM")
     public String getIsisCreateTime() {
         return isisCreateTime;
     }
@@ -93,7 +93,7 @@ public class IsisElementNodeDTO {
 
     @XmlElement(name="isisLastPollTime")
     @JsonProperty("isisLastPollTime")
-    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
+    @Schema(description = "Last-poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space.", example = "8/18/26, 1:16:57\u202fPM")
     public String getIsisLastPollTime() {
         return isisLastPollTime;
     }

--- a/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/IsisLinkNodeDTO.java
+++ b/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/IsisLinkNodeDTO.java
@@ -33,7 +33,7 @@ import org.codehaus.jackson.map.annotate.JsonRootName;
 
 @XmlRootElement(name="isisLinkNode")
 @JsonRootName("isisLinkNode")
-@Schema(description = "One discovered IS-IS adjacency of the node. Most fields are display strings built for the JSP UI; isisCircIfIndex and isisISAdjNbrExtendedCircID are the exceptions and are numeric.")
+@Schema(description = "One discovered IS-IS adjacency of the node. Most fields are display strings; isisCircIfIndex and isisISAdjNbrExtendedCircID are numeric.")
 public class IsisLinkNodeDTO {
 
     private Integer isisCircIfIndex;
@@ -62,7 +62,7 @@ public class IsisLinkNodeDTO {
 
     @XmlElement(name="isisCircIfIndex")
     @JsonProperty("isisCircIfIndex")
-    @Schema(description = "ifIndex of the local IS-IS circuit. One of the few numeric fields on these DTOs: it is the raw ifIndex, not a display label.", example = "2")
+    @Schema(description = "ifIndex of the local IS-IS circuit: the raw ifIndex, not a display label.", example = "2")
     public Integer getIsisCircIfIndex() {
         return isisCircIfIndex;
     }
@@ -126,7 +126,7 @@ public class IsisLinkNodeDTO {
 
     @XmlElement(name="isisISAdjNeighSysUrl")
     @JsonProperty("isisISAdjNeighSysUrl")
-    @Schema(description = "Intended as the relative URL of the neighbour's node page. The factory never assigns it, so it is absent from every response; isisISAdjUrl carries that link instead.", example = "element/linkednode.jsp?node=7")
+    @Schema(description = "Relative URL of the neighbour's node page. The factory never assigns it, so it is absent from every response; isisISAdjUrl carries that link instead.", example = "element/linkednode.jsp?node=7")
     public String getIsisISAdjNeighSysUrl() {
         return isisISAdjNeighSysUrl;
     }
@@ -222,7 +222,7 @@ public class IsisLinkNodeDTO {
 
     @XmlElement(name="isisLinkCreateTime")
     @JsonProperty("isisLinkCreateTime")
-    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
+    @Schema(description = "Create timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space.", example = "8/18/26, 1:16:57\u202fPM")
     public String getIsisLinkCreateTime() {
         return isisLinkCreateTime;
     }
@@ -238,7 +238,7 @@ public class IsisLinkNodeDTO {
 
     @XmlElement(name="isisLinkLastPollTime")
     @JsonProperty("isisLinkLastPollTime")
-    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
+    @Schema(description = "Last-poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space.", example = "8/18/26, 1:16:57\u202fPM")
     public String getIsisLinkLastPollTime() {
         return isisLinkLastPollTime;
     }

--- a/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/IsisLinkNodeDTO.java
+++ b/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/IsisLinkNodeDTO.java
@@ -23,6 +23,8 @@ package org.opennms.web.rest.model.v2;
 
 import java.util.Objects;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -31,6 +33,7 @@ import org.codehaus.jackson.map.annotate.JsonRootName;
 
 @XmlRootElement(name="isisLinkNode")
 @JsonRootName("isisLinkNode")
+@Schema(description = "One discovered IS-IS adjacency of the node. Most fields are display strings built for the JSP UI; isisCircIfIndex and isisISAdjNbrExtendedCircID are the exceptions and are numeric.")
 public class IsisLinkNodeDTO {
 
     private Integer isisCircIfIndex;
@@ -59,6 +62,7 @@ public class IsisLinkNodeDTO {
 
     @XmlElement(name="isisCircIfIndex")
     @JsonProperty("isisCircIfIndex")
+    @Schema(description = "ifIndex of the local IS-IS circuit. One of the few numeric fields on these DTOs: it is the raw ifIndex, not a display label.", example = "2")
     public Integer getIsisCircIfIndex() {
         return isisCircIfIndex;
     }
@@ -74,6 +78,7 @@ public class IsisLinkNodeDTO {
 
     @XmlElement(name="isisCircAdminState")
     @JsonProperty("isisCircAdminState")
+    @Schema(description = "Administrative state of the circuit, as a word rather than the SNMP integer.", example = "on", allowableValues = {"on", "off"})
     public String getIsisCircAdminState() {
         return isisCircAdminState;
     }
@@ -89,6 +94,7 @@ public class IsisLinkNodeDTO {
 
     @XmlElement(name="isisISAdjNeighSysID")
     @JsonProperty("isisISAdjNeighSysID")
+    @Schema(description = "Neighbour system id as a display label: the raw isisISAdjNeighSysID, or the node label followed by (isis system id:...) once the neighbour resolves to a node.", example = "core-rtr-01(isis system id:0000.0000.0002)")
     public String getIsisISAdjNeighSysID() {
         return isisISAdjNeighSysID;
     }
@@ -104,6 +110,7 @@ public class IsisLinkNodeDTO {
 
     @XmlElement(name="isisISAdjNeighSysType")
     @JsonProperty("isisISAdjNeighSysType")
+    @Schema(description = "IS-IS level of the neighbour, as a word rather than the SNMP integer.", example = "l1L2IntermediateSystem", allowableValues = {"l1_IntermediateSystem", "l2IntermediateSystem", "l1L2IntermediateSystem", "unknown"})
     public String getIsisISAdjNeighSysType() {
         return isisISAdjNeighSysType;
     }
@@ -119,6 +126,7 @@ public class IsisLinkNodeDTO {
 
     @XmlElement(name="isisISAdjNeighSysUrl")
     @JsonProperty("isisISAdjNeighSysUrl")
+    @Schema(description = "Intended as the relative URL of the neighbour's node page. The factory never assigns it, so it is absent from every response; isisISAdjUrl carries that link instead.", example = "element/linkednode.jsp?node=7")
     public String getIsisISAdjNeighSysUrl() {
         return isisISAdjNeighSysUrl;
     }
@@ -134,6 +142,7 @@ public class IsisLinkNodeDTO {
 
     @XmlElement(name="isisISAdjNeighSNPAAddress")
     @JsonProperty("isisISAdjNeighSNPAAddress")
+    @Schema(description = "SNPA (subnetwork point of attachment) address of the neighbour, as reported.", example = "00:1b:21:3c:4d:5e")
     public String getIsisISAdjNeighSNPAAddress() {
         return isisISAdjNeighSNPAAddress;
     }
@@ -149,6 +158,7 @@ public class IsisLinkNodeDTO {
 
     @XmlElement(name="isisISAdjNeighPort")
     @JsonProperty("isisISAdjNeighPort")
+    @Schema(description = "Neighbour port as a display label. When the remote interface resolves it is the port string, otherwise the fallback (Isis IS Adj Index: N) built from the adjacency index.", example = "GigabitEthernet0/2(ifindex:3)")
     public String getIsisISAdjNeighPort() {
         return isisISAdjNeighPort;
     }
@@ -164,6 +174,7 @@ public class IsisLinkNodeDTO {
 
     @XmlElement(name="isisISAdjState")
     @JsonProperty("isisISAdjState")
+    @Schema(description = "Adjacency state, as a word rather than the SNMP integer.", example = "up", allowableValues = {"down", "initializing", "up", "failed"})
     public String getIsisISAdjState() {
         return isisISAdjState;
     }
@@ -179,6 +190,7 @@ public class IsisLinkNodeDTO {
 
     @XmlElement(name="isisISAdjNbrExtendedCircID")
     @JsonProperty("isisISAdjNbrExtendedCircID")
+    @Schema(description = "isisISAdjNbrExtendedCircID as reported. Numeric, not a display label.", example = "3")
     public Integer getIsisISAdjNbrExtendedCircID() {
         return isisISAdjNbrExtendedCircID;
     }
@@ -194,6 +206,7 @@ public class IsisLinkNodeDTO {
 
     @XmlElement(name="isisISAdjUrl")
     @JsonProperty("isisISAdjUrl")
+    @Schema(description = "Relative URL for the adjacency: the neighbour's linked-node page when the neighbour resolves to a node, otherwise the neighbour's SNMP interface page.", example = "element/linkednode.jsp?node=7")
     public String getIsisISAdjUrl() {
         return isisISAdjUrl;
     }
@@ -209,6 +222,7 @@ public class IsisLinkNodeDTO {
 
     @XmlElement(name="isisLinkCreateTime")
     @JsonProperty("isisLinkCreateTime")
+    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
     public String getIsisLinkCreateTime() {
         return isisLinkCreateTime;
     }
@@ -224,6 +238,7 @@ public class IsisLinkNodeDTO {
 
     @XmlElement(name="isisLinkLastPollTime")
     @JsonProperty("isisLinkLastPollTime")
+    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
     public String getIsisLinkLastPollTime() {
         return isisLinkLastPollTime;
     }

--- a/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/LldpElementNodeDTO.java
+++ b/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/LldpElementNodeDTO.java
@@ -23,6 +23,8 @@ package org.opennms.web.rest.model.v2;
 
 import java.util.Objects;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -31,6 +33,7 @@ import org.codehaus.jackson.map.annotate.JsonRootName;
 
 @XmlRootElement(name="lldpElementNode")
 @JsonRootName("lldpElementNode")
+@Schema(description = "The LLDP agent on the node itself. Omitted from EnlinkdDTO entirely, not serialized as null, when the node has no LLDP element. Every field is a display string built for the JSP UI.")
 public class LldpElementNodeDTO {
 
     private String lldpChassisId;
@@ -43,6 +46,7 @@ public class LldpElementNodeDTO {
 
     @XmlElement(name="lldpChassisId")
     @JsonProperty("lldpChassisId")
+    @Schema(description = "Chassis id of the local LLDP agent as a display label: the id subtype and value in parentheses, for example (macAddress:00:1b:21:3c:4d:5e). Not a bare identifier.", example = "(macAddress:sc-001011)")
     public String getLldpChassisId() {
         return lldpChassisId;
     }
@@ -58,6 +62,7 @@ public class LldpElementNodeDTO {
 
     @XmlElement(name="lldpSysName")
     @JsonProperty("lldpSysName")
+    @Schema(description = "lldpLocSysName reported by the node.", example = "scale-dist-001")
     public String getLldpSysName() {
         return lldpSysName;
     }
@@ -73,6 +78,7 @@ public class LldpElementNodeDTO {
 
     @XmlElement(name="lldpCreateTime")
     @JsonProperty("lldpCreateTime")
+    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
     public String getLldpCreateTime() {
         return lldpCreateTime;
     }
@@ -88,6 +94,7 @@ public class LldpElementNodeDTO {
 
     @XmlElement(name="lldpLastPollTime")
     @JsonProperty("lldpLastPollTime")
+    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
     public String getLldpLastPollTime() {
         return lldpLastPollTime;
     }

--- a/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/LldpElementNodeDTO.java
+++ b/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/LldpElementNodeDTO.java
@@ -33,7 +33,7 @@ import org.codehaus.jackson.map.annotate.JsonRootName;
 
 @XmlRootElement(name="lldpElementNode")
 @JsonRootName("lldpElementNode")
-@Schema(description = "The LLDP agent on the node itself. Omitted from EnlinkdDTO entirely, not serialized as null, when the node has no LLDP element. Every field is a display string built for the JSP UI.")
+@Schema(description = "The LLDP agent on the node itself. Omitted from EnlinkdDTO entirely, not serialized as null, when the node has no LLDP element. Every field is a display string.")
 public class LldpElementNodeDTO {
 
     private String lldpChassisId;
@@ -78,7 +78,7 @@ public class LldpElementNodeDTO {
 
     @XmlElement(name="lldpCreateTime")
     @JsonProperty("lldpCreateTime")
-    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
+    @Schema(description = "Create timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space.", example = "8/18/26, 1:16:57\u202fPM")
     public String getLldpCreateTime() {
         return lldpCreateTime;
     }
@@ -94,7 +94,7 @@ public class LldpElementNodeDTO {
 
     @XmlElement(name="lldpLastPollTime")
     @JsonProperty("lldpLastPollTime")
-    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
+    @Schema(description = "Last-poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space.", example = "8/18/26, 1:16:57\u202fPM")
     public String getLldpLastPollTime() {
         return lldpLastPollTime;
     }

--- a/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/LldpLinkNodeDTO.java
+++ b/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/LldpLinkNodeDTO.java
@@ -23,6 +23,8 @@ package org.opennms.web.rest.model.v2;
 
 import java.util.Objects;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -31,6 +33,7 @@ import org.codehaus.jackson.map.annotate.JsonRootName;
 
 @XmlRootElement(name="lldpLinkNode")
 @JsonRootName("lldpLinkNode")
+@Schema(description = "One discovered LLDP neighbour of the node. Every field is a display string built for the JSP UI: ifIndexes and interface names are embedded in the port labels, URLs are relative JSP paths, and the two timestamps are locale-formatted rather than epoch milliseconds.")
 public class LldpLinkNodeDTO {
 
     private String   lldpLocalPort;
@@ -53,6 +56,7 @@ public class LldpLinkNodeDTO {
 
     @XmlElement(name="lldpLocalPort")
     @JsonProperty("lldpLocalPort")
+    @Schema(description = "Local port as a display label: the SNMP ifName, then (ifindex:N) when the SNMP interface resolves, then the LLDP port id in parentheses. The ifIndex is embedded in this string rather than carried as its own field.", example = "GigabitEthernet0/1001(ifindex:2)(interfaceName:Gi0/1001)")
     public String getLldpLocalPort() {
         return lldpLocalPort;
     }
@@ -68,6 +72,7 @@ public class LldpLinkNodeDTO {
 
     @XmlElement(name="lldpLocalPortUrl")
     @JsonProperty("lldpLocalPortUrl")
+    @Schema(description = "Relative URL of the local SNMP interface page in the JSP UI, resolved against /opennms/. Omitted when the ifIndex could not be resolved.", example = "element/snmpinterface.jsp?node=1011&ifindex=2")
     public String getLldpLocalPortUrl() {
         return lldpLocalPortUrl;
     }
@@ -83,6 +88,7 @@ public class LldpLinkNodeDTO {
 
     @XmlElement(name="lldpRemChassisId")
     @JsonProperty("lldpRemChassisId")
+    @Schema(description = "Remote chassis as a display label. When the neighbour resolves to a node it is the node label followed by the chassis id in parentheses, otherwise the parenthesised chassis id alone.", example = "scale-core-001(macAddress:sc-001001)")
     public String getLldpRemChassisId() {
         return lldpRemChassisId;
     }
@@ -98,6 +104,7 @@ public class LldpLinkNodeDTO {
 
     @XmlElement(name="lldpRemChassisIdUrl")
     @JsonProperty("lldpRemChassisIdUrl")
+    @Schema(description = "Relative URL of the neighbour's linked-node page. Omitted when the neighbour does not resolve to a node in this database.", example = "element/linkednode.jsp?node=1001")
     public String getLldpRemChassisIdUrl() {
         return lldpRemChassisIdUrl;
     }
@@ -113,6 +120,7 @@ public class LldpLinkNodeDTO {
 
     @XmlElement(name="lldpRemInfo")
     @JsonProperty("lldpRemInfo")
+    @Schema(description = "lldpRemSysName as advertised by the neighbour.", example = "scale-core-001")
     public String getLldpRemInfo() {
         return lldpRemInfo;
     }
@@ -128,6 +136,7 @@ public class LldpLinkNodeDTO {
 
     @XmlElement(name="ldpRemPort")
     @JsonProperty("ldpRemPort")
+    @Schema(description = "Remote port display label, in the same form as lldpLocalPort. The wire name is missing the leading l: it is ldpRemPort, not lldpRemPort. The spelling is client-visible and is left as is.", example = "GigabitEthernet0/1011(interfaceName:Gi0/1011)")
     public String getLdpRemPort() {
         return ldpRemPort;
     }
@@ -143,6 +152,7 @@ public class LldpLinkNodeDTO {
 
     @XmlElement(name="lldpRemPortUrl")
     @JsonProperty("lldpRemPortUrl")
+    @Schema(description = "Relative URL of the neighbour's SNMP interface page. Omitted unless the remote ifIndex resolves to a stored SNMP interface, which it did on none of the rows observed.", example = "element/snmpinterface.jsp?node=1001&ifindex=12")
     public String getLldpRemPortUrl() {
         return lldpRemPortUrl;
     }
@@ -158,6 +168,7 @@ public class LldpLinkNodeDTO {
 
     @XmlElement(name="lldpCreateTime")
     @JsonProperty("lldpCreateTime")
+    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
     public String getLldpCreateTime() {
         return lldpCreateTime;
     }
@@ -173,6 +184,7 @@ public class LldpLinkNodeDTO {
 
     @XmlElement(name="lldpLastPollTime")
     @JsonProperty("lldpLastPollTime")
+    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
     public String getLldpLastPollTime() {
         return lldpLastPollTime;
     }

--- a/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/LldpLinkNodeDTO.java
+++ b/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/LldpLinkNodeDTO.java
@@ -33,7 +33,7 @@ import org.codehaus.jackson.map.annotate.JsonRootName;
 
 @XmlRootElement(name="lldpLinkNode")
 @JsonRootName("lldpLinkNode")
-@Schema(description = "One discovered LLDP neighbour of the node. Every field is a display string built for the JSP UI: ifIndexes and interface names are embedded in the port labels, URLs are relative JSP paths, and the two timestamps are locale-formatted rather than epoch milliseconds.")
+@Schema(description = "One discovered LLDP neighbour of the node. Every field is a display string: ifIndexes and interface names are embedded in the port labels, URLs are relative JSP paths, and the two timestamps are locale-formatted rather than epoch milliseconds.")
 public class LldpLinkNodeDTO {
 
     private String   lldpLocalPort;
@@ -136,7 +136,7 @@ public class LldpLinkNodeDTO {
 
     @XmlElement(name="ldpRemPort")
     @JsonProperty("ldpRemPort")
-    @Schema(description = "Remote port display label, in the same form as lldpLocalPort. The wire name is missing the leading l: it is ldpRemPort, not lldpRemPort. The spelling is client-visible and is left as is.", example = "GigabitEthernet0/1011(interfaceName:Gi0/1011)")
+    @Schema(description = "Remote port display label, in the same form as lldpLocalPort. The wire name is ldpRemPort, without the leading l.", example = "GigabitEthernet0/1011(interfaceName:Gi0/1011)")
     public String getLdpRemPort() {
         return ldpRemPort;
     }
@@ -152,7 +152,7 @@ public class LldpLinkNodeDTO {
 
     @XmlElement(name="lldpRemPortUrl")
     @JsonProperty("lldpRemPortUrl")
-    @Schema(description = "Relative URL of the neighbour's SNMP interface page. Omitted unless the remote ifIndex resolves to a stored SNMP interface, which it did on none of the rows observed.", example = "element/snmpinterface.jsp?node=1001&ifindex=12")
+    @Schema(description = "Relative URL of the neighbour's SNMP interface page. Omitted unless the remote ifIndex resolves to a stored SNMP interface, which no observed row did.", example = "element/snmpinterface.jsp?node=1001&ifindex=12")
     public String getLldpRemPortUrl() {
         return lldpRemPortUrl;
     }
@@ -168,7 +168,7 @@ public class LldpLinkNodeDTO {
 
     @XmlElement(name="lldpCreateTime")
     @JsonProperty("lldpCreateTime")
-    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
+    @Schema(description = "Create timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space.", example = "8/18/26, 1:16:57\u202fPM")
     public String getLldpCreateTime() {
         return lldpCreateTime;
     }
@@ -184,7 +184,7 @@ public class LldpLinkNodeDTO {
 
     @XmlElement(name="lldpLastPollTime")
     @JsonProperty("lldpLastPollTime")
-    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/18/26, 1:16:57\u202fPM")
+    @Schema(description = "Last-poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space.", example = "8/18/26, 1:16:57\u202fPM")
     public String getLldpLastPollTime() {
         return lldpLastPollTime;
     }

--- a/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/OspfElementNodeDTO.java
+++ b/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/OspfElementNodeDTO.java
@@ -23,6 +23,8 @@ package org.opennms.web.rest.model.v2;
 
 import java.util.Objects;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -31,6 +33,7 @@ import org.codehaus.jackson.map.annotate.JsonRootName;
 
 @XmlRootElement(name="ospfElementNode")
 @JsonRootName("ospfElementNode")
+@Schema(description = "The OSPF process on the node itself. Omitted from EnlinkdDTO entirely, not serialized as null, when the node has no OSPF element.")
 public class OspfElementNodeDTO {
 
     private String ospfRouterId;
@@ -45,6 +48,7 @@ public class OspfElementNodeDTO {
 
     @XmlElement(name="ospfRouterId")
     @JsonProperty("ospfRouterId")
+    @Schema(description = "ospfRouterId of the node.", example = "10.255.0.1")
     public String getOspfRouterId() {
         return ospfRouterId;
     }
@@ -60,6 +64,7 @@ public class OspfElementNodeDTO {
 
     @XmlElement(name="ospfVersionNumber")
     @JsonProperty("ospfVersionNumber")
+    @Schema(description = "OSPF version advertised by the node.", example = "2")
     public Integer getOspfVersionNumber() {
         return ospfVersionNumber;
     }
@@ -75,6 +80,7 @@ public class OspfElementNodeDTO {
 
     @XmlElement(name="ospfAdminStat")
     @JsonProperty("ospfAdminStat")
+    @Schema(description = "Administrative status of the OSPF process, as a word rather than the SNMP integer.", example = "enabled", allowableValues = {"enabled", "disabled"})
     public String getOspfAdminStat() {
         return ospfAdminStat;
     }
@@ -90,6 +96,7 @@ public class OspfElementNodeDTO {
 
     @XmlElement(name="ospfCreateTime")
     @JsonProperty("ospfCreateTime")
+    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/17/26, 5:20:39\u202fPM")
     public String getOspfCreateTime() {
         return ospfCreateTime;
     }
@@ -105,6 +112,7 @@ public class OspfElementNodeDTO {
 
     @XmlElement(name="ospfLastPollTime")
     @JsonProperty("ospfLastPollTime")
+    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/17/26, 5:20:39\u202fPM")
     public String getOspfLastPollTime() {
         return ospfLastPollTime;
     }

--- a/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/OspfElementNodeDTO.java
+++ b/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/OspfElementNodeDTO.java
@@ -96,7 +96,7 @@ public class OspfElementNodeDTO {
 
     @XmlElement(name="ospfCreateTime")
     @JsonProperty("ospfCreateTime")
-    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/17/26, 5:20:39\u202fPM")
+    @Schema(description = "Create timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space.", example = "8/17/26, 5:20:39\u202fPM")
     public String getOspfCreateTime() {
         return ospfCreateTime;
     }
@@ -112,7 +112,7 @@ public class OspfElementNodeDTO {
 
     @XmlElement(name="ospfLastPollTime")
     @JsonProperty("ospfLastPollTime")
-    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/17/26, 5:20:39\u202fPM")
+    @Schema(description = "Last-poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space.", example = "8/17/26, 5:20:39\u202fPM")
     public String getOspfLastPollTime() {
         return ospfLastPollTime;
     }

--- a/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/OspfLinkNodeDTO.java
+++ b/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/OspfLinkNodeDTO.java
@@ -33,7 +33,7 @@ import org.codehaus.jackson.map.annotate.JsonRootName;
 
 @XmlRootElement(name="ospfLinkNode")
 @JsonRootName("ospfLinkNode")
-@Schema(description = "One discovered OSPF neighbour of the node. Every field is a display string built for the JSP UI, with ifIndexes and addresses embedded in the port labels and the timestamps locale-formatted rather than epoch milliseconds.")
+@Schema(description = "One discovered OSPF neighbour of the node. Every field is a display string, with ifIndexes and addresses embedded in the port labels and the timestamps locale-formatted rather than epoch milliseconds.")
 public class OspfLinkNodeDTO {
 
     private String ospfLocalPort;
@@ -168,7 +168,7 @@ public class OspfLinkNodeDTO {
 
     @XmlElement(name="ospfLinkCreateTime")
     @JsonProperty("ospfLinkCreateTime")
-    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/17/26, 5:20:39\u202fPM")
+    @Schema(description = "Create timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space.", example = "8/17/26, 5:20:39\u202fPM")
     public String getOspfLinkCreateTime() {
         return ospfLinkCreateTime;
     }
@@ -184,7 +184,7 @@ public class OspfLinkNodeDTO {
 
     @XmlElement(name="ospfLinkLastPollTime")
     @JsonProperty("ospfLinkLastPollTime")
-    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/17/26, 5:20:39\u202fPM")
+    @Schema(description = "Last-poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space.", example = "8/17/26, 5:20:39\u202fPM")
     public String getOspfLinkLastPollTime() {
         return ospfLinkLastPollTime;
     }

--- a/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/OspfLinkNodeDTO.java
+++ b/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/OspfLinkNodeDTO.java
@@ -23,6 +23,8 @@ package org.opennms.web.rest.model.v2;
 
 import java.util.Objects;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -31,6 +33,7 @@ import org.codehaus.jackson.map.annotate.JsonRootName;
 
 @XmlRootElement(name="ospfLinkNode")
 @JsonRootName("ospfLinkNode")
+@Schema(description = "One discovered OSPF neighbour of the node. Every field is a display string built for the JSP UI, with ifIndexes and addresses embedded in the port labels and the timestamps locale-formatted rather than epoch milliseconds.")
 public class OspfLinkNodeDTO {
 
     private String ospfLocalPort;
@@ -53,6 +56,7 @@ public class OspfLinkNodeDTO {
 
     @XmlElement(name="ospfLocalPort")
     @JsonProperty("ospfLocalPort")
+    @Schema(description = "Local interface as a display label: ifName, the ifAlias in parentheses, then (ifindex:N), then the interface address in parentheses. The ifIndex is embedded here rather than carried as its own field.", example = "Gi0/2(review-iface)(ifindex:2)(10.10.1.1)")
     public String getOspfLocalPort() {
         return ospfLocalPort;
     }
@@ -68,6 +72,7 @@ public class OspfLinkNodeDTO {
 
     @XmlElement(name="ospfLocalPortUrl")
     @JsonProperty("ospfLocalPortUrl")
+    @Schema(description = "Relative URL of the local SNMP interface page, or of the IP interface page when the link is addressed rather than address-less.", example = "element/snmpinterface.jsp?node=1&ifindex=2")
     public String getOspfLocalPortUrl() {
         return ospfLocalPortUrl;
     }
@@ -83,6 +88,7 @@ public class OspfLinkNodeDTO {
 
     @XmlElement(name="ospfRemRouterId")
     @JsonProperty("ospfRemRouterId")
+    @Schema(description = "Neighbour router as a display label: the node label followed by (router id:...) when the neighbour resolves to a node, otherwise the parenthesised router id alone.", example = "loopback-001(router id:10.255.0.2)")
     public String getOspfRemRouterId() {
         return ospfRemRouterId;
     }
@@ -98,6 +104,7 @@ public class OspfLinkNodeDTO {
 
     @XmlElement(name="ospfRemRouterUrl")
     @JsonProperty("ospfRemRouterUrl")
+    @Schema(description = "Relative URL of the neighbour's linked-node page. Omitted when the neighbour does not resolve to a node.", example = "element/linkednode.jsp?node=2")
     public String getOspfRemRouterUrl() {
         return ospfRemRouterUrl;
     }
@@ -113,6 +120,7 @@ public class OspfLinkNodeDTO {
 
     @XmlElement(name="ospfRemPort")
     @JsonProperty("ospfRemPort")
+    @Schema(description = "Neighbour interface as a display label. For an addressed neighbour this is just the parenthesised IP address.", example = "(10.10.1.2)")
     public String getOspfRemPort() {
         return ospfRemPort;
     }
@@ -128,6 +136,7 @@ public class OspfLinkNodeDTO {
 
     @XmlElement(name="ospfRemPortUrl")
     @JsonProperty("ospfRemPortUrl")
+    @Schema(description = "Relative URL of the neighbour's IP or SNMP interface page.", example = "element/interface.jsp?node=2&intf=10.10.1.2")
     public String getOspfRemPortUrl() {
         return ospfRemPortUrl;
     }
@@ -143,6 +152,7 @@ public class OspfLinkNodeDTO {
 
     @XmlElement(name="ospfLinkInfo")
     @JsonProperty("ospfLinkInfo")
+    @Schema(description = "Link mask as a display label, (mask:...) when known and (No mask) when not.", example = "(mask:255.255.255.252)")
     public String getOspfLinkInfo() {
         return ospfLinkInfo;
     }
@@ -158,6 +168,7 @@ public class OspfLinkNodeDTO {
 
     @XmlElement(name="ospfLinkCreateTime")
     @JsonProperty("ospfLinkCreateTime")
+    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/17/26, 5:20:39\u202fPM")
     public String getOspfLinkCreateTime() {
         return ospfLinkCreateTime;
     }
@@ -173,6 +184,7 @@ public class OspfLinkNodeDTO {
 
     @XmlElement(name="ospfLinkLastPollTime")
     @JsonProperty("ospfLinkLastPollTime")
+    @Schema(description = "Poll timestamp rendered as a locale-formatted display string, not epoch milliseconds. The separator before AM/PM is U+202F (narrow no-break space), not a plain space. Treat it as an opaque label.", example = "8/17/26, 5:20:39\u202fPM")
     public String getOspfLinkLastPollTime() {
         return ospfLinkLastPollTime;
     }

--- a/features/status/rest/pom.xml
+++ b/features/status/rest/pom.xml
@@ -17,6 +17,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>
+        <!-- Annotations only; swagger-annotations already ships in the webapp's WEB-INF/lib. -->
+        <dependency>
+          <groupId>io.swagger.core.v3</groupId>
+          <artifactId>swagger-annotations</artifactId>
+          <version>${swaggerVersion}</version>
+          <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.opennms.dependencies</groupId>
             <artifactId>spring-dependencies</artifactId>

--- a/features/status/rest/src/main/java/org/opennms/web/rest/v2/status/StatusRestService.java
+++ b/features/status/rest/src/main/java/org/opennms/web/rest/v2/status/StatusRestService.java
@@ -91,9 +91,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
         The list endpoints take `limit`, `offset`, `orderBy`, `order` and a repeatable `severityFilter`.
         `severityFilter` has to be spelled as a severity label (`Normal`, `Warning`, `Minor`, `Major`,
         `Critical`); any other value fails with a 500. On `/status/applications` and
-        `/status/business-services`, supplying `severityFilter` without `orderBy` also fails with a 500,
-        so send both. An empty page is reported as 204 rather than as an empty list, and a non-empty page
-        carries a `Content-Range: items <first>-<last>/<total>` header.""")
+        `/status/business-services`, supplying `severityFilter` without `orderBy` also fails with a 500.
+        An empty page is reported as 204 rather than as an empty list, and a non-empty page carries a
+        `Content-Range: items <first>-<last>/<total>` header.""")
 public class StatusRestService {
 
     @Autowired
@@ -202,7 +202,7 @@ public class StatusRestService {
             description = """
         Page through the applications, each carrying its rolled-up severity. `limit`, `offset`,
         `orderBy`, `order` and a repeatable `severityFilter` are read straight off the query string.
-        Supplying `severityFilter` without `orderBy` fails with a 500, so send both.""",
+        Supplying `severityFilter` without `orderBy` fails with a 500.""",
             operationId = "getApplicationStatusList"
     )
     @ApiResponses(value = {
@@ -263,7 +263,7 @@ public class StatusRestService {
             description = """
         Page through the business services, each carrying its rolled-up severity. `limit`, `offset`,
         `orderBy`, `order` and a repeatable `severityFilter` are read straight off the query string.
-        Supplying `severityFilter` without `orderBy` fails with a 500, so send both.""",
+        Supplying `severityFilter` without `orderBy` fails with a 500.""",
             operationId = "getBusinessServiceStatusList"
     )
     @ApiResponses(value = {
@@ -276,7 +276,7 @@ public class StatusRestService {
                       "totalCount": 1,
                       "count": 1,
                       "offset": 0,
-                      "business-services": [
+                      "businessservices": [
                         { "id": 23663, "name": "Storefront", "severity": "MINOR" }
                       ]
                     }""")),

--- a/features/status/rest/src/main/java/org/opennms/web/rest/v2/status/StatusRestService.java
+++ b/features/status/rest/src/main/java/org/opennms/web/rest/v2/status/StatusRestService.java
@@ -89,8 +89,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
         so they only work with `Accept: application/json`.
 
         The list endpoints take `limit`, `offset`, `orderBy`, `order` and a repeatable `severityFilter`.
-        `severityFilter` has to be spelled as a severity label (`Normal`, `Warning`, `Minor`, `Major`,
-        `Critical`); any other value fails with a 500. On `/status/applications` and
+        `severityFilter` has to be spelled as a severity label, matched case-insensitively; all seven
+        labels parse, `Indeterminate` and `Cleared` included. Any other value fails with a 500. On `/status/applications` and
         `/status/business-services`, supplying `severityFilter` without `orderBy` also fails with a 500.
         An empty page is reported as 204 rather than as an empty list, and a non-empty page carries a
         `Content-Range: items <first>-<last>/<total>` header.""")
@@ -232,7 +232,7 @@ public class StatusRestService {
                             examples = @ExampleObject(value = "Cannot invoke \"org.opennms.web.utils.QueryParameters$Order.getColumn()\" because the return value of \"org.opennms.web.utils.QueryParameters.getOrder()\" is null")))
     })
     public Response getApplications(
-            @Parameter(description = "Reads `limit`, `offset`, `orderBy`, `order` and a repeatable `severityFilter` (`Normal`, `Warning`, `Minor`, `Major`, `Critical`) from the query string.", hidden = true)
+            @Parameter(description = "Reads `limit`, `offset`, `orderBy`, `order` and a repeatable `severityFilter` (any severity label, `Indeterminate` through `Critical`) from the query string.", hidden = true)
             @Context final UriInfo uriInfo) {
         final QueryParameters queryParameters = QueryParametersBuilder.buildFrom(uriInfo);
         final SeverityFilter severityFilter = getSeverityFilter(uriInfo);
@@ -290,7 +290,7 @@ public class StatusRestService {
                             examples = @ExampleObject(value = "Cannot invoke \"org.opennms.netmgt.model.OnmsSeverity.getId()\" because \"s\" is null")))
     })
     public Response getBusinessServices(
-            @Parameter(description = "Reads `limit`, `offset`, `orderBy`, `order` and a repeatable `severityFilter` (`Normal`, `Warning`, `Minor`, `Major`, `Critical`) from the query string.", hidden = true)
+            @Parameter(description = "Reads `limit`, `offset`, `orderBy`, `order` and a repeatable `severityFilter` (any severity label, `Indeterminate` through `Critical`) from the query string.", hidden = true)
             @Context final UriInfo uriInfo) {
         final QueryParameters queryParameters = QueryParametersBuilder.buildFrom(uriInfo);
         final SeverityFilter severityFilter = getSeverityFilter(uriInfo);

--- a/features/status/rest/src/main/java/org/opennms/web/rest/v2/status/StatusRestService.java
+++ b/features/status/rest/src/main/java/org/opennms/web/rest/v2/status/StatusRestService.java
@@ -63,10 +63,37 @@ import org.springframework.stereotype.Component;
 
 import com.google.common.base.Strings;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 
 @Component("statusRestService")
 @Path("status")
 @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+@Tag(name = "Status", description = """
+        Status API.
+
+        Severity rollups for nodes, applications and business services. The `/summary/*` endpoints return
+        one count per severity; the list endpoints return a page of entities each carrying its own
+        severity.
+
+        `@Produces` lists XML before JSON, so a request whose `Accept` is `*/*` is answered as XML. The
+        three `/summary/*` endpoints return a raw `List<Object[]>` for which no XML writer is registered,
+        so they only work with `Accept: application/json`.
+
+        The list endpoints take `limit`, `offset`, `orderBy`, `order` and a repeatable `severityFilter`.
+        `severityFilter` has to be spelled as a severity label (`Normal`, `Warning`, `Minor`, `Major`,
+        `Critical`); any other value fails with a 500. On `/status/applications` and
+        `/status/business-services`, supplying `severityFilter` without `orderBy` also fails with a 500,
+        so send both. An empty page is reported as 204 rather than as an empty list, and a non-empty page
+        carries a `Content-Range: items <first>-<last>/<total>` header.""")
 public class StatusRestService {
 
     @Autowired
@@ -80,7 +107,34 @@ public class StatusRestService {
 
     @GET
     @Path("/summary/nodes/{type}")
-    public Response getNodeStatus(@PathParam("type") String type) {
+    @Operation(
+            summary = "Summarise node status by severity",
+            description = """
+        Return one count per severity across all nodes, using the named calculation strategy.
+        Requires `Accept: application/json`: the body is a raw list for which no XML writer exists, so
+        an XML or `*/*` request fails with a 500.
+        `None` is listed as a supported strategy by the 400 message but is not implemented for this
+        query and fails with a 500.""",
+            operationId = "getNodeStatusSummary"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Per-severity counts, ordered from least to most severe. Each element is a two-element array of severity label and count.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            array = @ArraySchema(schema = @Schema(type = "array")),
+                            examples = @ExampleObject(value = "[[\"Normal\",3676],[\"Warning\",0],[\"Minor\",1],[\"Major\",3],[\"Critical\",0]]"))),
+            @ApiResponse(responseCode = "400", description = "`type` did not name a calculation strategy.",
+                    content = @Content(schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Strategy 'bogus' not supported. Supported values are:[None, Alarms, Outages]"))),
+            @ApiResponse(responseCode = "500", description = "`type` was `None`, or the client asked for XML.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Query for CalculationStrategy is not implemented.")))
+    })
+    public Response getNodeStatus(
+            @Parameter(description = "Node status calculation strategy. `Alarms` rolls up unacknowledged alarms, `Outages` rolls up open outages. `None` is rejected at runtime.",
+                    example = "Alarms", required = true,
+                    schema = @Schema(allowableValues = {"None", "Alarms", "Outages"}))
+            @PathParam("type") String type) {
         final NodeStatusCalculationStrategy strategy = NodeStatusCalculationStrategy.createFrom(type);
         if (strategy == null) {
             return Response.status(Response.Status.BAD_REQUEST)
@@ -93,6 +147,24 @@ public class StatusRestService {
 
     @GET
     @Path("/summary/applications")
+    @Operation(
+            summary = "Summarise application status by severity",
+            description = """
+        Return one count per severity across all applications.
+        Requires `Accept: application/json`: the body is a raw list for which no XML writer exists, so
+        an XML or `*/*` request fails with a 500.""",
+            operationId = "getApplicationStatusSummary"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Per-severity counts, ordered from least to most severe. Each element is a two-element array of severity label and count.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            array = @ArraySchema(schema = @Schema(type = "array")),
+                            examples = @ExampleObject(value = "[[\"Normal\",4],[\"Warning\",0],[\"Minor\",0],[\"Major\",0],[\"Critical\",0]]"))),
+            @ApiResponse(responseCode = "500", description = "The client asked for XML.",
+                    content = @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "No message body writer has been found for class java.util.ArrayList, ContentType: application/xml")))
+    })
     public List<Object[]> getApplicationStatus() {
         StatusSummary summary = applicationStatusService.getSummary();
         return convert(summary);
@@ -100,6 +172,24 @@ public class StatusRestService {
 
     @GET
     @Path("/summary/business-services")
+    @Operation(
+            summary = "Summarise business service status by severity",
+            description = """
+        Return one count per severity across all business services.
+        Requires `Accept: application/json`: the body is a raw list for which no XML writer exists, so
+        an XML or `*/*` request fails with a 500.""",
+            operationId = "getBusinessServiceStatusSummary"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Per-severity counts, ordered from least to most severe. Each element is a two-element array of severity label and count.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            array = @ArraySchema(schema = @Schema(type = "array")),
+                            examples = @ExampleObject(value = "[[\"Normal\",0],[\"Warning\",0],[\"Minor\",0],[\"Major\",0],[\"Critical\",0]]"))),
+            @ApiResponse(responseCode = "500", description = "The client asked for XML.",
+                    content = @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "No message body writer has been found for class java.util.ArrayList, ContentType: application/xml")))
+    })
     public List<Object[]> getBusinessServiceStatus() {
         StatusSummary summary = businessServiceStatusService.getSummary();
         return convert(summary);
@@ -107,7 +197,43 @@ public class StatusRestService {
 
     @GET
     @Path("/applications")
-    public Response getApplications(@Context final UriInfo uriInfo) {
+    @Operation(
+            summary = "List applications with their status",
+            description = """
+        Page through the applications, each carrying its rolled-up severity. `limit`, `offset`,
+        `orderBy`, `order` and a repeatable `severityFilter` are read straight off the query string.
+        Supplying `severityFilter` without `orderBy` fails with a 500, so send both.""",
+            operationId = "getApplicationStatusList"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "One page of applications. `Content-Range` carries the offsets and the total.",
+                    content = {
+                        @Content(mediaType = MediaType.APPLICATION_JSON,
+                                schema = @Schema(implementation = ApplicationDTOList.class),
+                                examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 4,
+                      "count": 2,
+                      "offset": 0,
+                      "applications": [
+                        { "id": 1, "name": "Review Billing", "severity": "NORMAL" },
+                        { "id": 2, "name": "Review Storefront", "severity": "NORMAL" }
+                      ]
+                    }""")),
+                        @Content(mediaType = MediaType.APPLICATION_XML,
+                                schema = @Schema(implementation = ApplicationDTOList.class),
+                                examples = @ExampleObject(value = """
+                    <applications count="2" offset="0" totalCount="4"><application><id>1</id><name>Review Billing</name><severity>NORMAL</severity></application><application><id>2</id><name>Review Storefront</name><severity>NORMAL</severity></application></applications>"""))
+                    }),
+            @ApiResponse(responseCode = "204", description = "No application matched."),
+            @ApiResponse(responseCode = "500", description = "An unrecognised `severityFilter`, or a `severityFilter` sent without `orderBy`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot invoke \"org.opennms.web.utils.QueryParameters$Order.getColumn()\" because the return value of \"org.opennms.web.utils.QueryParameters.getOrder()\" is null")))
+    })
+    public Response getApplications(
+            @Parameter(description = "Reads `limit`, `offset`, `orderBy`, `order` and a repeatable `severityFilter` (`Normal`, `Warning`, `Minor`, `Major`, `Critical`) from the query string.", hidden = true)
+            @Context final UriInfo uriInfo) {
         final QueryParameters queryParameters = QueryParametersBuilder.buildFrom(uriInfo);
         final SeverityFilter severityFilter = getSeverityFilter(uriInfo);
         final Query query = new Query(queryParameters, severityFilter);
@@ -132,7 +258,40 @@ public class StatusRestService {
 
     @GET
     @Path("/business-services")
-    public Response getBusinessServices(@Context final UriInfo uriInfo) {
+    @Operation(
+            summary = "List business services with their status",
+            description = """
+        Page through the business services, each carrying its rolled-up severity. `limit`, `offset`,
+        `orderBy`, `order` and a repeatable `severityFilter` are read straight off the query string.
+        Supplying `severityFilter` without `orderBy` fails with a 500, so send both.""",
+            operationId = "getBusinessServiceStatusList"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "One page of business services. `Content-Range` carries the offsets and the total.",
+                    content = {
+                        @Content(mediaType = MediaType.APPLICATION_JSON,
+                                schema = @Schema(implementation = BusinessServiceDTOList.class),
+                                examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 1,
+                      "count": 1,
+                      "offset": 0,
+                      "business-services": [
+                        { "id": 23663, "name": "Storefront", "severity": "MINOR" }
+                      ]
+                    }""")),
+                        @Content(mediaType = MediaType.APPLICATION_XML,
+                                schema = @Schema(implementation = BusinessServiceDTOList.class))
+                    }),
+            @ApiResponse(responseCode = "204", description = "No business service matched, including when none is defined."),
+            @ApiResponse(responseCode = "500", description = "An unrecognised `severityFilter`, or a `severityFilter` sent without `orderBy`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot invoke \"org.opennms.netmgt.model.OnmsSeverity.getId()\" because \"s\" is null")))
+    })
+    public Response getBusinessServices(
+            @Parameter(description = "Reads `limit`, `offset`, `orderBy`, `order` and a repeatable `severityFilter` (`Normal`, `Warning`, `Minor`, `Major`, `Critical`) from the query string.", hidden = true)
+            @Context final UriInfo uriInfo) {
         final QueryParameters queryParameters = QueryParametersBuilder.buildFrom(uriInfo);
         final SeverityFilter severityFilter = getSeverityFilter(uriInfo);
         final Query query = new Query(queryParameters, severityFilter);
@@ -157,7 +316,53 @@ public class StatusRestService {
 
     @GET
     @Path("/nodes/{type}")
-    public Response getNodes(@Context final UriInfo uriInfo, @PathParam("type") String type) {
+    @Operation(
+            summary = "List nodes with their status",
+            description = """
+        Page through the nodes, each carrying the severity the named strategy computed. `limit`,
+        `offset`, `orderBy`, `order` and a repeatable `severityFilter` are read straight off the query
+        string.
+
+        `orderBy` has to name a database column, so `nodeid` and `nodelabel` work. `label` is rewritten
+        to `node.nodelabel` and then rejected with a 500, as is any other unrecognised value.""",
+            operationId = "getNodeStatusList"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "One page of nodes. `Content-Range` carries the offsets and the total.",
+                    content = {
+                        @Content(mediaType = MediaType.APPLICATION_JSON,
+                                schema = @Schema(implementation = NodeDTOList.class),
+                                examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 3680,
+                      "count": 2,
+                      "offset": 0,
+                      "nodes": [
+                        { "id": 1, "name": "loopback-004", "severity": "NORMAL" },
+                        { "id": 2, "name": "loopback-001", "severity": "MINOR" }
+                      ]
+                    }""")),
+                        @Content(mediaType = MediaType.APPLICATION_XML,
+                                schema = @Schema(implementation = NodeDTOList.class),
+                                examples = @ExampleObject(value = """
+                    <nodes count="2" offset="0" totalCount="3680"><node><id>1</id><name>loopback-004</name><severity>NORMAL</severity></node><node><id>2</id><name>loopback-001</name><severity>MINOR</severity></node></nodes>"""))
+                    }),
+            @ApiResponse(responseCode = "204", description = "No node matched."),
+            @ApiResponse(responseCode = "400", description = "`type` did not name a calculation strategy.",
+                    content = @Content(schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Strategy 'bogus' not supported. Supported values are:[None, Alarms, Outages]"))),
+            @ApiResponse(responseCode = "500", description = "An `orderBy` the DAO does not accept, or an unrecognised `severityFilter`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Invalid order column: node.nodelabel")))
+    })
+    public Response getNodes(
+            @Parameter(description = "Reads `limit`, `offset`, `orderBy` (a database column such as `nodeid` or `nodelabel`), `order` and a repeatable `severityFilter` (`Normal`, `Warning`, `Minor`, `Major`, `Critical`) from the query string.", hidden = true)
+            @Context final UriInfo uriInfo,
+            @Parameter(description = "Node status calculation strategy. `Alarms` rolls up unacknowledged alarms, `Outages` rolls up open outages.",
+                    example = "Alarms", required = true,
+                    schema = @Schema(allowableValues = {"None", "Alarms", "Outages"}))
+            @PathParam("type") String type) {
         final NodeStatusCalculationStrategy strategy = NodeStatusCalculationStrategy.createFrom(type);
         if (strategy == null) {
             return Response.status(Response.Status.BAD_REQUEST)

--- a/features/status/rest/src/main/java/org/opennms/web/rest/v2/status/model/ApplicationDTOList.java
+++ b/features/status/rest/src/main/java/org/opennms/web/rest/v2/status/model/ApplicationDTOList.java
@@ -29,10 +29,12 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.map.annotate.JsonRootName;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.opennms.core.config.api.JaxbListWrapper;
 
 @XmlRootElement(name="applications")
 @JsonRootName("applications")
+@Schema(description = "One page of applications with their rolled-up severity. `count` is the page size, `totalCount` the number of matches.")
 public class ApplicationDTOList extends JaxbListWrapper<ApplicationDTO> {
 
     private static final long serialVersionUID = 1L;

--- a/features/status/rest/src/main/java/org/opennms/web/rest/v2/status/model/BusinessServiceDTOList.java
+++ b/features/status/rest/src/main/java/org/opennms/web/rest/v2/status/model/BusinessServiceDTOList.java
@@ -29,10 +29,12 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.map.annotate.JsonRootName;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.opennms.core.config.api.JaxbListWrapper;
 
 @XmlRootElement(name="businessservices")
 @JsonRootName("businessservices")
+@Schema(description = "One page of business services with their rolled-up severity. `count` is the page size, `totalCount` the number of matches.")
 public class BusinessServiceDTOList extends JaxbListWrapper<BusinessServiceDTO> {
 
     private static final long serialVersionUID = 1L;

--- a/features/status/rest/src/main/java/org/opennms/web/rest/v2/status/model/NodeDTOList.java
+++ b/features/status/rest/src/main/java/org/opennms/web/rest/v2/status/model/NodeDTOList.java
@@ -29,10 +29,12 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.map.annotate.JsonRootName;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.opennms.core.config.api.JaxbListWrapper;
 
 @XmlRootElement(name="nodes")
 @JsonRootName("nodes")
+@Schema(description = "One page of nodes with their rolled-up severity. `count` is the page size, `totalCount` the number of matches.")
 public class NodeDTOList extends JaxbListWrapper<NodeDTO> {
 
     private static final long serialVersionUID = 1L;

--- a/features/status/rest/src/main/java/org/opennms/web/rest/v2/status/model/StatusDTO.java
+++ b/features/status/rest/src/main/java/org/opennms/web/rest/v2/status/model/StatusDTO.java
@@ -21,13 +21,22 @@
  */
 package org.opennms.web.rest.v2.status.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.opennms.features.status.api.SeveritySupplier;
 import org.opennms.netmgt.model.OnmsSeverity;
 
+@Schema(description = "One entity and the severity rolled up onto it.")
 public class StatusDTO implements SeveritySupplier {
 
+    @Schema(description = "Database id of the entity.", example = "1")
     private Integer id;
+
+    @Schema(description = "Node label, application name or business service name.", example = "loopback-001")
     private String name;
+
+    @Schema(description = "Rolled-up severity, serialized as the enum constant name rather than the label.",
+            example = "MINOR",
+            allowableValues = {"INDETERMINATE", "CLEARED", "NORMAL", "WARNING", "MINOR", "MAJOR", "CRITICAL"})
     private OnmsSeverity severity;
 
     @Override

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AcknowledgmentRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AcknowledgmentRestService.java
@@ -116,7 +116,7 @@ public class AcknowledgmentRestService extends OnmsRestService {
                       "refId": 4547
                     }"""))),
             @ApiResponse(responseCode = "404", description = "No acknowledgement with that id, or the path segment is not an integer.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Acknowledgement object 99999999 was not found."))),
             @ApiResponse(responseCode = "403", description = "The caller holds none of `ROLE_ADMIN`, `ROLE_REST`, `ROLE_USER` or `ROLE_MOBILE`. The container rejects the request before the resource is reached, so the body is its HTML error page rather than a REST payload.",
@@ -213,7 +213,7 @@ public class AcknowledgmentRestService extends OnmsRestService {
                       ]
                     }"""))),
             @ApiResponse(responseCode = "500", description = "A query parameter is not a property of the acknowledgement entity.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Unknown entity: null; nested exception is org.hibernate.HibernateException: Unknown entity: null"))),
             @ApiResponse(responseCode = "403", description = "The caller holds none of `ROLE_ADMIN`, `ROLE_REST`, `ROLE_USER` or `ROLE_MOBILE`. The container rejects the request before the resource is reached, so the body is its HTML error page rather than a REST payload.",
@@ -276,7 +276,7 @@ public class AcknowledgmentRestService extends OnmsRestService {
                     }"""))),
             @ApiResponse(responseCode = "304", description = "The id parsed but no alarm or notification has it."),
             @ApiResponse(responseCode = "400", description = "Neither or both ids were supplied, an id was not an integer, or `action` was not one of the four verbs.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "You must supply either an alarmId or notifId"))),
             @ApiResponse(responseCode = "403", description = "The caller holds `ROLE_READONLY`, or named somebody other than themselves in `ackUser` without holding `ROLE_ADMIN` or `ROLE_DELEGATE`.",

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AcknowledgmentRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AcknowledgmentRestService.java
@@ -35,6 +35,15 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.netmgt.dao.api.AcknowledgmentDao;
 import org.opennms.netmgt.dao.api.AlarmDao;
@@ -45,6 +54,7 @@ import org.opennms.netmgt.model.OnmsAcknowledgmentCollection;
 import org.opennms.netmgt.model.OnmsAlarm;
 import org.opennms.netmgt.model.OnmsNotification;
 import org.opennms.web.rest.support.SecurityHelper;
+import org.opennms.web.rest.v1.model.AcknowledgmentForm;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,6 +68,12 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component("acknowledgmentRestService")
 @Path("acks")
+@Tag(name = "Acknowledgments", description = """
+        Acknowledgments API.
+
+        An acknowledgement is an immutable audit row: acknowledging, unacknowledging, clearing or escalating an
+        alarm or a notification each append a new row rather than changing an existing one. The current state of
+        the alarm or notification is derived from the newest row that refers to it.""")
 public class AcknowledgmentRestService extends OnmsRestService {
     @Autowired
     private AcknowledgmentDao m_ackDao;
@@ -78,7 +94,37 @@ public class AcknowledgmentRestService extends OnmsRestService {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Path("{id}")
     @Transactional
-    public OnmsAcknowledgment getAcknowledgment(@PathParam("id") Integer acknowledgmentId) {
+    @Operation(
+            summary = "Get an acknowledgement",
+            description = """
+                    Return one acknowledgement row by id. `refId` is the id of the alarm or notification the row
+                    refers to, and `ackType` says which of the two.
+                    `ackTime` is epoch milliseconds in JSON and an ISO-8601 string in XML. The XML root element is
+                    `ack`, while the list endpoint wraps its entries in `onmsAcknowledgment`.""",
+            operationId = "getAcknowledgmentV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The acknowledgement.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsAcknowledgment.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "id": 23632,
+                      "log": null,
+                      "ackType": "ALARM",
+                      "ackAction": "ACKNOWLEDGE",
+                      "ackTime": 1787727613204,
+                      "ackUser": "admin",
+                      "refId": 4547
+                    }"""))),
+            @ApiResponse(responseCode = "404", description = "No acknowledgement with that id, or the path segment is not an integer.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Acknowledgement object 99999999 was not found.")))
+    })
+    public OnmsAcknowledgment getAcknowledgment(
+            @Parameter(description = "Acknowledgement id.", example = "23632", required = true)
+            @PathParam("id") Integer acknowledgmentId) {
         final OnmsAcknowledgment ack = m_ackDao.get(acknowledgmentId);
         if (ack == null) {
             throw getException(Status.NOT_FOUND, "Acknowledgement object {} was not found.", Integer.toString(acknowledgmentId));
@@ -95,6 +141,18 @@ public class AcknowledgmentRestService extends OnmsRestService {
     @Produces(MediaType.TEXT_PLAIN)
     @Path("count")
     @Transactional
+    @Operation(
+            summary = "Count all acknowledgements",
+            description = "Return the total number of acknowledgement rows as a plain-text integer. Query "
+                    + "parameters are ignored, so this is not a count of a filtered set.",
+            operationId = "getAcknowledgmentCountV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The acknowledgement count.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "7")))
+    })
     public String getCount() {
         return Integer.toString(m_ackDao.countAll());
     }
@@ -107,6 +165,52 @@ public class AcknowledgmentRestService extends OnmsRestService {
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
+    @Operation(
+            summary = "Search acknowledgements",
+            description = """
+                    Return acknowledgement rows matching the query parameters, newest `ackTime` first unless
+                    `orderBy` says otherwise.
+                    Filters are `OnmsAcknowledgment` property names such as `ackType`, `ackAction`, `ackUser` and
+                    `refId`. `limit` (default 10), `offset`, `orderBy`, `order`, `match` and `comparator` shape the
+                    result. A filter name that is not a property of the entity fails with 500.
+                    `totalCount` is the unpaged match count; `count` is the size of this page.""",
+            operationId = "getAcknowledgmentsV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The matching acknowledgements.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsAcknowledgmentCollection.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 7,
+                      "count": 2,
+                      "offset": 0,
+                      "onmsAcknowledgment": [
+                        {
+                          "id": 23631,
+                          "log": null,
+                          "ackType": "ALARM",
+                          "ackAction": "CLEAR",
+                          "ackTime": 1787727588461,
+                          "ackUser": "admin",
+                          "refId": 4547
+                        },
+                        {
+                          "id": 23630,
+                          "log": null,
+                          "ackType": "ALARM",
+                          "ackAction": "ESCALATE",
+                          "ackTime": 1787727588337,
+                          "ackUser": "admin",
+                          "refId": 4547
+                        }
+                      ]
+                    }"""))),
+            @ApiResponse(responseCode = "500", description = "A query parameter is not a property of the acknowledgement entity.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Unknown entity: null; nested exception is org.hibernate.HibernateException: Unknown entity: null")))
+    })
     public OnmsAcknowledgmentCollection getAcks(@Context final UriInfo uriInfo) {
         final CriteriaBuilder builder = getQueryFilters(uriInfo.getQueryParameters());
         OnmsAcknowledgmentCollection coll = new OnmsAcknowledgmentCollection(m_ackDao.findMatching(builder.toCriteria()));
@@ -130,6 +234,47 @@ public class AcknowledgmentRestService extends OnmsRestService {
     @POST
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Transactional
+    @Operation(
+            summary = "Acknowledge an alarm or a notification",
+            description = """
+                    Append an acknowledgement row for one alarm or one notification. The body is form-encoded;
+                    JSON is rejected with 415.
+                    Exactly one of `alarmId` and `notifId` has to be present. `action` defaults to `ack`. `ackUser`
+                    defaults to the authenticated user, and a non-admin caller may only name themselves.
+                    An id that parses as an integer but matches no row yields 304 rather than 404.
+                    The method declares no `@Produces`, so the entity is serialized according to the request's
+                    `Accept` header, XML by default. The XML root element is `ack`.""",
+            operationId = "createAcknowledgmentV1"
+    )
+    @RequestBody(required = true, description = "The alarm or notification to act on, and the action to record.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(implementation = AcknowledgmentForm.class),
+                    examples = @ExampleObject(value = "alarmId=4547&action=ack")))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The acknowledgement row that was written.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsAcknowledgment.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "id": 23632,
+                      "log": null,
+                      "ackType": "ALARM",
+                      "ackAction": "ACKNOWLEDGE",
+                      "ackTime": 1787727613204,
+                      "ackUser": "admin",
+                      "refId": 4547
+                    }"""))),
+            @ApiResponse(responseCode = "304", description = "The id parsed but no alarm or notification has it."),
+            @ApiResponse(responseCode = "400", description = "Neither or both ids were supplied, an id was not an integer, or `action` was not one of the four verbs.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "You must supply either an alarmId or notifId"))),
+            @ApiResponse(responseCode = "403", description = "The caller holds `ROLE_READONLY`, or named somebody other than themselves in `ackUser` without holding `ROLE_ADMIN` or `ROLE_DELEGATE`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User 'jroe', is not allowed to perform updates to alarms as user 'admin'"))),
+            @ApiResponse(responseCode = "415", description = "The body was not `application/x-www-form-urlencoded`.")
+    })
     public Response acknowledge(@Context final SecurityContext securityContext, MultivaluedMap<String, String> formParams) {
         String alarmId = formParams.getFirst("alarmId");
         String notifId = formParams.getFirst("notifId");

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AcknowledgmentRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AcknowledgmentRestService.java
@@ -69,11 +69,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Component("acknowledgmentRestService")
 @Path("acks")
 @Tag(name = "Acknowledgments", description = """
-        Acknowledgments API.
-
-        An acknowledgement is an immutable audit row: acknowledging, unacknowledging, clearing or escalating an
-        alarm or a notification each append a new row rather than changing an existing one. The current state of
-        the alarm or notification is derived from the newest row that refers to it.""")
+        Acknowledging, unacknowledging, clearing or escalating an alarm or a notification appends a new row rather
+        than changing an existing one. The state of the alarm or notification comes from the newest row that
+        refers to it.""")
 public class AcknowledgmentRestService extends OnmsRestService {
     @Autowired
     private AcknowledgmentDao m_ackDao;
@@ -120,7 +118,11 @@ public class AcknowledgmentRestService extends OnmsRestService {
             @ApiResponse(responseCode = "404", description = "No acknowledgement with that id, or the path segment is not an integer.",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON,
                             schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "Acknowledgement object 99999999 was not found.")))
+                            examples = @ExampleObject(value = "Acknowledgement object 99999999 was not found."))),
+            @ApiResponse(responseCode = "403", description = "The caller holds none of `ROLE_ADMIN`, `ROLE_REST`, `ROLE_USER` or `ROLE_MOBILE`. The container rejects the request before the resource is reached, so the body is its HTML error page rather than a REST payload.",
+                    content = @Content(mediaType = MediaType.TEXT_HTML,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "<html>\n<head>\n<title>Error 403 Forbidden</title>\n</head>\n<body><h2>HTTP ERROR 403 Forbidden</h2>\n</body>\n</html>")))
     })
     public OnmsAcknowledgment getAcknowledgment(
             @Parameter(description = "Acknowledgement id.", example = "23632", required = true)
@@ -144,14 +146,18 @@ public class AcknowledgmentRestService extends OnmsRestService {
     @Operation(
             summary = "Count all acknowledgements",
             description = "Return the total number of acknowledgement rows as a plain-text integer. Query "
-                    + "parameters are ignored, so this is not a count of a filtered set.",
+                    + "parameters are ignored.",
             operationId = "getAcknowledgmentCountV1"
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "The acknowledgement count.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "7")))
+                            examples = @ExampleObject(value = "7"))),
+            @ApiResponse(responseCode = "403", description = "The caller holds none of `ROLE_ADMIN`, `ROLE_REST`, `ROLE_USER` or `ROLE_MOBILE`. The container rejects the request before the resource is reached, so the body is its HTML error page rather than a REST payload.",
+                    content = @Content(mediaType = MediaType.TEXT_HTML,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "<html>\n<head>\n<title>Error 403 Forbidden</title>\n</head>\n<body><h2>HTTP ERROR 403 Forbidden</h2>\n</body>\n</html>")))
     })
     public String getCount() {
         return Integer.toString(m_ackDao.countAll());
@@ -209,7 +215,11 @@ public class AcknowledgmentRestService extends OnmsRestService {
             @ApiResponse(responseCode = "500", description = "A query parameter is not a property of the acknowledgement entity.",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON,
                             schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "Unknown entity: null; nested exception is org.hibernate.HibernateException: Unknown entity: null")))
+                            examples = @ExampleObject(value = "Unknown entity: null; nested exception is org.hibernate.HibernateException: Unknown entity: null"))),
+            @ApiResponse(responseCode = "403", description = "The caller holds none of `ROLE_ADMIN`, `ROLE_REST`, `ROLE_USER` or `ROLE_MOBILE`. The container rejects the request before the resource is reached, so the body is its HTML error page rather than a REST payload.",
+                    content = @Content(mediaType = MediaType.TEXT_HTML,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "<html>\n<head>\n<title>Error 403 Forbidden</title>\n</head>\n<body><h2>HTTP ERROR 403 Forbidden</h2>\n</body>\n</html>")))
     })
     public OnmsAcknowledgmentCollection getAcks(@Context final UriInfo uriInfo) {
         final CriteriaBuilder builder = getQueryFilters(uriInfo.getQueryParameters());

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AlarmRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AlarmRestService.java
@@ -36,6 +36,14 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.EnumUtils;
@@ -51,6 +59,7 @@ import org.opennms.netmgt.model.alarm.AlarmSummary;
 import org.opennms.netmgt.model.alarm.AlarmSummaryCollection;
 import org.opennms.web.rest.support.MultivaluedMapImpl;
 import org.opennms.web.rest.support.SecurityHelper;
+import org.opennms.web.rest.v1.model.AlarmAckForm;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -79,7 +88,68 @@ public class AlarmRestService extends AlarmRestServiceBase {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Path("{alarmId}")
     @Transactional
-    public Response getAlarm(@Context SecurityContext securityContext, @PathParam("alarmId") final String alarmId) {
+    @Operation(
+            summary = "Get an alarm",
+            description = """
+                    Return one alarm by id.
+                    The literal path segment `summaries` is handled by this same method and returns per-node alarm
+                    summaries instead of a single alarm, so `GET /alarms/summaries` is a second, differently shaped
+                    response from this operation.
+                    Timestamps are epoch milliseconds in JSON and ISO-8601 strings in XML, whatever the schema
+                    says.""",
+            operationId = "getAlarmV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The alarm, or the node alarm summaries for the `summaries` path segment.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsAlarm.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "id": 4547,
+                      "uei": "uei.opennms.org/apidoc/validationAlarm",
+                      "description": "Probe alarm",
+                      "logMessage": "Probe alarm",
+                      "reductionKey": "uei.opennms.org/apidoc/validationAlarm::probe",
+                      "severity": "MINOR",
+                      "type": 3,
+                      "count": 1,
+                      "ackId": 4547,
+                      "ackUser": "admin",
+                      "ackTime": 1787727572573,
+                      "firstEventTime": 1787727549288,
+                      "lastEventTime": 1787727549288,
+                      "suppressedTime": 1787727549288,
+                      "suppressedUntil": 1787727549288,
+                      "troubleTicket": "TT-4711",
+                      "troubleTicketState": "OPEN",
+                      "x733ProbableCause": 0,
+                      "parameters": [],
+                      "lastEvent": {
+                        "id": 55315,
+                        "uei": "uei.opennms.org/apidoc/validationAlarm",
+                        "time": 1787727549288,
+                        "createTime": 1787727549292,
+                        "source": "ReST",
+                        "severity": "MINOR",
+                        "log": "Y",
+                        "display": "Y",
+                        "parameters": []
+                      }
+                    }"""))),
+            @ApiResponse(responseCode = "404", description = "No alarm with that id."),
+            @ApiResponse(responseCode = "403", description = "The caller holds none of `ROLE_ADMIN`, `ROLE_REST`, `ROLE_USER` or `ROLE_MOBILE`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User 'jroe', is not allowed to read alarms."))),
+            @ApiResponse(responseCode = "500", description = "The path segment is neither `summaries` nor an integer.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"abc\"")))
+    })
+    public Response getAlarm(@Context SecurityContext securityContext,
+            @Parameter(description = "Alarm id, or the literal `summaries` for per-node alarm summaries.",
+                    example = "4547", required = true)
+            @PathParam("alarmId") final String alarmId) {
         SecurityHelper.assertUserReadCredentials(securityContext);
         if ("summaries".equals(alarmId)) {
             final List<AlarmSummary> collection = m_alarmDao.getNodeAlarmSummaries();
@@ -101,6 +171,22 @@ public class AlarmRestService extends AlarmRestServiceBase {
     @Produces(MediaType.TEXT_PLAIN)
     @Path("count")
     @Transactional
+    @Operation(
+            summary = "Count all alarms",
+            description = "Return the total number of alarm rows as a plain-text integer. Query parameters are "
+                    + "ignored, so this is not a count of a filtered set.",
+            operationId = "getAlarmCountV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The alarm count.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "13"))),
+            @ApiResponse(responseCode = "403", description = "The caller holds none of `ROLE_ADMIN`, `ROLE_REST`, `ROLE_USER` or `ROLE_MOBILE`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User 'jroe', is not allowed to read alarms.")))
+    })
     public String getCount(@Context SecurityContext securityContext) {
         SecurityHelper.assertUserReadCredentials(securityContext);
         return Integer.toString(m_alarmDao.countAll());
@@ -116,6 +202,69 @@ public class AlarmRestService extends AlarmRestServiceBase {
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
+    @Operation(
+            summary = "Search alarms",
+            description = """
+                    Return alarms matching the query parameters, newest `lastEventTime` first unless `orderBy`
+                    says otherwise.
+                    Filters are `OnmsAlarm` property names, with `nodeId`, `nodeLabel` and `alarmId` accepted as
+                    aliases for `node.id`, `node.label` and `id`. `limit` (default 10), `offset`, `orderBy`,
+                    `order`, `match` and `comparator` shape the result. A filter name that is not a property of
+                    the entity fails with 500.
+                    `totalCount` is the unpaged match count; `count` is the size of this page.""",
+            operationId = "getAlarmsV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The matching alarms.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsAlarmCollection.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 1,
+                      "count": 1,
+                      "offset": 0,
+                      "alarm": [ {
+                          "id": 4547,
+                          "uei": "uei.opennms.org/apidoc/validationAlarm",
+                          "description": "Probe alarm",
+                          "logMessage": "Probe alarm",
+                          "reductionKey": "uei.opennms.org/apidoc/validationAlarm::probe",
+                          "severity": "MINOR",
+                          "type": 3,
+                          "count": 1,
+                          "ackId": 4547,
+                          "ackUser": "admin",
+                          "ackTime": 1787727572573,
+                          "firstEventTime": 1787727549288,
+                          "lastEventTime": 1787727549288,
+                          "suppressedTime": 1787727549288,
+                          "suppressedUntil": 1787727549288,
+                          "troubleTicket": "TT-4711",
+                          "troubleTicketState": "OPEN",
+                          "x733ProbableCause": 0,
+                          "parameters": [],
+                          "lastEvent": {
+                            "id": 55315,
+                            "uei": "uei.opennms.org/apidoc/validationAlarm",
+                            "time": 1787727549288,
+                            "createTime": 1787727549292,
+                            "source": "ReST",
+                            "severity": "MINOR",
+                            "log": "Y",
+                            "display": "Y",
+                            "parameters": []
+                          }
+                        } ]
+                    }"""))),
+            @ApiResponse(responseCode = "500", description = "A query parameter is not a property of the alarm entity.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Unknown entity: null; nested exception is org.hibernate.HibernateException: Unknown entity: null"))),
+            @ApiResponse(responseCode = "403", description = "The caller holds none of `ROLE_ADMIN`, `ROLE_REST`, `ROLE_USER` or `ROLE_MOBILE`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User 'jroe', is not allowed to read alarms.")))
+    })
     public OnmsAlarmCollection getAlarms(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo) {
         SecurityHelper.assertUserReadCredentials(securityContext);
         final CriteriaBuilder builder = getCriteriaBuilder(uriInfo.getQueryParameters(), false);
@@ -142,7 +291,37 @@ public class AlarmRestService extends AlarmRestServiceBase {
     @Path("{alarmId}")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Transactional
-    public Response updateAlarm(@Context final SecurityContext securityContext, @PathParam("alarmId") final Integer alarmId, final MultivaluedMapImpl formProperties) {
+    @Operation(
+            summary = "Acknowledge, clear, escalate or ticket one alarm",
+            description = """
+                    Apply an acknowledgement action and optional trouble-ticket fields to one alarm. The body is
+                    form-encoded; JSON is rejected with 415.
+                    `ack`, `escalate` and `clear` are checked in that order and only the first one present is
+                    acted on. `ticketId` and `ticketState` are applied independently of the acknowledgement, and a
+                    `ticketState` outside the enumeration is ignored rather than reported.
+                    A body with none of those fields still returns 204 without changing the alarm.""",
+            operationId = "updateAlarmV1"
+    )
+    @RequestBody(required = true, description = "The action to apply.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(implementation = AlarmAckForm.class),
+                    examples = @ExampleObject(value = "ack=true")))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The request was processed."),
+            @ApiResponse(responseCode = "400", description = "No alarm with that id.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Unable to locate alarm with ID '99999999'"))),
+            @ApiResponse(responseCode = "403", description = "The caller holds `ROLE_READONLY`, or named somebody other than themselves in `ackUser` without holding `ROLE_ADMIN` or `ROLE_DELEGATE`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User 'jroe', is not allowed to perform updates to alarms as user 'admin'"))),
+            @ApiResponse(responseCode = "404", description = "The path segment is not an integer."),
+            @ApiResponse(responseCode = "415", description = "The body was not `application/x-www-form-urlencoded`.")
+    })
+    public Response updateAlarm(@Context final SecurityContext securityContext,
+            @Parameter(description = "Alarm id.", example = "4547", required = true)
+            @PathParam("alarmId") final Integer alarmId, final MultivaluedMapImpl formProperties) {
         writeLock();
 
         try {
@@ -231,6 +410,41 @@ public class AlarmRestService extends AlarmRestServiceBase {
     @PUT
     @Transactional
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Operation(
+            summary = "Acknowledge, clear or escalate matching alarms",
+            description = """
+                    Apply one acknowledgement action to every alarm matching the filters in the form body. Fields
+                    other than `ack`, `escalate`, `clear` and `ackUser` are read as alarm filters, so a body of
+                    just `ack=true` matches everything the filter defaults allow and acknowledges it. Scope the
+                    request with `id`, `severity` or another `OnmsAlarm` property.
+                    `alarmId` is accepted as an alias for `id`, but sending both is a 400. `ticketId` and
+                    `ticketState` are not honoured here.
+                    The limit and offset that the filter parsing derives are reset to unlimited, so the action
+                    reaches the whole match set rather than one page of it. The paging equivalents on
+                    `GET /alarms` therefore do not restrict what this operation touches.""",
+            operationId = "updateAlarmsV1"
+    )
+    @RequestBody(required = true, description = "The action to apply, plus the filters selecting the alarms.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(implementation = AlarmAckForm.class),
+                    examples = @ExampleObject(value = "ack=true&id=4547")))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "At least one alarm matched and was processed."),
+            @ApiResponse(responseCode = "304", description = "No alarm matched the filters."),
+            @ApiResponse(responseCode = "400", description = "None of `ack`, `escalate` or `clear` was supplied, or both `id` and `alarmId` were.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Must supply one of the 'ack', 'escalate', or 'clear' parameters, set to either 'true' or 'false'."))),
+            @ApiResponse(responseCode = "403", description = "The caller holds `ROLE_READONLY`, or named somebody other than themselves in `ackUser` without holding `ROLE_ADMIN` or `ROLE_DELEGATE`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User 'jroe', is not allowed to perform updates to alarms as user 'admin'"))),
+            @ApiResponse(responseCode = "415", description = "The body was not `application/x-www-form-urlencoded`."),
+            @ApiResponse(responseCode = "500", description = "A form parameter is not a property of the alarm entity.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Unknown entity: null; nested exception is org.hibernate.HibernateException: Unknown entity: null")))
+    })
     public Response updateAlarms(@Context final SecurityContext securityContext, final MultivaluedMapImpl formProperties) {
         writeLock();
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AlarmRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AlarmRestService.java
@@ -141,7 +141,7 @@ public class AlarmRestService extends AlarmRestServiceBase {
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "User 'jroe', is not allowed to read alarms."))),
             @ApiResponse(responseCode = "500", description = "The path segment is neither `summaries` nor an integer.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "For input string: \"abc\"")))
     })
@@ -256,7 +256,7 @@ public class AlarmRestService extends AlarmRestServiceBase {
                         } ]
                     }"""))),
             @ApiResponse(responseCode = "500", description = "A query parameter is not a property of the alarm entity.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Unknown entity: null; nested exception is org.hibernate.HibernateException: Unknown entity: null"))),
             @ApiResponse(responseCode = "403", description = "The caller holds none of `ROLE_ADMIN`, `ROLE_REST`, `ROLE_USER` or `ROLE_MOBILE`. The shipped security rules gate the endpoint on the same four roles, so the container answers first with its own HTML error page; the plain-text body below comes from the resource check.",
@@ -308,7 +308,7 @@ public class AlarmRestService extends AlarmRestServiceBase {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "The request was processed."),
             @ApiResponse(responseCode = "400", description = "No alarm with that id.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Unable to locate alarm with ID '99999999'"))),
             @ApiResponse(responseCode = "403", description = "The caller holds `ROLE_READONLY`, or named somebody other than themselves in `ackUser` without holding `ROLE_ADMIN` or `ROLE_DELEGATE`.",
@@ -428,9 +428,10 @@ public class AlarmRestService extends AlarmRestServiceBase {
                     examples = @ExampleObject(value = "ack=true&id=4547")))
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "At least one alarm matched and was processed."),
-            @ApiResponse(responseCode = "304", description = "No alarm matched the filters."),
-            @ApiResponse(responseCode = "400", description = "None of `ack`, `escalate` or `clear` was supplied, or both `id` and `alarmId` were.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+            @ApiResponse(responseCode = "304", description = "No alarm matched the filters. Returned even when no action parameter was supplied: the "
+                    + "missing-action check runs per matched alarm, so it is never reached with an empty match."),
+            @ApiResponse(responseCode = "400", description = "At least one alarm matched but none of `ack`, `escalate` or `clear` was supplied, or both `id` and `alarmId` were.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Must supply one of the 'ack', 'escalate', or 'clear' parameters, set to either 'true' or 'false'."))),
             @ApiResponse(responseCode = "403", description = "The caller holds `ROLE_READONLY`, or named somebody other than themselves in `ackUser` without holding `ROLE_ADMIN` or `ROLE_DELEGATE`.",
@@ -439,7 +440,7 @@ public class AlarmRestService extends AlarmRestServiceBase {
                             examples = @ExampleObject(value = "User 'jroe', is not allowed to perform updates to alarms as user 'admin'"))),
             @ApiResponse(responseCode = "415", description = "The body was not `application/x-www-form-urlencoded`."),
             @ApiResponse(responseCode = "500", description = "A form parameter is not a property of the alarm entity.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Unknown entity: null; nested exception is org.hibernate.HibernateException: Unknown entity: null")))
     })

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AlarmRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AlarmRestService.java
@@ -93,10 +93,9 @@ public class AlarmRestService extends AlarmRestServiceBase {
             description = """
                     Return one alarm by id.
                     The literal path segment `summaries` is handled by this same method and returns per-node alarm
-                    summaries instead of a single alarm, so `GET /alarms/summaries` is a second, differently shaped
-                    response from this operation.
-                    Timestamps are epoch milliseconds in JSON and ISO-8601 strings in XML, whatever the schema
-                    says.""",
+                    summaries instead of a single alarm.
+                    The derived schema shows `date-time`; the wire carries epoch milliseconds in JSON and ISO-8601
+                    strings in XML.""",
             operationId = "getAlarmV1"
     )
     @ApiResponses(value = {
@@ -137,7 +136,7 @@ public class AlarmRestService extends AlarmRestServiceBase {
                       }
                     }"""))),
             @ApiResponse(responseCode = "404", description = "No alarm with that id."),
-            @ApiResponse(responseCode = "403", description = "The caller holds none of `ROLE_ADMIN`, `ROLE_REST`, `ROLE_USER` or `ROLE_MOBILE`.",
+            @ApiResponse(responseCode = "403", description = "The caller holds none of `ROLE_ADMIN`, `ROLE_REST`, `ROLE_USER` or `ROLE_MOBILE`. The shipped security rules gate the endpoint on the same four roles, so the container answers first with its own HTML error page; the plain-text body below comes from the resource check.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "User 'jroe', is not allowed to read alarms."))),
@@ -174,7 +173,7 @@ public class AlarmRestService extends AlarmRestServiceBase {
     @Operation(
             summary = "Count all alarms",
             description = "Return the total number of alarm rows as a plain-text integer. Query parameters are "
-                    + "ignored, so this is not a count of a filtered set.",
+                    + "ignored.",
             operationId = "getAlarmCountV1"
     )
     @ApiResponses(value = {
@@ -182,7 +181,7 @@ public class AlarmRestService extends AlarmRestServiceBase {
                     content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "13"))),
-            @ApiResponse(responseCode = "403", description = "The caller holds none of `ROLE_ADMIN`, `ROLE_REST`, `ROLE_USER` or `ROLE_MOBILE`.",
+            @ApiResponse(responseCode = "403", description = "The caller holds none of `ROLE_ADMIN`, `ROLE_REST`, `ROLE_USER` or `ROLE_MOBILE`. The shipped security rules gate the endpoint on the same four roles, so the container answers first with its own HTML error page; the plain-text body below comes from the resource check.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "User 'jroe', is not allowed to read alarms.")))
@@ -260,7 +259,7 @@ public class AlarmRestService extends AlarmRestServiceBase {
                     content = @Content(mediaType = MediaType.APPLICATION_JSON,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Unknown entity: null; nested exception is org.hibernate.HibernateException: Unknown entity: null"))),
-            @ApiResponse(responseCode = "403", description = "The caller holds none of `ROLE_ADMIN`, `ROLE_REST`, `ROLE_USER` or `ROLE_MOBILE`.",
+            @ApiResponse(responseCode = "403", description = "The caller holds none of `ROLE_ADMIN`, `ROLE_REST`, `ROLE_USER` or `ROLE_MOBILE`. The shipped security rules gate the endpoint on the same four roles, so the container answers first with its own HTML error page; the plain-text body below comes from the resource check.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "User 'jroe', is not allowed to read alarms.")))
@@ -414,14 +413,13 @@ public class AlarmRestService extends AlarmRestServiceBase {
             summary = "Acknowledge, clear or escalate matching alarms",
             description = """
                     Apply one acknowledgement action to every alarm matching the filters in the form body. Fields
-                    other than `ack`, `escalate`, `clear` and `ackUser` are read as alarm filters, so a body of
-                    just `ack=true` matches everything the filter defaults allow and acknowledges it. Scope the
-                    request with `id`, `severity` or another `OnmsAlarm` property.
+                    other than `ack`, `escalate`, `clear` and `ackUser` are read as filters on `OnmsAlarm` property
+                    names such as `id` and `severity`, so a body of just `ack=true` matches everything the filter
+                    defaults allow and acknowledges it.
                     `alarmId` is accepted as an alias for `id`, but sending both is a 400. `ticketId` and
                     `ticketState` are not honoured here.
-                    The limit and offset that the filter parsing derives are reset to unlimited, so the action
-                    reaches the whole match set rather than one page of it. The paging equivalents on
-                    `GET /alarms` therefore do not restrict what this operation touches.""",
+                    The `limit` and `offset` the filter parsing derives are reset to unlimited, so the action
+                    reaches the whole match set rather than one page of it.""",
             operationId = "updateAlarmsV1"
     )
     @RequestBody(required = true, description = "The action to apply, plus the filters selecting the alarms.",

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AlarmStatsRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AlarmStatsRestService.java
@@ -86,9 +86,8 @@ public class AlarmStatsRestService extends AlarmRestServiceBase {
             description = """
                     Return acknowledged and unacknowledged alarm counts together with the newest and oldest alarm
                     in each of those two sets.
-                    Query parameters are applied as alarm filters in the same way as `GET /alarms`, so the counts
-                    can be narrowed. The four newest/oldest lookups run against their own criteria and are not
-                    filtered by those parameters.
+                    Query parameters are applied as alarm filters in the same way as `GET /alarms`. The four
+                    newest/oldest lookups run against their own criteria and are not filtered by those parameters.
                     In JSON each of `newestAcked`, `newestUnacked`, `oldestAcked` and `oldestUnacked` is an array
                     of one element, and that element is `null` when the set is empty. Alarm timestamps inside them
                     are epoch milliseconds in JSON and ISO-8601 strings in XML.""",
@@ -139,8 +138,8 @@ public class AlarmStatsRestService extends AlarmRestServiceBase {
             description = """
                     Return one statistics block per severity. With `severities` absent, all seven severities are
                     reported in ordinal order.
-                    A name that is not a severity resolves to `INDETERMINATE` rather than being rejected, so a
-                    misspelled name silently yields the indeterminate block. Names are matched case-insensitively.
+                    A name that is not a severity resolves to `INDETERMINATE` rather than being rejected. Names
+                    are matched case-insensitively.
                     Other query parameters are applied as alarm filters, as on `GET /stats/alarms`.""",
             operationId = "getAlarmStatsBySeverityV1"
     )

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AlarmStatsRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AlarmStatsRestService.java
@@ -38,6 +38,13 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -74,6 +81,52 @@ public class AlarmStatsRestService extends AlarmRestServiceBase {
 
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get alarm statistics",
+            description = """
+                    Return acknowledged and unacknowledged alarm counts together with the newest and oldest alarm
+                    in each of those two sets.
+                    Query parameters are applied as alarm filters in the same way as `GET /alarms`, so the counts
+                    can be narrowed. The four newest/oldest lookups run against their own criteria and are not
+                    filtered by those parameters.
+                    In JSON each of `newestAcked`, `newestUnacked`, `oldestAcked` and `oldestUnacked` is an array
+                    of one element, and that element is `null` when the set is empty. Alarm timestamps inside them
+                    are epoch milliseconds in JSON and ISO-8601 strings in XML.""",
+            operationId = "getAlarmStatsV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The statistics. `severity` is null on this operation.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = AlarmStatistics.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "acknowledgedCount": 2,
+                      "unacknowledgedCount": 14,
+                      "totalCount": 16,
+                      "severity": null,
+                      "newestAcked": [
+                        {
+                          "id": 4548,
+                          "uei": "uei.opennms.org/apidoc/validationAlarm",
+                          "severity": "WARNING",
+                          "ackUser": "admin",
+                          "ackTime": 1787727618396,
+                          "firstEventTime": 1787727549288,
+                          "lastEventTime": 1787727549288,
+                          "count": 1,
+                          "type": 3,
+                          "parameters": []
+                        }
+                      ],
+                      "newestUnacked": [ null ],
+                      "oldestAcked": [ null ],
+                      "oldestUnacked": [ null ]
+                    }"""))),
+            @ApiResponse(responseCode = "500", description = "A query parameter is not a property of the alarm entity.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Unknown entity: null; nested exception is org.hibernate.HibernateException: Unknown entity: null")))
+    })
     public AlarmStatistics getStats(@Context final UriInfo uriInfo) {
         return getStats(uriInfo, null);
     }
@@ -81,7 +134,55 @@ public class AlarmStatsRestService extends AlarmRestServiceBase {
     @GET
     @Path("/by-severity")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    public AlarmStatisticsBySeverity getStatsForEachSeverity(@Context final UriInfo uriInfo, @QueryParam("severities") final String severitiesString) {
+    @Operation(
+            summary = "Get alarm statistics per severity",
+            description = """
+                    Return one statistics block per severity. With `severities` absent, all seven severities are
+                    reported in ordinal order.
+                    A name that is not a severity resolves to `INDETERMINATE` rather than being rejected, so a
+                    misspelled name silently yields the indeterminate block. Names are matched case-insensitively.
+                    Other query parameters are applied as alarm filters, as on `GET /stats/alarms`.""",
+            operationId = "getAlarmStatsBySeverityV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "One statistics block per requested severity.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = AlarmStatisticsBySeverity.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "alarmStatistics": [
+                        {
+                          "acknowledgedCount": 0,
+                          "unacknowledgedCount": 3,
+                          "totalCount": 3,
+                          "severity": "MINOR",
+                          "newestAcked": [ null ],
+                          "newestUnacked": [ null ],
+                          "oldestAcked": [ null ],
+                          "oldestUnacked": [ null ]
+                        },
+                        {
+                          "acknowledgedCount": 0,
+                          "unacknowledgedCount": 3,
+                          "totalCount": 3,
+                          "severity": "MAJOR",
+                          "newestAcked": [ null ],
+                          "newestUnacked": [ null ],
+                          "oldestAcked": [ null ],
+                          "oldestUnacked": [ null ]
+                        }
+                      ]
+                    }"""))),
+            @ApiResponse(responseCode = "500", description = "A query parameter is not a property of the alarm entity.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Unknown entity: null; nested exception is org.hibernate.HibernateException: Unknown entity: null")))
+    })
+    public AlarmStatisticsBySeverity getStatsForEachSeverity(@Context final UriInfo uriInfo,
+            @Parameter(description = "Comma-separated severity names to report on. All severities when omitted.",
+                    example = "MINOR,MAJOR",
+                    schema = @Schema(type = "string"))
+            @QueryParam("severities") final String severitiesString) {
         final AlarmStatisticsBySeverity stats = new AlarmStatisticsBySeverity();
 
         String[] severities = StringUtils.split(severitiesString, ",");
@@ -186,10 +287,12 @@ public class AlarmStatsRestService extends AlarmRestServiceBase {
 
     @Entity
     @XmlRootElement(name = "severities")
+    @Schema(name = "AlarmStatisticsBySeverity", description = "One alarm statistics block per severity.")
     public static class AlarmStatisticsBySeverity {
         private List<AlarmStatistics> m_stats = new LinkedList<>();
 
         @XmlElement(name="alarmStatistics")
+        @Schema(description = "One entry per requested severity, in the order they were requested.")
         public List<AlarmStatistics> getStats() {
             return m_stats;
         }
@@ -212,6 +315,8 @@ public class AlarmStatsRestService extends AlarmRestServiceBase {
     
     @Entity
     @XmlRootElement(name = "alarmStatistics")
+    @Schema(name = "AlarmStatistics", description = "Acknowledged and unacknowledged alarm counts, plus the newest "
+            + "and oldest alarm in each set.")
     public static class AlarmStatistics {
         private int m_totalCount = 0;
         private int m_acknowledgedCount = 0;
@@ -235,6 +340,7 @@ public class AlarmStatsRestService extends AlarmRestServiceBase {
                 .toString();
         }
         @XmlAttribute(name="totalCount")
+        @Schema(description = "Alarms matching the criteria, acknowledged or not.", example = "16")
         public int getTotalCount() {
             return m_totalCount;
         }
@@ -244,6 +350,7 @@ public class AlarmStatsRestService extends AlarmRestServiceBase {
         }
 
         @XmlAttribute(name="acknowledgedCount")
+        @Schema(description = "Matching alarms that carry an acknowledgement.", example = "2")
         public int getAcknowledgedCount() {
             return m_acknowledgedCount;
         }
@@ -253,6 +360,8 @@ public class AlarmStatsRestService extends AlarmRestServiceBase {
         }
 
         @XmlAttribute(name="unacknowledgedCount")
+        @Schema(description = "Derived as `totalCount` minus `acknowledgedCount`; the setter is a no-op.",
+                example = "14")
         public int getUnacknowledgedCount() {
             return m_totalCount - m_acknowledgedCount;
         }
@@ -260,6 +369,7 @@ public class AlarmStatsRestService extends AlarmRestServiceBase {
         public void setUnacknowledgedCount(final int count) {}
 
         @XmlAttribute(name="severity")
+        @Schema(description = "Severity this block covers. Null on `GET /stats/alarms`.", example = "MINOR")
         public OnmsSeverity getSeverity() {
             return m_severity;
         }
@@ -270,6 +380,8 @@ public class AlarmStatsRestService extends AlarmRestServiceBase {
 
         @XmlElementWrapper(name="newestAcked")
         @XmlElement(name="alarm")
+        @Schema(description = "Most recent acknowledged alarm, as a one-element list whose element is null when "
+                + "there is none.")
         public List<OnmsAlarm> getNewestAcknowledged() {
             return Collections.singletonList(m_newestAcknowledged);
         }
@@ -280,6 +392,8 @@ public class AlarmStatsRestService extends AlarmRestServiceBase {
 
         @XmlElementWrapper(name="newestUnacked")
         @XmlElement(name="alarm")
+        @Schema(description = "Most recent unacknowledged alarm, as a one-element list whose element is null when "
+                + "there is none.")
         public List<OnmsAlarm> getNewestUnacknowledged() {
             return Collections.singletonList(m_newestUnacknowledged);
         }
@@ -290,6 +404,8 @@ public class AlarmStatsRestService extends AlarmRestServiceBase {
 
         @XmlElementWrapper(name="oldestAcked")
         @XmlElement(name="alarm")
+        @Schema(description = "Oldest acknowledged alarm by `firstEventTime`, as a one-element list whose element "
+                + "is null when there is none.")
         public List<OnmsAlarm> getOldestAcknowledged() {
             return Collections.singletonList(m_oldestAcknowledged);
         }
@@ -300,6 +416,8 @@ public class AlarmStatsRestService extends AlarmRestServiceBase {
 
         @XmlElementWrapper(name="oldestUnacked")
         @XmlElement(name="alarm")
+        @Schema(description = "Oldest unacknowledged alarm by `firstEventTime`, as a one-element list whose "
+                + "element is null when there is none.")
         public List<OnmsAlarm> getOldestUnacknowledged() {
             return Collections.singletonList(m_oldestUnacknowledged);
         }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AssetRecordResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AssetRecordResource.java
@@ -73,12 +73,10 @@ import com.google.common.base.Strings;
         Asset Records API.
 
         An asset record holds the inventory and location metadata attached to one node, and is created together
-        with the node. Reach it through the node: `/nodes/{nodeCriteria}/assetRecord`.
+        with the node. The node-scoped path is `/nodes/{nodeCriteria}/assetRecord`.
 
-        The class also carries its own `@Path("assetRecord")`, so the generated document additionally lists
-        `/assetRecord` with no node in the path. Both handlers need a `nodeCriteria` path parameter that the
-        bare path cannot supply, so `GET /assetRecord` and `PUT /assetRecord` fail with HTTP 500 on every
-        request. Use the node-scoped paths.""")
+        The document also lists `/assetRecord` with no node in the path. That path cannot supply the required
+        `nodeCriteria`, so `GET /assetRecord` and `PUT /assetRecord` fail with HTTP 500 on every request.""")
 @Transactional
 public class AssetRecordResource extends OnmsRestService {
 
@@ -113,9 +111,7 @@ public class AssetRecordResource extends OnmsRestService {
                     other fields rather than nested. `dateInstalled`, `lease`, `leaseExpires` and
                     `maintContractExpiration` are free-text strings, not dates. `lastModifiedDate` is a real
                     timestamp and serializes as epoch milliseconds in JSON and as an ISO-8601 offset date-time in
-                    XML.
-
-                    Reached without a node in the path (`GET /assetRecord`) this fails with HTTP 500.""",
+                    XML.""",
             operationId = "getNodeAssetRecord"
     )
     @ApiResponses(value = {
@@ -201,9 +197,7 @@ public class AssetRecordResource extends OnmsRestService {
                     installation and lease fields are plain strings and are stored verbatim.
 
                     A successful write sets `lastModifiedBy` to the authenticated user and `lastModifiedDate` to
-                    now, then publishes `assetInfoChanged`.
-
-                    Reached without a node in the path (`PUT /assetRecord`) this fails with HTTP 500.""",
+                    now, then publishes `assetInfoChanged`.""",
             operationId = "updateNodeAssetRecord"
     )
     @RequestBody(

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AssetRecordResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AssetRecordResource.java
@@ -35,6 +35,14 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.netmgt.dao.api.AssetRecordDao;
 import org.opennms.netmgt.dao.api.NodeDao;
@@ -61,7 +69,16 @@ import com.google.common.base.Strings;
 
 @Component("assetRecordResource")
 @Path("assetRecord")
-@Tag(name = "Asset Records", description = "Asset Records API")
+@Tag(name = "Asset Records", description = """
+        Asset Records API.
+
+        An asset record holds the inventory and location metadata attached to one node, and is created together
+        with the node. Reach it through the node: `/nodes/{nodeCriteria}/assetRecord`.
+
+        The class also carries its own `@Path("assetRecord")`, so the generated document additionally lists
+        `/assetRecord` with no node in the path. Both handlers need a `nodeCriteria` path parameter that the
+        bare path cannot supply, so `GET /assetRecord` and `PUT /assetRecord` fail with HTTP 500 on every
+        request. Use the node-scoped paths.""")
 @Transactional
 public class AssetRecordResource extends OnmsRestService {
 
@@ -85,7 +102,74 @@ public class AssetRecordResource extends OnmsRestService {
      */
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-    public OnmsAssetRecord getAssetRecord(@PathParam("nodeCriteria") final String nodeCriteria) {
+    @Operation(
+            summary = "Get a node's asset record",
+            description = """
+                    Returns the asset record of one node. Every node has exactly one, created with the node, so a
+                    node that has never been edited still returns a record with `category` set to `Unspecified`
+                    and the remaining fields null.
+
+                    `latitude` and `longitude` are read from the record's geolocation and appear alongside the
+                    other fields rather than nested. `dateInstalled`, `lease`, `leaseExpires` and
+                    `maintContractExpiration` are free-text strings, not dates. `lastModifiedDate` is a real
+                    timestamp and serializes as epoch milliseconds in JSON and as an ISO-8601 offset date-time in
+                    XML.
+
+                    Reached without a node in the path (`GET /assetRecord`) this fails with HTTP 500.""",
+            operationId = "getNodeAssetRecord"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The node's asset record. Fields never set are null and are still present in the JSON body.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsAssetRecord.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "category": "Unspecified",
+                      "id": 23600,
+                      "description": "Top-of-rack switch",
+                      "assetNumber": "ASSET-0001",
+                      "rack": "R7",
+                      "building": "HQ",
+                      "floor": "2",
+                      "room": "210",
+                      "city": "Pittsboro",
+                      "state": "NC",
+                      "region": "Southeast",
+                      "latitude": 35.7196,
+                      "longitude": -79.1778,
+                      "dateInstalled": "2026-01-15",
+                      "comment": "Installed during the spring refresh",
+                      "lastModifiedBy": "admin",
+                      "lastModifiedDate": 1787727690002
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsAssetRecord.class),
+                                    examples = @ExampleObject(value = """
+                    <assetRecord>
+                      <category>Unspecified</category>
+                      <city>Pittsboro</city>
+                      <id>23600</id>
+                      <lastModifiedBy>admin</lastModifiedBy>
+                      <lastModifiedDate>2026-08-26T02:55:13.802-04:00</lastModifiedDate>
+                      <latitude>35.7196</latitude>
+                      <longitude>-79.1778</longitude>
+                      <node>258</node>
+                      <state>NC</state>
+                    </assetRecord>"""))
+                    }),
+            @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "getAssetRecord: Can't find node 999999"))),
+            @ApiResponse(responseCode = "500", description = "Returned unconditionally when the operation is called as `GET /assetRecord`, with no node in the path.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot invoke \"String.contains(java.lang.CharSequence)\" because \"lookupCriteria\" is null")))
+    })
+    public OnmsAssetRecord getAssetRecord(@Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.",
+                                                    example = "Router-Requisition:node1")
+                                          @PathParam("nodeCriteria") final String nodeCriteria) {
         OnmsNode node = m_nodeDao.get(nodeCriteria);
         if (node == null) {
             throw getException(Status.BAD_REQUEST, "getAssetRecord: Can't find node " + nodeCriteria);
@@ -101,7 +185,54 @@ public class AssetRecordResource extends OnmsRestService {
      */
     @PUT
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-    public Response updateAssetRecord(@PathParam("nodeCriteria") final String nodeCriteria
+    @Operation(
+            summary = "Update a node's asset record",
+            description = """
+                    Applies form-encoded fields to the node's asset record. Each key is a bean property name on
+                    `OnmsAssetRecord`; keys that do not resolve to a writable property are ignored rather than
+                    rejected, so a request that names only unknown fields comes back 304.
+
+                    `id`, `dbId`, `nodeId`, `authorizedGroups`, `foreignSource`, `foreignId` and `type` are
+                    protected and are dropped with a warning in the log.
+
+                    Nested geolocation fields are reachable directly (`latitude`, `longitude`, `city`, `state`,
+                    `zip`, `country`, `address1`, `address2`); the geolocation object is created on demand if the
+                    record has none. `Date`-typed properties are parsed with an ISO-8601 editor, but the visible
+                    installation and lease fields are plain strings and are stored verbatim.
+
+                    A successful write sets `lastModifiedBy` to the authenticated user and `lastModifiedDate` to
+                    now, then publishes `assetInfoChanged`.
+
+                    Reached without a node in the path (`PUT /assetRecord`) this fails with HTTP 500.""",
+            operationId = "updateNodeAssetRecord"
+    )
+    @RequestBody(
+            required = true,
+            description = "Form-encoded asset fields to set. Only the keys present are touched.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "string"),
+                    examples = {
+                            @ExampleObject(name = "location", summary = "Set physical location and coordinates",
+                                    value = "city=Pittsboro&state=NC&region=Southeast&building=HQ&floor=2&room=210&rack=R7&latitude=35.7196&longitude=-79.1778"),
+                            @ExampleObject(name = "inventory", summary = "Set inventory identifiers",
+                                    value = "assetNumber=ASSET-0001&serialNumber=SN12345&manufacturer=Example+Corp&modelNumber=X-9000&dateInstalled=2026-01-15")
+                    })
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "At least one field was written. No body."),
+            @ApiResponse(responseCode = "304", description = "No key in the body resolved to a writable, unprotected property, so nothing was written."),
+            @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "updateAssetRecord: Can't find node 999999"))),
+            @ApiResponse(responseCode = "500", description = "Publishing `assetInfoChanged` failed, or the operation was called as `PUT /assetRecord` with no node in the path.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot invoke \"String.contains(java.lang.CharSequence)\" because \"lookupCriteria\" is null")))
+    })
+    public Response updateAssetRecord(@Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.",
+                                                 example = "Router-Requisition:node1")
+                                      @PathParam("nodeCriteria") final String nodeCriteria
             , @Context final HttpServletRequest request
             , final MultivaluedMapImpl params) {
         OnmsNode node = m_nodeDao.get(nodeCriteria);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AssetSuggestionsRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AssetSuggestionsRestService.java
@@ -161,15 +161,10 @@ public class AssetSuggestionsRestService extends OnmsRestService implements Init
     @Operation(
             summary = "List distinct asset-record values per field",
             description = """
-                    Returns, for every writable asset-record field, the distinct values already stored across all
-                    nodes. Intended to back type-ahead in asset editors.
-
-                    `class`, `geolocation`, `lastModifiedDate` and `lastModifiedBy` are excluded. Fields with no
-                    stored value still appear, with an empty list. An empty string counts as a value, so lists
-                    often contain "".
-
-                    The cost grows with the number of asset records, since every distinct record is walked once
-                    per field.""",
+                    Returns the distinct values already stored across all nodes, for every asset-record field
+                    except `class`, `geolocation`, `lastModifiedDate` and `lastModifiedBy`. Fields with no stored
+                    value still appear, with an empty list. An empty string counts as a value, so lists often
+                    contain "".""",
             operationId = "getAssetSuggestions"
     )
     @ApiResponses(value = {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AssetSuggestionsRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AssetSuggestionsRestService.java
@@ -38,6 +38,12 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.config.api.JaxbListWrapper;
 import org.opennms.netmgt.dao.api.AssetRecordDao;
@@ -88,6 +94,11 @@ public class AssetSuggestionsRestService extends OnmsRestService implements Init
      */
     @SuppressWarnings("serial")
     @XmlRootElement(name="suggestions")
+    @Schema(name = "AssetSuggestions",
+            description = """
+                    Distinct values already stored for each asset-record field, keyed by field name. In JSON the
+                    document is a plain object whose keys are the field names; in XML the same data is emitted as
+                    `suggestions/mappings/entry` elements with `key` and `value` children.""")
     public static class Suggestions extends TreeMap<String, SuggestionList> {
 
         /**
@@ -106,6 +117,8 @@ public class AssetSuggestionsRestService extends OnmsRestService implements Init
      */
     @SuppressWarnings("serial")
     @XmlRootElement(name="suggestions")
+    @Schema(name = "AssetSuggestionList",
+            description = "Distinct values recorded for one asset-record field, sorted. `totalCount` and `count` are null when the list is empty.")
     public static class SuggestionList extends JaxbListWrapper<String> {
 
         /**
@@ -145,6 +158,51 @@ public class AssetSuggestionsRestService extends OnmsRestService implements Init
     @GET
     @Path("suggestions")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "List distinct asset-record values per field",
+            description = """
+                    Returns, for every writable asset-record field, the distinct values already stored across all
+                    nodes. Intended to back type-ahead in asset editors.
+
+                    `class`, `geolocation`, `lastModifiedDate` and `lastModifiedBy` are excluded. Fields with no
+                    stored value still appear, with an empty list. An empty string counts as a value, so lists
+                    often contain "".
+
+                    The cost grows with the number of asset records, since every distinct record is walked once
+                    per field.""",
+            operationId = "getAssetSuggestions"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Suggestions for every non-excluded asset field.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = Suggestions.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "address1": { "totalCount": 1, "count": 1, "offset": 0, "suggestion": ["1 Example St"] },
+                      "address2": { "totalCount": null, "count": null, "offset": 0, "suggestion": [] },
+                      "building": { "totalCount": 3, "count": 3, "offset": 0, "suggestion": ["", "Annex", "HQ"] },
+                      "city": { "totalCount": 2, "count": 2, "offset": 0, "suggestion": ["Pittsboro", "Raleigh"] }
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = Suggestions.class),
+                                    examples = @ExampleObject(value = """
+                    <suggestions>
+                      <mappings>
+                        <entry>
+                          <key>address1</key>
+                          <value count="1" offset="0" totalCount="1">
+                            <suggestion>1 Example St</suggestion>
+                          </value>
+                        </entry>
+                        <entry>
+                          <key>address2</key>
+                          <value offset="0"/>
+                        </entry>
+                      </mappings>
+                    </suggestions>"""))
+                    })
+    })
     public Suggestions getAssetSuggestions() {
         final Suggestions suggestions = new Suggestions();
         final List<OnmsAssetRecord> distinctAssetProperties = m_assetDao.getDistinctProperties();

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AvailabilityRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AvailabilityRestService.java
@@ -44,6 +44,13 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.map.annotate.JsonRootName;
@@ -59,6 +66,7 @@ import org.opennms.web.category.Category;
 import org.opennms.web.category.CategoryList;
 import org.opennms.web.category.CategoryModel;
 import org.opennms.web.category.NodeList;
+import org.opennms.web.rest.v1.model.AvailabilityDataResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -73,7 +81,19 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component("availabilityRestService")
 @Path("availability")
-@Tag(name = "Availability", description = "Availability API")
+@Tag(name = "Availability", description = """
+        Availability API.
+
+        Availability figures come from the RTC (real-time console) rolling window rather than from a fresh
+        query, so they lag behind the outage tables and are recomputed on the RTC's own schedule. All
+        percentages are 0 to 100.
+
+        The category groupings and their thresholds come from `categories.xml`. `last-updated` on a category
+        is serialised as epoch milliseconds, not as the date-time string the derived schema shows.
+
+        Categories are addressed by name in the path. Names commonly contain spaces, so they have to be
+        percent-encoded (`Web%20Servers`); the handler URL-decodes the path segment before looking the
+        category up.""")
 @Transactional
 @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
 public class AvailabilityRestService extends OnmsRestService {
@@ -98,6 +118,64 @@ public class AvailabilityRestService extends OnmsRestService {
     }
 
     @GET
+    @Operation(
+            summary = "Get availability for every category group",
+            description = """
+        Return every category group from `categories.xml` with the categories it contains and their current
+        availability figures. This is the whole RTC view in one response, so it grows with the number of
+        categories and with the number of nodes in each of them: the `nodes` array on a category lists every
+        node id in that category.
+
+        `last-updated` on each category is epoch milliseconds.""",
+            operationId = "getAvailabilityForAllCategories"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Category groups with their categories.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = AvailabilityDataResponse.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "section": [
+                        {
+                          "name": "Categories",
+                          "categories": {
+                            "totalCount": 8,
+                            "count": 8,
+                            "offset": 0,
+                            "category": [
+                              {
+                                "name": "Web Servers",
+                                "comment": "This category includes all managed interfaces which are running an HTTP (Web) server on port 80 or other common ports.",
+                                "service-percentage": 100.0,
+                                "service-down-count": 0,
+                                "outage-class": "Normal",
+                                "availability-class": "Warning",
+                                "outage-text": "0 of 254",
+                                "availability-text": "99.927%",
+                                "nodes": [
+                                  1,
+                                  2,
+                                  3
+                                ],
+                                "last-updated": 1787727304745,
+                                "normal-threshold": 99.99,
+                                "warning-threshold": 97.0,
+                                "availability": 99.92666456601779
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = AvailabilityDataResponse.class))
+                    }),
+            @ApiResponse(responseCode = "500", description = "The category data could not be read.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Failed to get availability data: <cause>")))
+    })
     public AvailabilityData getNodeAvailability() {
         try {
             return new AvailabilityData(m_categoryList.getCategoryData());
@@ -109,7 +187,56 @@ public class AvailabilityRestService extends OnmsRestService {
 
     @GET
     @Path("/categories/{category}")
-    public Category getCategory(@PathParam("category") final String categoryName) {
+    @Operation(
+            summary = "Get availability for one category",
+            description = """
+        Return the current availability figures for a single category from `categories.xml`, including the
+        list of node ids it covers. `outage-class` and `availability-class` are the RTC's own severity
+        labels, derived from the category's `normal-threshold` and `warning-threshold`. `last-updated` is
+        epoch milliseconds.""",
+            operationId = "getAvailabilityCategory"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The category and its availability figures.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = Category.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "name": "Web Servers",
+                      "comment": "This category includes all managed interfaces which are running an HTTP (Web) server on port 80 or other common ports.",
+                      "service-percentage": 100.0,
+                      "service-down-count": 0,
+                      "outage-class": "Normal",
+                      "availability-class": "Warning",
+                      "outage-text": "0 of 254",
+                      "availability-text": "99.927%",
+                      "nodes": [
+                        1,
+                        2,
+                        3
+                      ],
+                      "last-updated": 1787727424662,
+                      "normal-threshold": 99.99,
+                      "warning-threshold": 97.0,
+                      "availability": 99.92666456601779
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = Category.class))
+                    }),
+            @ApiResponse(responseCode = "404", description = "No category with that name is defined.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Category Web Serverz was not found."))),
+            @ApiResponse(responseCode = "500", description = "The category data could not be read.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Failed to get availability data for category Web Servers : <cause>")))
+    })
+    public Category getCategory(
+            @Parameter(description = "Category name from categories.xml, percent-encoded. Case sensitive.",
+                    required = true, example = "Web Servers")
+            @PathParam("category") final String categoryName) {
         try {
             final String category = URLDecoder.decode(categoryName, StandardCharsets.UTF_8.name());
             final Category cat = CategoryModel.getInstance().getCategory(category);
@@ -125,7 +252,50 @@ public class AvailabilityRestService extends OnmsRestService {
 
     @GET
     @Path("/categories/{category}/nodes")
-    public NodeList getCategoryNodes(@PathParam("category") final String categoryName) {
+    @Operation(
+            summary = "List the nodes in a category with their availability",
+            description = """
+        Return one entry per node in the category, each with the node's availability and service counts.
+        The `ipinterfaces` array is empty on this operation: interface and service detail is only filled in
+        by the single-node operations.""",
+            operationId = "getAvailabilityCategoryNodes"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Nodes in the category.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = NodeList.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 254,
+                      "count": 254,
+                      "offset": 0,
+                      "node": [
+                        {
+                          "id": 1,
+                          "availability": 99.92797222222222,
+                          "service-count": 1,
+                          "service-down-count": 0,
+                          "ipinterfaces": []
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = NodeList.class))
+                    }),
+            @ApiResponse(responseCode = "404", description = "No category with that name is defined.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Category Web Serverz was not found."))),
+            @ApiResponse(responseCode = "500", description = "The category data could not be read.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Failed to get availability data for category Web Servers : <cause>")))
+    })
+    public NodeList getCategoryNodes(
+            @Parameter(description = "Category name from categories.xml, percent-encoded. Case sensitive.",
+                    required = true, example = "Web Servers")
+            @PathParam("category") final String categoryName) {
         try {
             final String category = URLDecoder.decode(categoryName, StandardCharsets.UTF_8.name());
             final Category cat = CategoryModel.getInstance().getCategory(category);
@@ -141,7 +311,64 @@ public class AvailabilityRestService extends OnmsRestService {
 
     @GET
     @Path("/categories/{category}/nodes/{nodeId}")
-    public AvailabilityNode getCategoryNode(@PathParam("category") final String categoryName, @PathParam("nodeId") final Long nodeId) {
+    @Operation(
+            summary = "Get availability for one node within a category",
+            description = """
+        Return the node's availability broken down by IP interface and monitored service. The category has
+        to contain the node; membership is checked before the node is loaded.
+
+        The result is the same payload as `GET /availability/nodes/{nodeId}`: the category only acts as a
+        membership check and does not restrict which of the node's services are reported.
+
+        A node id that is not in the category, or that does not exist, is reported as 500 rather than 404,
+        because the handler's catch-all wraps the not-found response.""",
+            operationId = "getAvailabilityCategoryNode"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The node with its interfaces and services.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = AvailabilityNode.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "id": 1,
+                      "availability": 99.92797222222222,
+                      "service-count": 1,
+                      "service-down-count": 0,
+                      "ipinterfaces": [
+                        {
+                          "id": 1,
+                          "address": "127.0.0.4",
+                          "availability": 99.92797222222222,
+                          "services": [
+                            {
+                              "up": true,
+                              "id": 1022,
+                              "name": "HTTP-8080",
+                              "availability": 99.92797222222222
+                            }
+                          ]
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = AvailabilityNode.class))
+                    }),
+            @ApiResponse(responseCode = "404", description = "No category with that name is defined.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Category Web Serverz was not found."))),
+            @ApiResponse(responseCode = "500", description = "The node is not in the category, does not exist, or the category data could not be read.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Failed to get availability data for category Web Servers : HTTP 404 Not Found")))
+    })
+    public AvailabilityNode getCategoryNode(
+            @Parameter(description = "Category name from categories.xml, percent-encoded. Case sensitive.",
+                    required = true, example = "Web Servers")
+            @PathParam("category") final String categoryName,
+            @Parameter(description = "Database id of the node.", required = true, example = "1")
+            @PathParam("nodeId") final Long nodeId) {
         try {
             final String category = URLDecoder.decode(categoryName, StandardCharsets.UTF_8.name());
             final Category cat = CategoryModel.getInstance().getCategory(category);
@@ -161,7 +388,54 @@ public class AvailabilityRestService extends OnmsRestService {
 
     @GET
     @Path("/nodes/{nodeId}")
-    public AvailabilityNode getNode(@PathParam("nodeId") final Integer nodeId) {
+    @Operation(
+            summary = "Get availability for one node",
+            description = """
+        Return the node's availability broken down by IP interface and monitored service. `up` on a service
+        reflects the current service status, not the availability figure next to it.
+
+        An unknown node id is reported as 500, not 404: the handler dereferences the node before checking it
+        for null, so the null-pointer failure is what reaches the caller.""",
+            operationId = "getAvailabilityNode"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The node with its interfaces and services.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = AvailabilityNode.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "id": 1,
+                      "availability": 99.92797222222222,
+                      "service-count": 1,
+                      "service-down-count": 0,
+                      "ipinterfaces": [
+                        {
+                          "id": 1,
+                          "address": "127.0.0.4",
+                          "availability": 99.92797222222222,
+                          "services": [
+                            {
+                              "up": true,
+                              "id": 1022,
+                              "name": "HTTP-8080",
+                              "availability": 99.92797222222222
+                            }
+                          ]
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = AvailabilityNode.class))
+                    }),
+            @ApiResponse(responseCode = "500", description = "The node does not exist, or its availability data could not be read.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Failed to get availability data for node 999999 : Cannot invoke \"org.opennms.netmgt.model.OnmsNode.getIpInterfaces()\" because \"dbNode\" is null")))
+    })
+    public AvailabilityNode getNode(
+            @Parameter(description = "Database id of the node.", required = true, example = "1")
+            @PathParam("nodeId") final Integer nodeId) {
         try {
             final AvailabilityNode avail = getAvailabilityNode(nodeId);
             if (avail == null) {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AvailabilityRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AvailabilityRestService.java
@@ -347,11 +347,9 @@ public class AvailabilityRestService extends OnmsRestService {
                             @Content(mediaType = MediaType.APPLICATION_XML,
                                     schema = @Schema(implementation = AvailabilityNode.class))
                     }),
-            @ApiResponse(responseCode = "404", description = "No category with that name is defined.",
-                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
-                            schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "Category Web Serverz was not found."))),
-            @ApiResponse(responseCode = "500", description = "The node is not in the category, does not exist, or the category data could not be read.",
+            @ApiResponse(responseCode = "500", description = "The category is not defined, the node is not in it or does not exist, or the "
+                    + "category data could not be read. The handler catches every failure, including the internal "
+                    + "unknown-category 404, and rewraps it as 500, so this operation never answers 404.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Failed to get availability data for category Web Servers : HTTP 404 Not Found")))

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AvailabilityRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AvailabilityRestService.java
@@ -82,11 +82,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Component("availabilityRestService")
 @Path("availability")
 @Tag(name = "Availability", description = """
-        Availability API.
-
         Availability figures come from the RTC (real-time console) rolling window rather than from a fresh
-        query, so they lag behind the outage tables and are recomputed on the RTC's own schedule. All
-        percentages are 0 to 100.
+        query, and are recomputed on the RTC's own schedule. All percentages are 0 to 100.
 
         The category groupings and their thresholds come from `categories.xml`. `last-updated` on a category
         is serialised as epoch milliseconds, not as the date-time string the derived schema shows.
@@ -122,9 +119,7 @@ public class AvailabilityRestService extends OnmsRestService {
             summary = "Get availability for every category group",
             description = """
         Return every category group from `categories.xml` with the categories it contains and their current
-        availability figures. This is the whole RTC view in one response, so it grows with the number of
-        categories and with the number of nodes in each of them: the `nodes` array on a category lists every
-        node id in that category.
+        availability figures. The `nodes` array on a category lists every node id in that category.
 
         `last-updated` on each category is epoch milliseconds.""",
             operationId = "getAvailabilityForAllCategories"
@@ -256,8 +251,7 @@ public class AvailabilityRestService extends OnmsRestService {
             summary = "List the nodes in a category with their availability",
             description = """
         Return one entry per node in the category, each with the node's availability and service counts.
-        The `ipinterfaces` array is empty on this operation: interface and service detail is only filled in
-        by the single-node operations.""",
+        The `ipinterfaces` array is empty on this operation.""",
             operationId = "getAvailabilityCategoryNodes"
     )
     @ApiResponses(value = {
@@ -320,8 +314,7 @@ public class AvailabilityRestService extends OnmsRestService {
         The result is the same payload as `GET /availability/nodes/{nodeId}`: the category only acts as a
         membership check and does not restrict which of the node's services are reported.
 
-        A node id that is not in the category, or that does not exist, is reported as 500 rather than 404,
-        because the handler's catch-all wraps the not-found response.""",
+        A node id that is not in the category, or that does not exist, is reported as 500 rather than 404.""",
             operationId = "getAvailabilityCategoryNode"
     )
     @ApiResponses(value = {
@@ -394,8 +387,7 @@ public class AvailabilityRestService extends OnmsRestService {
         Return the node's availability broken down by IP interface and monitored service. `up` on a service
         reflects the current service status, not the availability figure next to it.
 
-        An unknown node id is reported as 500, not 404: the handler dereferences the node before checking it
-        for null, so the null-pointer failure is what reaches the caller.""",
+        An unknown node id is reported as 500, not 404.""",
             operationId = "getAvailabilityNode"
     )
     @ApiResponses(value = {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/CategoryRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/CategoryRestService.java
@@ -75,8 +75,10 @@ import org.springframework.transaction.annotation.Transactional;
         Surveillance categories group nodes and gate who may see them. A category is identified by name
         everywhere in this API, and names are unique.
 
-        `/categories/nodes/...` and `/categories/groups/...` are fixed sub-resources, so a category whose name is
-        literally `nodes` or `groups` cannot be addressed through `/categories/{categoryName}`.""")
+        `/categories/nodes/{nodeCriteria}` and `/categories/groups/{groupName}` are fixed two-segment
+        sub-resources. They shadow only the two-segment category routes, so a category literally named
+        `nodes` or `groups` is still reachable at `/categories/nodes` or `/categories/groups`, but not
+        through the nested `/categories/{categoryName}/...` paths.""")
 @Transactional
 public class CategoryRestService extends OnmsRestService {
 	

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/CategoryRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/CategoryRestService.java
@@ -75,9 +75,6 @@ import org.springframework.transaction.annotation.Transactional;
         Surveillance categories group nodes and gate who may see them. A category is identified by name
         everywhere in this API, and names are unique.
 
-        Deleting a category is unconditional: requisitions, surveillance views, notification rules and filter
-        expressions that name it are not consulted and keep the now-dangling name.
-
         `/categories/nodes/...` and `/categories/groups/...` are fixed sub-resources, so a category whose name is
         literally `nodes` or `groups` cannot be addressed through `/categories/{categoryName}`.""")
 @Transactional
@@ -143,9 +140,8 @@ public class CategoryRestService extends OnmsRestService {
     @Operation(
             summary = "Check whether a node carries a category",
             description = """
-                    Returns the category if it is assigned to the node, so this doubles as a membership test.
-                    The lookup is over the node's own categories, so a category that exists but is not on the node
-                    is a 404 rather than a 200.""",
+                    Returns the category if it is assigned to the node. A category that exists but is not on the
+                    node is a 404 rather than a 200.""",
             operationId = "getCategoryOfNode"
     )
     @ApiResponses(value = {
@@ -188,9 +184,8 @@ public class CategoryRestService extends OnmsRestService {
                     Adds an already-defined category to a node. The category is not created here; an unknown name
                     is a 400.
 
-                    No request body is read, but the method declares `@Consumes(application/xml)`, so a request
-                    that sends no `Content-Type` at all is rejected with 400 before the handler runs. Send
-                    `Content-Type: application/xml` with an empty body.
+                    No request body is read, but `application/xml` is the only accepted `Content-Type`, so a
+                    request that sends none is rejected with 400 before the handler runs.
 
                     The `Location` header of the 201 is built by appending the category name to the request URI,
                     so it comes back with the name repeated
@@ -226,13 +221,13 @@ public class CategoryRestService extends OnmsRestService {
                     are bean property names on `OnmsCategory`; unknown keys are ignored.
 
                     `id`, `dbId`, `nodeId`, `authorizedGroups`, `foreignSource`, `foreignId` and `type` are
-                    protected and dropped with a log warning, so the group ACL cannot be edited here; use
-                    `PUT /categories/{categoryName}/groups/{groupName}`.
+                    protected and dropped with a log warning, so the group ACL cannot be edited here.
+                    `PUT /categories/{categoryName}/groups/{groupName}` writes it.
 
                     `name` is *not* protected on this endpoint, so sending `name=` renames the category in place.
                     The same field is protected on `PUT /nodes/{nodeCriteria}/categories/{categoryName}`. After a
                     rename, requests that still use the old name have been observed to fail with HTTP 500 rather
-                    than 404, because the name-to-category lookup is cached.""",
+                    than 404.""",
             operationId = "updateCategory"
     )
     @RequestBody(
@@ -360,13 +355,11 @@ public class CategoryRestService extends OnmsRestService {
             description = """
                     Creates a surveillance category. The name must not already be in use.
 
-                    The method declares no `@Consumes`, so both an XML and a JSON body are accepted. A
-                    form-encoded body is rejected with 415, and a body that fails to parse comes back as 500
-                    rather than 400.
+                    Both an XML and a JSON body are accepted. A form-encoded body is rejected with 415, and a
+                    body that fails to parse comes back as 500 rather than 400.
 
                     `id` in the body is ignored; the database assigns it. `authorizedGroups` sent here is not
-                    applied, so grant group access afterwards with
-                    `PUT /categories/{categoryName}/groups/{groupName}`.""",
+                    applied; `PUT /categories/{categoryName}/groups/{groupName}` grants group access.""",
             operationId = "createCategory"
     )
     @RequestBody(
@@ -421,7 +414,7 @@ public class CategoryRestService extends OnmsRestService {
             description = """
                     Returns every surveillance category defined in the system. The result is not paged and takes
                     no query parameters; `offset` is always 0 and `count` always equals `totalCount`. The order
-                    follows the database and is not guaranteed.""",
+                    follows the database.""",
             operationId = "listCategories"
     )
     @ApiResponses(value = {
@@ -489,8 +482,7 @@ public class CategoryRestService extends OnmsRestService {
     @Operation(
             summary = "Authorize a group for a category",
             description = """
-                    Adds the category to a group's authorized-category list, which is what lets members of that
-                    group see nodes in the category. No request body is read.
+                    Adds the category to a group's authorized-category list. No request body is read.
 
                     Both the "category does not exist" and the "category is already authorized for this group"
                     cases come back as the same 400 message.""",

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/CategoryRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/CategoryRestService.java
@@ -38,6 +38,14 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.netmgt.dao.api.CategoryDao;
 import org.opennms.netmgt.model.OnmsCategory;
@@ -61,7 +69,17 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component("categoryRestService")
 @Path("categories")
-@Tag(name = "Categories", description = "Categories API")
+@Tag(name = "Categories", description = """
+        Categories API.
+
+        Surveillance categories group nodes and gate who may see them. A category is identified by name
+        everywhere in this API, and names are unique.
+
+        Deleting a category is unconditional: requisitions, surveillance views, notification rules and filter
+        expressions that name it are not consulted and keep the now-dangling name.
+
+        `/categories/nodes/...` and `/categories/groups/...` are fixed sub-resources, so a category whose name is
+        literally `nodes` or `groups` cannot be addressed through `/categories/{categoryName}`.""")
 @Transactional
 public class CategoryRestService extends OnmsRestService {
 	
@@ -73,28 +91,172 @@ public class CategoryRestService extends OnmsRestService {
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     @Path("/nodes/{nodeCriteria}")
-    public OnmsCategoryCollection getCategoriesForNode(@Context final ResourceContext context, @PathParam("nodeCriteria") String nodeCriteria) {
+    @Operation(
+            summary = "List the categories assigned to a node",
+            description = """
+                    Returns the categories currently on one node. Equivalent to
+                    `GET /nodes/{nodeCriteria}/categories`, which this delegates to.
+
+                    On a node with no categories the collection comes back with `totalCount` and `count` null
+                    rather than 0.""",
+            operationId = "listCategoriesOfNode"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The node's categories.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsCategoryCollection.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 2,
+                      "count": 2,
+                      "offset": 0,
+                      "category": [
+                        { "id": 1, "authorizedGroups": [], "name": "Routers" },
+                        { "id": 4, "authorizedGroups": ["Admin"], "name": "Production" }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsCategoryCollection.class),
+                                    examples = @ExampleObject(value = """
+                    <categories count="2" offset="0" totalCount="2">
+                      <category id="1" name="Routers"/>
+                      <category id="4" name="Production">
+                        <authorizedGroups>Admin</authorizedGroups>
+                      </category>
+                    </categories>"""))
+                    }),
+            @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Node 999999 was not found.")))
+    })
+    public OnmsCategoryCollection getCategoriesForNode(@Context final ResourceContext context,
+                                                       @Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                                       @PathParam("nodeCriteria") String nodeCriteria) {
         return context.getResource(NodeRestService.class).getCategoriesForNode(nodeCriteria);
     }
 
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     @Path("{categoryName}/nodes/{nodeCriteria}")
-    public OnmsCategory getCategoryForNode(@Context final ResourceContext context, @PathParam("nodeCriteria") String nodeCriteria, @PathParam("categoryName") final String categoryName) {
+    @Operation(
+            summary = "Check whether a node carries a category",
+            description = """
+                    Returns the category if it is assigned to the node, so this doubles as a membership test.
+                    The lookup is over the node's own categories, so a category that exists but is not on the node
+                    is a 404 rather than a 200.""",
+            operationId = "getCategoryOfNode"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The category is assigned to the node.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsCategory.class),
+                                    examples = @ExampleObject(value = """
+                    { "id": 1, "description": "Routing devices", "authorizedGroups": [], "name": "Routers" }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsCategory.class),
+                                    examples = @ExampleObject(value = """
+                    <category id="1" name="Routers">
+                      <description>Routing devices</description>
+                    </category>"""))
+                    }),
+            @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Node 999999 was not found."))),
+            @ApiResponse(responseCode = "404", description = "The node exists but does not carry that category.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Can't find category Test for node 258.")))
+    })
+    public OnmsCategory getCategoryForNode(@Context final ResourceContext context,
+                                           @Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                           @PathParam("nodeCriteria") String nodeCriteria,
+                                           @Parameter(description = "Category name.", example = "Routers")
+                                           @PathParam("categoryName") final String categoryName) {
         return context.getResource(NodeRestService.class).getCategoryForNode(nodeCriteria, categoryName);
     }
 
     @PUT
     @Consumes(MediaType.APPLICATION_XML)
     @Path("{categoryName}/nodes/{nodeCriteria}/")
-    public Response addCategoryToNode(@Context final ResourceContext context, @Context final UriInfo uriInfo, @PathParam("nodeCriteria") final String nodeCriteria, @PathParam("categoryName") final String categoryName) {
+    @Operation(
+            summary = "Assign an existing category to a node",
+            description = """
+                    Adds an already-defined category to a node. The category is not created here; an unknown name
+                    is a 400.
+
+                    No request body is read, but the method declares `@Consumes(application/xml)`, so a request
+                    that sends no `Content-Type` at all is rejected with 400 before the handler runs. Send
+                    `Content-Type: application/xml` with an empty body.
+
+                    The `Location` header of the 201 is built by appending the category name to the request URI,
+                    so it comes back with the name repeated
+                    (`/categories/Routers/nodes/258/Routers`) and is not a usable URL.""",
+            operationId = "assignCategoryToNode"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "The category was added. `Location` repeats the category name and is not a working URL."),
+            @ApiResponse(responseCode = "400", description = "No such node, no such category, the category is already on the node, or no `Content-Type` was sent.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "alreadyAssigned", value = "Category 'Routers' already added to node '258'"),
+                                    @ExampleObject(name = "unknownCategory", value = "Category NoSuchCat was not found."),
+                                    @ExampleObject(name = "unknownNode", value = "Node 999999 was not found.")
+                            }))
+    })
+    public Response addCategoryToNode(@Context final ResourceContext context, @Context final UriInfo uriInfo,
+                                      @Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                      @PathParam("nodeCriteria") final String nodeCriteria,
+                                      @Parameter(description = "Name of an existing category.", example = "Routers")
+                                      @PathParam("categoryName") final String categoryName) {
         return context.getResource(NodeRestService.class).addCategoryToNode(uriInfo, nodeCriteria, categoryName);
     }
 
     @PUT
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("/{categoryName}")
-    public Response updateCategory(@PathParam("categoryName") final String categoryName, final MultivaluedMapImpl params) {
+    @Operation(
+            summary = "Update a category definition",
+            description = """
+                    Applies form-encoded fields to the category itself, not to any node-category assignment. Keys
+                    are bean property names on `OnmsCategory`; unknown keys are ignored.
+
+                    `id`, `dbId`, `nodeId`, `authorizedGroups`, `foreignSource`, `foreignId` and `type` are
+                    protected and dropped with a log warning, so the group ACL cannot be edited here; use
+                    `PUT /categories/{categoryName}/groups/{groupName}`.
+
+                    `name` is *not* protected on this endpoint, so sending `name=` renames the category in place.
+                    The same field is protected on `PUT /nodes/{nodeCriteria}/categories/{categoryName}`. After a
+                    rename, requests that still use the old name have been observed to fail with HTTP 500 rather
+                    than 404, because the name-to-category lookup is cached.""",
+            operationId = "updateCategory"
+    )
+    @RequestBody(
+            required = true,
+            description = "Form-encoded category fields to set.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "string"),
+                    examples = {
+                            @ExampleObject(name = "description", summary = "Set the description",
+                                    value = "description=Routing+devices"),
+                            @ExampleObject(name = "rename", summary = "Rename the category",
+                                    value = "name=Core-Routers")
+                    })
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "At least one field was written. No body."),
+            @ApiResponse(responseCode = "304", description = "No key in the body resolved to a writable, unprotected property."),
+            @ApiResponse(responseCode = "400", description = "No category has that name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Category with name 'NoSuchCat' was not found.")))
+    })
+    public Response updateCategory(@Parameter(description = "Current name of the category.", example = "Routers")
+                                   @PathParam("categoryName") final String categoryName, final MultivaluedMapImpl params) {
         writeLock();
         try {
             OnmsCategory category = m_categoryDao.findByName(categoryName);
@@ -129,14 +291,63 @@ public class CategoryRestService extends OnmsRestService {
 
     @DELETE
     @Path("/{categoryName}/nodes/{nodeCriteria}/")
-    public Response removeCategoryFromNode(@Context final ResourceContext context, @PathParam("nodeCriteria") String nodeCriteria, @PathParam("categoryName") String categoryName) {
+    @Operation(
+            summary = "Remove a category from a node",
+            description = """
+                    Detaches the category from the node. The category definition itself is left alone.
+                    Equivalent to `DELETE /nodes/{nodeCriteria}/categories/{categoryName}`.""",
+            operationId = "unassignCategoryFromNode"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The category is no longer on the node. No body."),
+            @ApiResponse(responseCode = "400", description = "No such node, or the node does not carry that category.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "notOnNode", value = "Category Routers not found on node 258"),
+                                    @ExampleObject(name = "unknownNode", value = "Node 999999 was not found.")
+                            }))
+    })
+    public Response removeCategoryFromNode(@Context final ResourceContext context,
+                                           @Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                           @PathParam("nodeCriteria") String nodeCriteria,
+                                           @Parameter(description = "Category name.", example = "Routers")
+                                           @PathParam("categoryName") String categoryName) {
         return context.getResource(NodeRestService.class).removeCategoryFromNode(nodeCriteria, categoryName);
     }
 
     @GET
     @Path("/{categoryName}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-    public OnmsCategory getCategory(@PathParam("categoryName") final String categoryName) {
+    @Operation(
+            summary = "Get one category by name",
+            description = """
+                    Looks a category up by name. `authorizedGroups` lists the groups allowed to see nodes in the
+                    category; an empty list means no group restriction.""",
+            operationId = "getCategoryByName"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The category.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsCategory.class),
+                                    examples = @ExampleObject(value = """
+                    { "id": 1, "description": "Routing devices", "authorizedGroups": ["Admin"], "name": "Routers" }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsCategory.class),
+                                    examples = @ExampleObject(value = """
+                    <category id="1" name="Routers">
+                      <authorizedGroups>Admin</authorizedGroups>
+                      <description>Routing devices</description>
+                    </category>"""))
+                    }),
+            @ApiResponse(responseCode = "404", description = "No category has that name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Category with name 'NoSuchCat' was not found.")))
+    })
+    public OnmsCategory getCategory(@Parameter(description = "Category name.", example = "Routers")
+                                    @PathParam("categoryName") final String categoryName) {
         OnmsCategory category = m_categoryDao.findByName(categoryName);
         if (category == null) throw getException(Response.Status.NOT_FOUND, "Category with name '{}' was not found.", categoryName);
         return category;
@@ -144,6 +355,54 @@ public class CategoryRestService extends OnmsRestService {
     
     @POST
     @Path("/")
+    @Operation(
+            summary = "Create a category",
+            description = """
+                    Creates a surveillance category. The name must not already be in use.
+
+                    The method declares no `@Consumes`, so both an XML and a JSON body are accepted. A
+                    form-encoded body is rejected with 415, and a body that fails to parse comes back as 500
+                    rather than 400.
+
+                    `id` in the body is ignored; the database assigns it. `authorizedGroups` sent here is not
+                    applied, so grant group access afterwards with
+                    `PUT /categories/{categoryName}/groups/{groupName}`.""",
+            operationId = "createCategory"
+    )
+    @RequestBody(
+            required = true,
+            description = "The category to create. Only `name` is required; `description` is optional.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = OnmsCategory.class),
+                            examples = @ExampleObject(value = """
+                    <category name="Core-Routers">
+                      <description>Spine and core routing devices</description>
+                    </category>""")),
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsCategory.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "name": "Core-Routers",
+                      "description": "Spine and core routing devices"
+                    }"""))
+            }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Created. `Location` points at `/categories/{name}`."),
+            @ApiResponse(responseCode = "400", description = "The body was absent, or a category with that name already exists.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "duplicate", value = "A category with name 'Routers' already exists."),
+                                    @ExampleObject(name = "missing", value = "Category must not be null.")
+                            })),
+            @ApiResponse(responseCode = "415", description = "The body was form-encoded. Send XML or JSON."),
+            @ApiResponse(responseCode = "500", description = "The body could not be parsed as a category.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Failed to marshal/unmarshal XML file while unmarshalling an object (OnmsCategory): javax.xml.bind.UnmarshalException")))
+    })
     public Response createCategory(@Context final UriInfo uriInfo, final OnmsCategory category) {
         if (category == null) throw getException(Response.Status.BAD_REQUEST, "Category must not be null.");
         boolean exists = m_categoryDao.findByName(category.getName()) != null;
@@ -157,13 +416,65 @@ public class CategoryRestService extends OnmsRestService {
     @GET
     @Path("/")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    @Operation(
+            summary = "List all categories",
+            description = """
+                    Returns every surveillance category defined in the system. The result is not paged and takes
+                    no query parameters; `offset` is always 0 and `count` always equals `totalCount`. The order
+                    follows the database and is not guaranteed.""",
+            operationId = "listCategories"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "All categories.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsCategoryCollection.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 3,
+                      "count": 3,
+                      "offset": 0,
+                      "category": [
+                        { "id": 1, "authorizedGroups": [], "name": "Routers" },
+                        { "id": 2, "authorizedGroups": [], "name": "Switches" },
+                        { "id": 4, "description": "Production estate", "authorizedGroups": ["Admin"], "name": "Production" }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsCategoryCollection.class),
+                                    examples = @ExampleObject(value = """
+                    <categories count="2" offset="0" totalCount="2">
+                      <category id="1" name="Routers"/>
+                      <category id="2" name="Switches"/>
+                    </categories>"""))
+                    })
+    })
     public OnmsCategoryCollection listCategories() {
         return new OnmsCategoryCollection(new ArrayList<OnmsCategory>(m_categoryDao.findAll()));
     }
 
     @DELETE
     @Path("/{categoryName}")
-    public Response deleteCategory(@PathParam("categoryName") final String categoryName) {
+    @Operation(
+            summary = "Delete a category",
+            description = """
+                    Deletes the category definition and, with it, its assignment to every node and its group ACL
+                    entries.
+
+                    Nothing else is checked first. Requisitions, surveillance views, notification rules and
+                    filter expressions that reference the name are not consulted and keep referring to a category
+                    that no longer exists.""",
+            operationId = "deleteCategory"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Deleted. No body."),
+            @ApiResponse(responseCode = "400", description = "No category has that name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "A category with name 'NoSuchCat' does not exist.")))
+    })
+    public Response deleteCategory(@Parameter(description = "Category name.", example = "Core-Routers")
+                                   @PathParam("categoryName") final String categoryName) {
         OnmsCategory category = m_categoryDao.findByName(categoryName);
         if (category != null) {
             m_categoryDao.delete(category);
@@ -175,20 +486,103 @@ public class CategoryRestService extends OnmsRestService {
 
     @PUT
     @Path("/{categoryName}/groups/{groupName}")
-    public Response addCategoryToGroup(@Context final ResourceContext context, @PathParam("groupName") final String groupName, @PathParam("categoryName") final String categoryName) {
+    @Operation(
+            summary = "Authorize a group for a category",
+            description = """
+                    Adds the category to a group's authorized-category list, which is what lets members of that
+                    group see nodes in the category. No request body is read.
+
+                    Both the "category does not exist" and the "category is already authorized for this group"
+                    cases come back as the same 400 message.""",
+            operationId = "authorizeGroupForCategory"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The group is now authorized for the category. No body."),
+            @ApiResponse(responseCode = "400", description = "The category does not exist, or is already authorized for the group.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Category with name 'Routers' already added or does not exist."))),
+            @ApiResponse(responseCode = "404", description = "No group has that name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Group with name 'NoSuchGroup' does not exist.")))
+    })
+    public Response addCategoryToGroup(@Context final ResourceContext context,
+                                       @Parameter(description = "Name of an existing group.", example = "Admin")
+                                       @PathParam("groupName") final String groupName,
+                                       @Parameter(description = "Name of an existing category.", example = "Routers")
+                                       @PathParam("categoryName") final String categoryName) {
         return context.getResource(GroupRestService.class).addCategory(groupName, categoryName);
     }
 
     @DELETE
     @Path("/{categoryName}/groups/{groupName}")
-    public Response removeCategoryFromGroup(@Context final ResourceContext context, @PathParam("groupName") final String groupName, @PathParam("categoryName") final String categoryName) {
+    @Operation(
+            summary = "Withdraw a group's authorization for a category",
+            description = "Removes the category from a group's authorized-category list. The category definition itself is untouched.",
+            operationId = "deauthorizeGroupForCategory"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The authorization was removed. No body."),
+            @ApiResponse(responseCode = "400", description = "The category was not in the group's authorized list.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Category with name 'Routers' does not exist. Remove failed."))),
+            @ApiResponse(responseCode = "404", description = "No group has that name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Group with name 'NoSuchGroup' does not exist.")))
+    })
+    public Response removeCategoryFromGroup(@Context final ResourceContext context,
+                                            @Parameter(description = "Name of an existing group.", example = "Admin")
+                                            @PathParam("groupName") final String groupName,
+                                            @Parameter(description = "Category name.", example = "Routers")
+                                            @PathParam("categoryName") final String categoryName) {
         return context.getResource(GroupRestService.class).removeCategory(groupName, categoryName);
     }
 
     @GET
     @Path("/groups/{groupName}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-    public OnmsCategoryCollection listCategoriesForGroup(@Context final ResourceContext context, @PathParam("groupName") final String groupName) {
+    @Operation(
+            summary = "List the categories a group is authorized for",
+            description = """
+                    Returns the categories on one group's authorized-category list. A group with none returns an
+                    empty collection whose `totalCount` and `count` are null rather than 0.""",
+            operationId = "listCategoriesForGroup"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The group's authorized categories.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsCategoryCollection.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 1,
+                      "count": 1,
+                      "offset": 0,
+                      "category": [
+                        { "id": 1, "description": "Routing devices", "authorizedGroups": ["Admin"], "name": "Routers" }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsCategoryCollection.class),
+                                    examples = @ExampleObject(value = """
+                    <categories count="1" offset="0" totalCount="1">
+                      <category id="1" name="Routers">
+                        <authorizedGroups>Admin</authorizedGroups>
+                        <description>Routing devices</description>
+                      </category>
+                    </categories>"""))
+                    }),
+            @ApiResponse(responseCode = "404", description = "No group has that name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Group with name 'NoSuchGroup' does not exist.")))
+    })
+    public OnmsCategoryCollection listCategoriesForGroup(@Context final ResourceContext context,
+                                                         @Parameter(description = "Group name.", example = "Admin")
+                                                         @PathParam("groupName") final String groupName) {
         return context.getResource(GroupRestService.class).listCategories(groupName);
     }
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ConfigRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ConfigRestService.java
@@ -44,7 +44,28 @@ import org.springframework.stereotype.Component;
 
 @Component("configRestService")
 @Path("config")
-@Tag(name = "Config", description = "Config API")
+@Tag(name = "Config", description = """
+        Config API.
+
+        Read and write a handful of the daemon configuration files directly. The read-only subtrees
+        (`/config/snmp`, `/config/trapd`, `/config/jmx`, `/config/datacollection`, `/config/agents`) return
+        the file or DAO contents as they stand. The northbounder and JavaMail subtrees
+        (`/config/email-nbi`, `/config/syslog-nbi`, `/config/snmptrap-nbi`, `/config/javamail`) also accept
+        writes.
+
+        Every write re-marshals the whole target file from the in-memory model and then sends a
+        `reloadDaemonConfig` event, so comments and formatting in the file are lost even when the change is
+        confined to one named entry. There is no dry run and no versioning; take a copy of the file first if
+        you need one.
+
+        The `POST` on `/config/email-nbi`, `/config/syslog-nbi` and `/config/snmptrap-nbi` replaces the
+        entire file rather than merging, so anything absent from the body is dropped. Prefer the
+        per-destination and per-sink operations for incremental changes.
+
+        The `PUT` operations that take `application/x-www-form-urlencoded` address bean property names, not
+        the XML element or attribute names the GET returns, and quietly ignore keys that do not resolve to a
+        writable property. Nested blocks and lists are not reachable that way; re-POST the whole entry
+        instead.""")
 public class ConfigRestService extends OnmsRestService {
 
     @Path("datacollection")

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ConfigRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ConfigRestService.java
@@ -55,17 +55,14 @@ import org.springframework.stereotype.Component;
 
         Every write re-marshals the whole target file from the in-memory model and then sends a
         `reloadDaemonConfig` event, so comments and formatting in the file are lost even when the change is
-        confined to one named entry. There is no dry run and no versioning; take a copy of the file first if
-        you need one.
+        confined to one named entry.
 
         The `POST` on `/config/email-nbi`, `/config/syslog-nbi` and `/config/snmptrap-nbi` replaces the
-        entire file rather than merging, so anything absent from the body is dropped. Prefer the
-        per-destination and per-sink operations for incremental changes.
+        entire file rather than merging, so anything absent from the body is dropped.
 
         The `PUT` operations that take `application/x-www-form-urlencoded` address bean property names, not
-        the XML element or attribute names the GET returns, and quietly ignore keys that do not resolve to a
-        writable property. Nested blocks and lists are not reachable that way; re-POST the whole entry
-        instead.""")
+        the XML element or attribute names the GET returns, and ignore keys that do not resolve to a writable
+        property. Nested blocks and lists are not reachable that way.""")
 public class ConfigRestService extends OnmsRestService {
 
     @Path("datacollection")

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/EventRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/EventRestService.java
@@ -102,8 +102,8 @@ public class EventRestService extends OnmsRestService {
             summary = "Get an event",
             description = """
                     Return one persisted event by id.
-                    `time` and `createTime` are epoch milliseconds in JSON and ISO-8601 strings in XML, whatever the
-                    schema says.""",
+                    The derived schema shows `date-time`; `time` and `createTime` are epoch milliseconds in JSON
+                    and ISO-8601 strings in XML.""",
             operationId = "getEventV1"
     )
     @ApiResponses(value = {
@@ -155,7 +155,7 @@ public class EventRestService extends OnmsRestService {
     @Operation(
             summary = "Count all events",
             description = "Return the total number of event rows as a plain-text integer. Query parameters are "
-                    + "ignored, so this is not a count of a filtered set.",
+                    + "ignored.",
             operationId = "getEventCountV1"
     )
     @ApiResponses(value = {
@@ -420,8 +420,8 @@ public class EventRestService extends OnmsRestService {
             summary = "Acknowledge or unacknowledge matching events",
             description = """
                     Set or clear the acknowledgement on every event matching the filters in the form body. Fields
-                    other than `ack` are read as event filters, so scope the request with `eventSource`,
-                    `eventUei`, `id` or another `OnmsEvent` property.
+                    other than `ack` are read as filters on `OnmsEvent` property names such as `eventSource`,
+                    `eventUei` and `id`.
                     `ack` is optional here and defaults to `false`, and only the exact string `true` acknowledges.
                     The default limit of 10 applies, so a large match set is processed one page at a time.
                     A body that matches nothing still returns 204.""",
@@ -479,17 +479,17 @@ public class EventRestService extends OnmsRestService {
             summary = "Send an event",
             description = """
                     Hand an event to eventd. `source` defaults to `ReST` and `time` to now when they are absent.
-                    The response is 202 as soon as the event is queued, so it says nothing about whether eventd
-                    accepted or persisted it. Bean validation runs first, but only `source` and `time` carry
-                    constraints and both are defaulted, so a body without a `uei` is still accepted.
+                    The 202 is returned as soon as the event is queued, before eventd accepts or persists it. Bean
+                    validation runs first, but only `source` and `time` carry constraints and both are defaulted,
+                    so a body without a `uei` returns 202.
                     Whether the event produces an alarm depends on the matching event definition, or on an
                     `alarm-data` element supplied in the body.
-                    JSON and XML are not interchangeable. In XML the child elements have to appear in schema
-                    order (`uei`, `source`, `nodeid`, `time`, `host`, `interface`, `snmphost`, `service`, `snmp`,
-                    `parms`, `descr`, `logmsg`, `severity`, and so on) and the description element is `descr`, not
-                    `description`. In JSON the `logmsg` and parameter `value` bodies are carried in a field named
-                    `value`, since Jackson maps the `@XmlValue` field to that name. Getting either wrong is a
-                    500.""",
+                    In XML the child elements have to appear in schema order (`uei`, `source`, `nodeid`, `time`,
+                    `host`, `interface`, `snmphost`, `service`, `snmp`, `parms`, `descr`, `logmsg`, `severity`, and
+                    so on) and the description element is `descr`, not `description`. In JSON the `logmsg` and
+                    parameter `value` bodies are carried in a field named `value`, since Jackson maps the
+                    `@XmlValue` field to that name. Getting either wrong is a 500.
+                    `application/atom+xml` is also consumed and is unmarshalled as the same XML document.""",
             operationId = "publishEventV1"
     )
     @RequestBody(required = true, description = "The event to send.",
@@ -511,6 +511,23 @@ public class EventRestService extends OnmsRestService {
                       ]
                     }""")),
                     @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = org.opennms.netmgt.xml.event.Event.class),
+                            examples = @ExampleObject(value = """
+                    <event>
+                      <uei>uei.opennms.org/internal/capsd/snmpConflictsWithDb</uei>
+                      <source>ReST</source>
+                      <time>2026-08-26T00:00:00-04:00</time>
+                      <parms>
+                        <parm>
+                          <parmName>probe</parmName>
+                          <value type="string" encoding="text">1</value>
+                        </parm>
+                      </parms>
+                      <descr>Probe event</descr>
+                      <logmsg dest="logndisplay">Probe event</logmsg>
+                      <severity>Warning</severity>
+                    </event>""")),
+                    @Content(mediaType = MediaType.APPLICATION_ATOM_XML,
                             schema = @Schema(implementation = org.opennms.netmgt.xml.event.Event.class),
                             examples = @ExampleObject(value = """
                     <event>

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/EventRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/EventRestService.java
@@ -45,6 +45,14 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
@@ -55,6 +63,7 @@ import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.model.OnmsEvent;
 import org.opennms.netmgt.model.OnmsEventCollection;
 import org.opennms.web.rest.support.MultivaluedMapImpl;
+import org.opennms.web.rest.v1.model.AckOnlyForm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -89,7 +98,44 @@ public class EventRestService extends OnmsRestService {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Path("{eventId}")
     @Transactional
-    public OnmsEvent getEvent(@PathParam("eventId") final Long eventId) {
+    @Operation(
+            summary = "Get an event",
+            description = """
+                    Return one persisted event by id.
+                    `time` and `createTime` are epoch milliseconds in JSON and ISO-8601 strings in XML, whatever the
+                    schema says.""",
+            operationId = "getEventV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The event.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsEvent.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "id": 55273,
+                      "uei": "uei.opennms.org/internal/capsd/snmpConflictsWithDb",
+                      "time": 1787716800000,
+                      "createTime": 1787727510202,
+                      "source": "ReST",
+                      "severity": "WARNING",
+                      "description": "Probe event",
+                      "logMessage": "Probe event",
+                      "log": "Y",
+                      "display": "Y",
+                      "serviceType": null,
+                      "ifIndex": null,
+                      "parameters": [
+                        { "name": "probe", "value": "1", "type": "string" }
+                      ]
+                    }"""))),
+            @ApiResponse(responseCode = "404", description = "No event with that id, or the path segment is not an integer.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Event object 99999999 was not found.")))
+    })
+    public OnmsEvent getEvent(
+            @Parameter(description = "Event id.", example = "55273", required = true)
+            @PathParam("eventId") final Long eventId) {
         final OnmsEvent e = m_eventDao.get(eventId);
         if (e == null) {
             throw getException(Status.NOT_FOUND, "Event object {} was not found.", Long.toString(eventId));
@@ -106,6 +152,18 @@ public class EventRestService extends OnmsRestService {
     @Produces(MediaType.TEXT_PLAIN)
     @Path("count")
     @Transactional
+    @Operation(
+            summary = "Count all events",
+            description = "Return the total number of event rows as a plain-text integer. Query parameters are "
+                    + "ignored, so this is not a count of a filtered set.",
+            operationId = "getEventCountV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The event count.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "55420")))
+    })
     public String getCount() {
         return Integer.toString(m_eventDao.countAll());
     }
@@ -121,6 +179,51 @@ public class EventRestService extends OnmsRestService {
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
+    @Operation(
+            summary = "Search events",
+            description = """
+                    Return events matching the query parameters, oldest `eventTime` first unless `orderBy` says
+                    otherwise.
+                    Filters are `OnmsEvent` property names, so they are `eventUei`, `eventSource` and
+                    `eventSeverity` rather than the `uei`, `source` and `severity` spellings the response uses.
+                    `node.id`, `node.label`, `ipInterface.*`, `snmpInterface.*` and `serviceType.*` are reachable
+                    through their aliases. `limit` (default 10), `offset`, `orderBy`, `order`, `match` and
+                    `comparator` shape the result. A filter name that is not a property of the entity fails with
+                    500.""",
+            operationId = "getEventsV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The matching events.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsEventCollection.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 3,
+                      "count": 1,
+                      "offset": 0,
+                      "event": [ {
+                          "id": 55273,
+                          "uei": "uei.opennms.org/internal/capsd/snmpConflictsWithDb",
+                          "time": 1787716800000,
+                          "createTime": 1787727510202,
+                          "source": "ReST",
+                          "severity": "WARNING",
+                          "description": "Probe event",
+                          "logMessage": "Probe event",
+                          "log": "Y",
+                          "display": "Y",
+                          "serviceType": null,
+                          "ifIndex": null,
+                          "parameters": [
+                            { "name": "probe", "value": "1", "type": "string" }
+                          ]
+                        } ]
+                    }"""))),
+            @ApiResponse(responseCode = "500", description = "A query parameter is not a property of the event entity.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Unknown entity: null; nested exception is org.hibernate.HibernateException: Unknown entity: null")))
+    })
     public OnmsEventCollection getEvents(@Context final UriInfo uriInfo) throws ParseException {
         final CriteriaBuilder builder = getCriteriaBuilder(uriInfo.getQueryParameters());
         builder.orderBy("eventTime").asc();
@@ -143,6 +246,54 @@ public class EventRestService extends OnmsRestService {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Path("between")
     @Transactional
+    @Operation(
+            summary = "Search events in a time range",
+            description = """
+                    Return events whose timestamp column falls between `begin` and `end`. `begin` defaults to the
+                    epoch and `end` to now, and `column` defaults to `eventTime`.
+                    Both bounds are parsed as ISO-8601 and a timezone offset is required, so
+                    `2026-08-26T00:00:00-04:00` and `2026-08-26T00:00:00Z` parse while
+                    `2026-08-26T00:00:00` is rejected with 400. Fractional seconds are optional.
+                    Remaining query parameters are applied as event filters exactly as on `GET /events`, and
+                    `match` is forced to `all`. A `column` that is not a property of the entity fails with 500.""",
+            operationId = "getEventsBetweenV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The matching events.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsEventCollection.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 3,
+                      "count": 1,
+                      "offset": 0,
+                      "event": [ {
+                          "id": 55273,
+                          "uei": "uei.opennms.org/internal/capsd/snmpConflictsWithDb",
+                          "time": 1787716800000,
+                          "createTime": 1787727510202,
+                          "source": "ReST",
+                          "severity": "WARNING",
+                          "description": "Probe event",
+                          "logMessage": "Probe event",
+                          "log": "Y",
+                          "display": "Y",
+                          "serviceType": null,
+                          "ifIndex": null,
+                          "parameters": [
+                            { "name": "probe", "value": "1", "type": "string" }
+                          ]
+                        } ]
+                    }"""))),
+            @ApiResponse(responseCode = "400", description = "`begin` or `end` could not be parsed.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Can't parse start date"))),
+            @ApiResponse(responseCode = "500", description = "`column` or another query parameter is not a property of the event entity.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Unknown entity: null; nested exception is org.hibernate.HibernateException: Unknown entity: null")))
+    })
     public OnmsEventCollection getEventsBetween(@Context final UriInfo uriInfo) throws ParseException {
         final MultivaluedMap<String, String> params = uriInfo.getQueryParameters();
 
@@ -212,7 +363,34 @@ public class EventRestService extends OnmsRestService {
     @Path("{eventId}")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Transactional
-    public Response updateEvent(@Context final SecurityContext securityContext, @PathParam("eventId") final Long eventId, @FormParam("ack") final Boolean ack) {
+    @Operation(
+            summary = "Acknowledge or unacknowledge one event",
+            description = """
+                    Set or clear the acknowledgement on one event. The acknowledging user is taken from the
+                    authenticated principal and cannot be overridden.
+                    `ack` has to be present. Any value other than `true` parses as `false` and unacknowledges the
+                    event.""",
+            operationId = "updateEventV1"
+    )
+    @RequestBody(required = true, description = "The acknowledge flag.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(implementation = AckOnlyForm.class),
+                    examples = @ExampleObject(value = "ack=true")))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The event was updated."),
+            @ApiResponse(responseCode = "400", description = "`ack` was absent.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Must supply the 'ack' parameter, set to either 'true' or 'false'"))),
+            @ApiResponse(responseCode = "404", description = "No event with that id.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Event object 99999999 was not found."))),
+            @ApiResponse(responseCode = "415", description = "The body was not `application/x-www-form-urlencoded`.")
+    })
+    public Response updateEvent(@Context final SecurityContext securityContext,
+            @Parameter(description = "Event id.", example = "55273", required = true)
+            @PathParam("eventId") final Long eventId, @FormParam("ack") final Boolean ack) {
         writeLock();
 
         try {
@@ -238,6 +416,29 @@ public class EventRestService extends OnmsRestService {
     @PUT
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Transactional
+    @Operation(
+            summary = "Acknowledge or unacknowledge matching events",
+            description = """
+                    Set or clear the acknowledgement on every event matching the filters in the form body. Fields
+                    other than `ack` are read as event filters, so scope the request with `eventSource`,
+                    `eventUei`, `id` or another `OnmsEvent` property.
+                    `ack` is optional here and defaults to `false`, and only the exact string `true` acknowledges.
+                    The default limit of 10 applies, so a large match set is processed one page at a time.
+                    A body that matches nothing still returns 204.""",
+            operationId = "updateEventsV1"
+    )
+    @RequestBody(required = true, description = "The acknowledge flag, plus the filters selecting the events.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(implementation = AckOnlyForm.class),
+                    examples = @ExampleObject(value = "ack=true&eventSource=ReST")))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The request was processed, whether or not anything matched."),
+            @ApiResponse(responseCode = "415", description = "The body was not `application/x-www-form-urlencoded`."),
+            @ApiResponse(responseCode = "500", description = "A form parameter is not a property of the event entity.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Unknown entity: null; nested exception is org.hibernate.HibernateException: Unknown entity: null")))
+    })
     public Response updateEvents(@Context final SecurityContext securityContext, final MultivaluedMapImpl formProperties) {
         writeLock();
 
@@ -274,6 +475,70 @@ public class EventRestService extends OnmsRestService {
     @POST
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
+    @Operation(
+            summary = "Send an event",
+            description = """
+                    Hand an event to eventd. `source` defaults to `ReST` and `time` to now when they are absent.
+                    The response is 202 as soon as the event is queued, so it says nothing about whether eventd
+                    accepted or persisted it. Bean validation runs first, but only `source` and `time` carry
+                    constraints and both are defaulted, so a body without a `uei` is still accepted.
+                    Whether the event produces an alarm depends on the matching event definition, or on an
+                    `alarm-data` element supplied in the body.
+                    JSON and XML are not interchangeable. In XML the child elements have to appear in schema
+                    order (`uei`, `source`, `nodeid`, `time`, `host`, `interface`, `snmphost`, `service`, `snmp`,
+                    `parms`, `descr`, `logmsg`, `severity`, and so on) and the description element is `descr`, not
+                    `description`. In JSON the `logmsg` and parameter `value` bodies are carried in a field named
+                    `value`, since Jackson maps the `@XmlValue` field to that name. Getting either wrong is a
+                    500.""",
+            operationId = "publishEventV1"
+    )
+    @RequestBody(required = true, description = "The event to send.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = org.opennms.netmgt.xml.event.Event.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "uei": "uei.opennms.org/internal/capsd/snmpConflictsWithDb",
+                      "source": "ReST",
+                      "descr": "Probe event",
+                      "logmsg": { "dest": "logndisplay", "value": "Probe event" },
+                      "severity": "Warning",
+                      "parms": [
+                        {
+                          "parmName": "probe",
+                          "value": { "type": "string", "encoding": "text", "value": "1" }
+                        }
+                      ]
+                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = org.opennms.netmgt.xml.event.Event.class),
+                            examples = @ExampleObject(value = """
+                    <event>
+                      <uei>uei.opennms.org/internal/capsd/snmpConflictsWithDb</uei>
+                      <source>ReST</source>
+                      <time>2026-08-26T00:00:00-04:00</time>
+                      <parms>
+                        <parm>
+                          <parmName>probe</parmName>
+                          <value type="string" encoding="text">1</value>
+                        </parm>
+                      </parms>
+                      <descr>Probe event</descr>
+                      <logmsg dest="logndisplay">Probe event</logmsg>
+                      <severity>Warning</severity>
+                    </event>"""))
+            })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "202", description = "The event was handed to eventd."),
+            @ApiResponse(responseCode = "400", description = "Bean validation failed, or the event could not be sent.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "1 errors found while validating event."))),
+            @ApiResponse(responseCode = "500", description = "The body could not be unmarshalled: an unknown field, or XML elements out of schema order.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Unrecognized field \"description\" (Class org.opennms.netmgt.xml.event.Event), not marked as ignorable")))
+    })
     public Response publishEvent(final org.opennms.netmgt.xml.event.Event event) {
         if (event.getSource() == null) {
             event.setSource("ReST");

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/EventRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/EventRestService.java
@@ -129,7 +129,7 @@ public class EventRestService extends OnmsRestService {
                       ]
                     }"""))),
             @ApiResponse(responseCode = "404", description = "No event with that id, or the path segment is not an integer.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Event object 99999999 was not found.")))
     })
@@ -220,7 +220,7 @@ public class EventRestService extends OnmsRestService {
                         } ]
                     }"""))),
             @ApiResponse(responseCode = "500", description = "A query parameter is not a property of the event entity.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Unknown entity: null; nested exception is org.hibernate.HibernateException: Unknown entity: null")))
     })
@@ -286,11 +286,11 @@ public class EventRestService extends OnmsRestService {
                         } ]
                     }"""))),
             @ApiResponse(responseCode = "400", description = "`begin` or `end` could not be parsed.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Can't parse start date"))),
             @ApiResponse(responseCode = "500", description = "`column` or another query parameter is not a property of the event entity.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Unknown entity: null; nested exception is org.hibernate.HibernateException: Unknown entity: null")))
     })
@@ -379,11 +379,11 @@ public class EventRestService extends OnmsRestService {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "The event was updated."),
             @ApiResponse(responseCode = "400", description = "`ack` was absent.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Must supply the 'ack' parameter, set to either 'true' or 'false'"))),
             @ApiResponse(responseCode = "404", description = "No event with that id.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Event object 99999999 was not found."))),
             @ApiResponse(responseCode = "415", description = "The body was not `application/x-www-form-urlencoded`.")
@@ -435,7 +435,7 @@ public class EventRestService extends OnmsRestService {
             @ApiResponse(responseCode = "204", description = "The request was processed, whether or not anything matched."),
             @ApiResponse(responseCode = "415", description = "The body was not `application/x-www-form-urlencoded`."),
             @ApiResponse(responseCode = "500", description = "A form parameter is not a property of the event entity.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Unknown entity: null; nested exception is org.hibernate.HibernateException: Unknown entity: null")))
     })
@@ -547,12 +547,13 @@ public class EventRestService extends OnmsRestService {
             })
     @ApiResponses(value = {
             @ApiResponse(responseCode = "202", description = "The event was handed to eventd."),
-            @ApiResponse(responseCode = "400", description = "Bean validation failed, or the event could not be sent.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+            @ApiResponse(responseCode = "400", description = "Bean validation failed, or the event could not be sent. The handler's catch block "
+                    + "rewraps the inner error, so the body is the generic reason phrase rather than the validation message.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "1 errors found while validating event."))),
+                            examples = @ExampleObject(value = "HTTP 400 Bad Request"))),
             @ApiResponse(responseCode = "500", description = "The body could not be unmarshalled: an unknown field, or XML elements out of schema order.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Unrecognized field \"description\" (Class org.opennms.netmgt.xml.event.Event), not marked as ignorable")))
     })

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/FilesystemRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/FilesystemRestService.java
@@ -54,6 +54,15 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
@@ -72,7 +81,23 @@ import com.google.common.collect.ImmutableSet;
 
 @Component
 @Path("filesystem")
-@Tag(name = "FileSystem", description = "File System API")
+@Tag(name = "FileSystem", description = """
+        File System API: read and write the configuration files under the OpenNMS `etc` directory, addressed
+        by their path relative to that directory.
+
+        Every operation requires `ROLE_FILESYSTEM_EDITOR`. That is enforced twice, by the servlet security
+        configuration and again in each handler, so a caller without the role gets 403 from the container
+        before the handler runs. `ROLE_ADMIN` on its own is not enough. `users.xml` is further restricted and
+        needs `ROLE_ADMIN` as well.
+
+        Only files whose extension is one of the supported set are reachable, and only inside `etc`, up to
+        four levels deep. A name that resolves outside `etc`, or whose extension is not supported, is
+        rejected with 400.
+
+        Writing is a whole-file replace, not a patch, and an existing file is overwritten without a version
+        check. `.xml` files are checked for well-formedness before the replace, which catches a truncated
+        upload but not a schema violation: a well-formed file that the daemon cannot load is still written.
+        Writes do not reload anything; the affected daemon has to be told separately.""")
 public class FilesystemRestService {
     private static final Logger LOG = LoggerFactory.getLogger(FilesystemRestService.class);
 
@@ -104,7 +129,37 @@ public class FilesystemRestService {
     @GET
     @Path("/")
     @Produces(MediaType.APPLICATION_JSON)
-    public List<String> getFiles(@QueryParam("changedFilesOnly") boolean changedFilesOnly, @Context SecurityContext securityContext) {
+    @Operation(
+            summary = "List editable configuration files",
+            description = """
+        List the configuration files under `etc` that this API can read or write, as paths relative to `etc`,
+        sorted. The walk goes four levels deep and follows symbolic links, and only files with a supported
+        extension are listed.
+
+        `users.xml` is listed only for callers that also hold `ROLE_ADMIN`.
+
+        With `changedFilesOnly=true` the list is narrowed to files that differ from the pristine copy shipped
+        in `share/etc-pristine`, ignoring line-ending differences. A file with no pristine counterpart counts
+        as changed, so locally added files are included.""",
+            operationId = "getEditableFiles"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The file paths, relative to `etc`.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            array = @ArraySchema(schema = @Schema(type = "string")),
+                            examples = @ExampleObject(value = """
+                    [
+                      "collectd-configuration.xml",
+                      "discovery-configuration.xml",
+                      "opennms.properties",
+                      "poller-configuration.xml"
+                    ]"""))),
+            @ApiResponse(responseCode = "403", description = "The caller does not hold `ROLE_FILESYSTEM_EDITOR`.")
+    })
+    public List<String> getFiles(
+            @Parameter(description = "When true, list only files that differ from their `share/etc-pristine` counterpart, or that have none.",
+                    example = "false")
+            @QueryParam("changedFilesOnly") boolean changedFilesOnly, @Context SecurityContext securityContext) {
         if (!securityContext.isUserInRole(Authentication.ROLE_FILESYSTEM_EDITOR)) {
             throw new ForbiddenException("FILESYSTEM EDITOR role is required for enumerating files.");
         }
@@ -139,7 +194,31 @@ public class FilesystemRestService {
     @GET
     @Path("/help")
     @Produces("text/markdown")
-    public InputStream getFileHelp(@QueryParam("f") String fileName, @Context SecurityContext securityContext) {
+    @Operation(
+            summary = "Get the help text for a configuration file",
+            description = """
+        Return the bundled Markdown help for one configuration file, if the distribution ships any. Help is
+        looked up by file name, so a file with no help document produces an empty response body rather than a
+        404.
+
+        The file name still has to pass the same checks as the other operations, so an unsupported extension
+        or a path outside `etc` is rejected with 400 even though nothing is read from `etc`.""",
+            operationId = "getFileHelp"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The Markdown help document, or an empty body when none is bundled.",
+                    content = @Content(mediaType = "text/markdown",
+                            schema = @Schema(type = "string"))),
+            @ApiResponse(responseCode = "400", description = "The name resolves outside `etc`, or its extension is not supported.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Unsupported file extension: passwd"))),
+            @ApiResponse(responseCode = "403", description = "The caller does not hold `ROLE_FILESYSTEM_EDITOR`, or the file is `users.xml` and the caller is not an admin.")
+    })
+    public InputStream getFileHelp(
+            @Parameter(description = "File path relative to `etc`, as listed by `GET /filesystem`.",
+                    required = true, example = "discovery-configuration.xml")
+            @QueryParam("f") String fileName, @Context SecurityContext securityContext) {
         if (!securityContext.isUserInRole(Authentication.ROLE_FILESYSTEM_EDITOR)) {
             throw new ForbiddenException("FILESYSTEM EDITOR role is required for retrieving help.");
         }
@@ -150,6 +229,31 @@ public class FilesystemRestService {
     @GET
     @Path("/extensions")
     @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "List the file extensions this API will handle",
+            description = """
+        List the file extensions the other operations accept, sorted. The set is fixed in the code rather
+        than configurable, and a file whose extension is not in it cannot be read or written here whatever
+        its location.""",
+            operationId = "getSupportedFileExtensions"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The supported extensions.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            array = @ArraySchema(schema = @Schema(type = "string")),
+                            examples = @ExampleObject(value = """
+                    [
+                      "boot",
+                      "bsh",
+                      "cfg",
+                      "dcb",
+                      "drl",
+                      "groovy",
+                      "properties",
+                      "xml"
+                    ]"""))),
+            @ApiResponse(responseCode = "403", description = "The caller does not hold `ROLE_FILESYSTEM_EDITOR`.")
+    })
     public List<String> getSupportedExtensions(@Context SecurityContext securityContext) {
         if (!securityContext.isUserInRole(Authentication.ROLE_FILESYSTEM_EDITOR)) {
             throw new ForbiddenException("FILESYSTEM EDITOR role is required for retrieving supported extensions.");
@@ -161,7 +265,32 @@ public class FilesystemRestService {
 
     @GET
     @Path("/contents")
-    public Response getFileContents(@QueryParam("f") String fileName, @Context SecurityContext securityContext) {
+    @Operation(
+            summary = "Read a configuration file",
+            description = """
+        Return the contents of one configuration file as text, read as UTF-8. The response media type is
+        probed from the file rather than fixed, and `Content-Disposition` carries the bare file name while
+        `Last-Modified` carries the file's timestamp.
+
+        A name that passes the checks but does not exist yields 204 with no body, so 204 is how a missing file
+        is reported rather than 404. Read the file before writing it back: the write is a whole-file replace
+        with no version check.""",
+            operationId = "getFileContents"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The file contents. The media type is probed from the file.",
+                    content = @Content(schema = @Schema(type = "string"))),
+            @ApiResponse(responseCode = "204", description = "The file does not exist. No body."),
+            @ApiResponse(responseCode = "400", description = "The name resolves outside `etc`, or its extension is not supported.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot access files outside of folder! Filename given: ../../passwd"))),
+            @ApiResponse(responseCode = "403", description = "The caller does not hold `ROLE_FILESYSTEM_EDITOR`, or the file is `users.xml` and the caller is not an admin.")
+    })
+    public Response getFileContents(
+            @Parameter(description = "File path relative to `etc`, as listed by `GET /filesystem`.",
+                    required = true, example = "discovery-configuration.xml")
+            @QueryParam("f") String fileName, @Context SecurityContext securityContext) {
         if (!securityContext.isUserInRole(Authentication.ROLE_FILESYSTEM_EDITOR)) {
             throw new ForbiddenException("FILESYSTEM EDITOR role is required for reading files.");
         }
@@ -172,7 +301,44 @@ public class FilesystemRestService {
     @Path("/contents")
     @Produces(MediaType.TEXT_HTML)
     @Consumes(MediaType.MULTIPART_FORM_DATA)
-    public String uploadFile(@QueryParam("f") String fileName,
+    @Operation(
+            summary = "Write a configuration file",
+            description = """
+        Replace the contents of one configuration file with the uploaded part. The part must be named
+        `upload`. The target file is named by the `f` query parameter, not by the part's own filename.
+
+        This is a whole-file replace with no version check: an existing file is overwritten, and a file that
+        does not exist yet is created. Read the current contents first if they matter.
+
+        A `.xml` upload is parsed for well-formedness before the replace, and a parse failure is reported as
+        400 with the target left untouched. The parse is non-validating and external entities are disabled, so
+        a well-formed file that violates its schema is still written.
+
+        Nothing is reloaded. Whatever daemon reads the file has to be told separately, for instance through
+        its own reload endpoint or a `reloadDaemonConfig` event.""",
+            operationId = "uploadFileContents"
+    )
+    @RequestBody(
+            required = true,
+            description = "Multipart form with a single part named `upload` carrying the new file contents.",
+            content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA,
+                    schema = @Schema(type = "string", format = "binary"))
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The file was written. The body is a plain confirmation, despite the `text/html` media type.",
+                    content = @Content(mediaType = MediaType.TEXT_HTML,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Successfully wrote to '/opt/opennms/etc/example.xml'."))),
+            @ApiResponse(responseCode = "400", description = "The name resolves outside `etc`, its extension is not supported, or an `.xml` upload is not well formed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Validation failed: XML document structures must start and end within the same entity."))),
+            @ApiResponse(responseCode = "403", description = "The caller does not hold `ROLE_FILESYSTEM_EDITOR`, or the file is `users.xml` and the caller is not an admin.")
+    })
+    public String uploadFile(
+            @Parameter(description = "File path relative to `etc` to write. Created if it does not exist, overwritten if it does.",
+                    required = true, example = "ApiDoc-probe.xml")
+            @QueryParam("f") String fileName,
                              @Multipart("upload") Attachment attachment,
                              @Context SecurityContext securityContext) throws IOException {
         if (!securityContext.isUserInRole(Authentication.ROLE_FILESYSTEM_EDITOR)) {
@@ -205,7 +371,33 @@ public class FilesystemRestService {
     @DELETE
     @Path("/contents")
     @Produces(MediaType.TEXT_HTML)
-    public String deleteFile(@QueryParam("f") String fileName,
+    @Operation(
+            summary = "Delete a configuration file",
+            description = """
+        Delete one configuration file from `etc`. There is no confirmation step and no backup, and deleting a
+        file the running instance depends on will break it at the next reload or restart.
+
+        A name that passes the checks but does not exist fails with 500 from the underlying delete, not with
+        404.""",
+            operationId = "deleteFileContents"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The file was deleted. The body is a plain confirmation, despite the `text/html` media type.",
+                    content = @Content(mediaType = MediaType.TEXT_HTML,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Successfully deleted to '/opt/opennms/etc/example.xml'."))),
+            @ApiResponse(responseCode = "400", description = "The name resolves outside `etc`, or its extension is not supported.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Unsupported file extension: passwd"))),
+            @ApiResponse(responseCode = "403", description = "The caller does not hold `ROLE_FILESYSTEM_EDITOR`, or the file is `users.xml` and the caller is not an admin."),
+            @ApiResponse(responseCode = "500", description = "The file does not exist, or could not be removed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string")))
+    })
+    public String deleteFile(
+            @Parameter(description = "File path relative to `etc` to delete.", required = true, example = "ApiDoc-probe.xml")
+            @QueryParam("f") String fileName,
                              @Context SecurityContext securityContext) throws IOException {
         if (!securityContext.isUserInRole(Authentication.ROLE_FILESYSTEM_EDITOR)) {
             throw new ForbiddenException("FILESYSTEM EDITOR role is required for deleting file contents.");

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/FilesystemRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/FilesystemRestService.java
@@ -208,10 +208,7 @@ public class FilesystemRestService {
             @ApiResponse(responseCode = "200", description = "The Markdown help document, or an empty body when none is bundled.",
                     content = @Content(mediaType = "text/markdown",
                             schema = @Schema(type = "string"))),
-            @ApiResponse(responseCode = "400", description = "The name resolves outside `etc`, or its extension is not supported.",
-                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
-                            schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "Unsupported file extension: passwd"))),
+            @ApiResponse(responseCode = "400", description = "The name resolves outside `etc`, or its extension is not supported. The body is empty: the message-only exception is mapped without its message."),
             @ApiResponse(responseCode = "403", description = "The caller does not hold `ROLE_FILESYSTEM_EDITOR`, or the file is `users.xml` and the caller is not an admin.")
     })
     public InputStream getFileHelp(
@@ -278,10 +275,7 @@ public class FilesystemRestService {
             @ApiResponse(responseCode = "200", description = "The file contents. The media type is probed from the file.",
                     content = @Content(schema = @Schema(type = "string"))),
             @ApiResponse(responseCode = "204", description = "The file does not exist. No body."),
-            @ApiResponse(responseCode = "400", description = "The name resolves outside `etc`, or its extension is not supported.",
-                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
-                            schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "Cannot access files outside of folder! Filename given: ../../passwd"))),
+            @ApiResponse(responseCode = "400", description = "The name resolves outside `etc`, or its extension is not supported. The body is empty: the message-only exception is mapped without its message."),
             @ApiResponse(responseCode = "403", description = "The caller does not hold `ROLE_FILESYSTEM_EDITOR`, or the file is `users.xml` and the caller is not an admin.")
     })
     public Response getFileContents(
@@ -326,7 +320,7 @@ public class FilesystemRestService {
                     content = @Content(mediaType = MediaType.TEXT_HTML,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Successfully wrote to '/opt/opennms/etc/example.xml'."))),
-            @ApiResponse(responseCode = "400", description = "The name resolves outside `etc`, its extension is not supported, or an `.xml` upload is not well formed.",
+            @ApiResponse(responseCode = "400", description = "An `.xml` upload is not well formed (body as below). A name outside `etc` or an unsupported extension is also a 400, but with an empty body.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Validation failed: XML document structures must start and end within the same entity."))),
@@ -382,10 +376,7 @@ public class FilesystemRestService {
                     content = @Content(mediaType = MediaType.TEXT_HTML,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Successfully deleted to '/opt/opennms/etc/example.xml'."))),
-            @ApiResponse(responseCode = "400", description = "The name resolves outside `etc`, or its extension is not supported.",
-                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
-                            schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "Unsupported file extension: passwd"))),
+            @ApiResponse(responseCode = "400", description = "The name resolves outside `etc`, or its extension is not supported. The body is empty: the message-only exception is mapped without its message."),
             @ApiResponse(responseCode = "403", description = "The caller does not hold `ROLE_FILESYSTEM_EDITOR`, or the file is `users.xml` and the caller is not an admin."),
             @ApiResponse(responseCode = "500", description = "The file does not exist, or could not be removed.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN,

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/FilesystemRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/FilesystemRestService.java
@@ -82,8 +82,8 @@ import com.google.common.collect.ImmutableSet;
 @Component
 @Path("filesystem")
 @Tag(name = "FileSystem", description = """
-        File System API: read and write the configuration files under the OpenNMS `etc` directory, addressed
-        by their path relative to that directory.
+        Read and write the configuration files under the OpenNMS `etc` directory, addressed by their path
+        relative to that directory.
 
         Every operation requires `ROLE_FILESYSTEM_EDITOR`. That is enforced twice, by the servlet security
         configuration and again in each handler, so a caller without the role gets 403 from the container
@@ -95,9 +95,9 @@ import com.google.common.collect.ImmutableSet;
         rejected with 400.
 
         Writing is a whole-file replace, not a patch, and an existing file is overwritten without a version
-        check. `.xml` files are checked for well-formedness before the replace, which catches a truncated
-        upload but not a schema violation: a well-formed file that the daemon cannot load is still written.
-        Writes do not reload anything; the affected daemon has to be told separately.""")
+        check. `.xml` files are checked for well-formedness before the replace; a well-formed file that the
+        daemon cannot load is still written. Writes do not reload anything; the affected daemon has to be
+        told separately.""")
 public class FilesystemRestService {
     private static final Logger LOG = LoggerFactory.getLogger(FilesystemRestService.class);
 
@@ -197,9 +197,8 @@ public class FilesystemRestService {
     @Operation(
             summary = "Get the help text for a configuration file",
             description = """
-        Return the bundled Markdown help for one configuration file, if the distribution ships any. Help is
-        looked up by file name, so a file with no help document produces an empty response body rather than a
-        404.
+        Return the bundled Markdown help for one configuration file. Help is looked up by file name, and a
+        file with no help document produces an empty response body rather than a 404.
 
         The file name still has to pass the same checks as the other operations, so an unsupported extension
         or a path outside `etc` is rejected with 400 even though nothing is read from `etc`.""",
@@ -233,8 +232,7 @@ public class FilesystemRestService {
             summary = "List the file extensions this API will handle",
             description = """
         List the file extensions the other operations accept, sorted. The set is fixed in the code rather
-        than configurable, and a file whose extension is not in it cannot be read or written here whatever
-        its location.""",
+        than configurable, and a file whose extension is not in it cannot be read or written here.""",
             operationId = "getSupportedFileExtensions"
     )
     @ApiResponses(value = {
@@ -273,8 +271,7 @@ public class FilesystemRestService {
         `Last-Modified` carries the file's timestamp.
 
         A name that passes the checks but does not exist yields 204 with no body, so 204 is how a missing file
-        is reported rather than 404. Read the file before writing it back: the write is a whole-file replace
-        with no version check.""",
+        is reported rather than 404.""",
             operationId = "getFileContents"
     )
     @ApiResponses(value = {
@@ -308,7 +305,7 @@ public class FilesystemRestService {
         `upload`. The target file is named by the `f` query parameter, not by the part's own filename.
 
         This is a whole-file replace with no version check: an existing file is overwritten, and a file that
-        does not exist yet is created. Read the current contents first if they matter.
+        does not exist yet is created.
 
         A `.xml` upload is parsed for well-formedness before the replace, and a parse failure is reported as
         400 with the target left untouched. The parse is non-validating and external entities are disabled, so
@@ -374,8 +371,7 @@ public class FilesystemRestService {
     @Operation(
             summary = "Delete a configuration file",
             description = """
-        Delete one configuration file from `etc`. There is no confirmation step and no backup, and deleting a
-        file the running instance depends on will break it at the next reload or restart.
+        Delete one configuration file from `etc`. There is no confirmation step and no backup.
 
         A name that passes the checks but does not exist fails with 500 from the underlying delete, not with
         404.""",

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ForeignSourceConfigRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ForeignSourceConfigRestService.java
@@ -43,6 +43,12 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.config.api.JaxbListWrapper;
 import org.opennms.netmgt.config.PollerConfig;
@@ -71,7 +77,15 @@ import com.google.common.collect.Lists;
  */
 @Component("foreignSourceConfigRestService")
 @Path("foreignSourcesConfig")
-@Tag(name = "ForeignSourcesConfig", description = "Foreign Sources Config API")
+@Tag(name = "ForeignSourcesConfig", description = """
+        Foreign Sources Config API.
+
+        Read-only lookups that back the provisioning UI: the detector and policy plugin classes this
+        installation can load, the parameters each one accepts, the service names a detector may be bound
+        to, the surveillance categories that exist, and the asset field names a requisition may set.
+
+        These describe what is *available*, not what any one foreign source is configured with. For the
+        configured detectors and policies of a foreign source, use `/foreignSources/{foreignSource}`.""")
 public class ForeignSourceConfigRestService extends OnmsRestService implements InitializingBean {
     private static final Logger LOG = LoggerFactory.getLogger(ForeignSourceConfigRestService.class);
 
@@ -118,6 +132,7 @@ public class ForeignSourceConfigRestService extends OnmsRestService implements I
          */
         @XmlElement(name="plugin")
         @XmlElementWrapper(name="plugins")
+        @Schema(description = "One entry per plugin class that could be loaded and introspected. A class that fails to wrap is logged and skipped, so this can be shorter than the configured plugin list.")
         public List<SimplePluginConfig> getPlugins() {
             return getObjects();
         }
@@ -132,15 +147,18 @@ public class ForeignSourceConfigRestService extends OnmsRestService implements I
 
         /** The name. */
         @XmlAttribute(name="name")
+        @Schema(description = "Display name. For detectors this is the service name the detector registers under; for policies it is the policy's registered label.", example = "SNMP")
         public String name;
 
         /** The plugin class. */
         @XmlAttribute(name="class")
+        @Schema(description = "Fully qualified class name, the value to put in a foreign source definition's detector or policy `class` attribute.", example = "org.opennms.netmgt.provision.detector.snmp.SnmpDetector")
         public String pluginClass;
 
         /** The parameters. */
         @XmlElement(name="parameter")
         @XmlElementWrapper(name="parameters")
+        @Schema(description = "Accepted parameters, required ones first, each group sorted by key.")
         public List<SimplePluginParameter> parameters = new ArrayList<>();
 
         /**
@@ -169,15 +187,18 @@ public class ForeignSourceConfigRestService extends OnmsRestService implements I
 
         /** The key. */
         @XmlAttribute
+        @Schema(description = "Parameter name.", example = "matchBehavior")
         public String key;
 
         /** The required. */
         @XmlAttribute
+        @Schema(description = "Whether the plugin declares the parameter as required.", example = "true")
         public Boolean required;
 
         /** The options. */
         @XmlElement(name="option")
         @XmlElementWrapper(name="options")
+        @Schema(description = "Permitted values, sorted. Empty when the parameter is free-form.", example = "[\"ALL_PARAMETERS\",\"ANY_PARAMETER\",\"NO_PARAMETERS\"]")
         public List<String> options = new ArrayList<>();
 
         /**
@@ -228,6 +249,7 @@ public class ForeignSourceConfigRestService extends OnmsRestService implements I
          * @return the elements
          */
         @XmlElement(name="element")
+        @Schema(description = "The listed names, sorted.", example = "[\"Production\",\"Routers\",\"Servers\"]")
         public List<String> getElements() {
             List<String> elements = getObjects();
             Collections.sort(elements);
@@ -257,6 +279,58 @@ public class ForeignSourceConfigRestService extends OnmsRestService implements I
     @GET
     @Path("policies")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "List the provisioning policy classes available on this installation",
+            description = """
+                    Each entry carries the policy's display name, its class name, and the parameters it accepts.
+                    Required parameters are listed before optional ones and each group is sorted by key. A
+                    parameter whose value is constrained reports its permitted values in `options`; a free-form
+                    parameter reports an empty `options`. Policy classes that could not be introspected are
+                    logged and left out, so the list can be shorter than the set of registered policies.""",
+            operationId = "getAvailablePolicies")
+    @ApiResponse(responseCode = "200", description = "Available policy classes.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = SimplePluginConfigList.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "plugins": [
+                                        {
+                                          "name": "Match IP Interface",
+                                          "class": "org.opennms.netmgt.provision.persist.policies.MatchingIpInterfacePolicy",
+                                          "parameters": [
+                                            { "key": "action", "required": true,
+                                              "options": [ "DISABLE_COLLECTION", "DISABLE_SNMP_POLL", "DO_NOT_PERSIST", "ENABLE_COLLECTION", "ENABLE_SNMP_POLL", "MANAGE", "UNMANAGE" ] },
+                                            { "key": "matchBehavior", "required": true,
+                                              "options": [ "ALL_PARAMETERS", "ANY_PARAMETER", "NO_PARAMETERS" ] },
+                                            { "key": "hostName", "required": false, "options": [] },
+                                            { "key": "ipAddress", "required": false, "options": [] }
+                                          ]
+                                        }
+                                      ],
+                                      "totalCount": 6,
+                                      "count": 6,
+                                      "offset": 0
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = SimplePluginConfigList.class),
+                            examples = @ExampleObject(value = """
+                                    <plugin-configuration count="6" offset="0" totalCount="6">
+                                      <plugins>
+                                        <plugin name="Match IP Interface" class="org.opennms.netmgt.provision.persist.policies.MatchingIpInterfacePolicy">
+                                          <parameters>
+                                            <parameter key="action" required="true">
+                                              <options>
+                                                <option>DO_NOT_PERSIST</option>
+                                                <option>MANAGE</option>
+                                              </options>
+                                            </parameter>
+                                            <parameter key="ipAddress" required="false"><options/></parameter>
+                                          </parameters>
+                                        </plugin>
+                                      </plugins>
+                                    </plugin-configuration>"""))
+            })
     public SimplePluginConfigList getAvailablePolicies() {
         SimplePluginConfigList plugins = new SimplePluginConfigList();
         Map<String,String> typesMap = m_foreignSourceService.getPolicyTypes();
@@ -281,6 +355,50 @@ public class ForeignSourceConfigRestService extends OnmsRestService implements I
     @GET
     @Path("detectors")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "List the service detector classes available on this installation",
+            description = """
+                    Same shape as `/foreignSourcesConfig/policies`, sorted by detector name. `name` is the
+                    service name the detector is registered under, which is the name that appears on the
+                    monitored service when detection succeeds. Detector classes that could not be introspected
+                    are logged and left out.""",
+            operationId = "getAvailableDetectors")
+    @ApiResponse(responseCode = "200", description = "Available detector classes, sorted by name.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = SimplePluginConfigList.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "plugins": [
+                                        {
+                                          "name": "ActiveMQ",
+                                          "class": "org.opennms.netmgt.provision.detector.jms.ActiveMQDetector",
+                                          "parameters": [
+                                            { "key": "brokerURL", "required": false, "options": [] },
+                                            { "key": "ipMatch", "required": false, "options": [] },
+                                            { "key": "port", "required": false, "options": [] },
+                                            { "key": "timeout", "required": false, "options": [] }
+                                          ]
+                                        }
+                                      ],
+                                      "totalCount": 44,
+                                      "count": 44,
+                                      "offset": 0
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = SimplePluginConfigList.class),
+                            examples = @ExampleObject(value = """
+                                    <plugin-configuration count="44" offset="0" totalCount="44">
+                                      <plugins>
+                                        <plugin name="ActiveMQ" class="org.opennms.netmgt.provision.detector.jms.ActiveMQDetector">
+                                          <parameters>
+                                            <parameter key="brokerURL" required="false"><options/></parameter>
+                                            <parameter key="port" required="false"><options/></parameter>
+                                          </parameters>
+                                        </plugin>
+                                      </plugins>
+                                    </plugin-configuration>"""))
+            })
     public SimplePluginConfigList getAvailableDetectors() {
         SimplePluginConfigList plugins = new SimplePluginConfigList();
         Map<String, Class<?>> detectorMap = m_foreignSourceService.getDetectorTypes();
@@ -333,7 +451,39 @@ public class ForeignSourceConfigRestService extends OnmsRestService implements I
     @GET
     @Path("services/{groupName}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    public ElementList getServices(@PathParam("groupName") String groupName) {
+    @Operation(
+            summary = "List the service names that may be bound to a requisition's interfaces",
+            description = """
+                    The union of the service monitors configured in `poller-configuration.xml`, the services
+                    configured in `collectd-configuration.xml`, the detector names on the named foreign source,
+                    and the service types already present in the database. The result is sorted and
+                    de-duplicated.
+
+                    An unknown `groupName` is not reported as an error: the foreign source lookup falls back to
+                    the default definition, so the response is still a 200 and simply carries the default
+                    definition's detector names.""",
+            operationId = "getForeignSourceConfigServices")
+    @ApiResponse(responseCode = "200", description = "Service names, sorted.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ElementList.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "totalCount": 43,
+                                      "count": 43,
+                                      "offset": 0,
+                                      "element": [ "ActiveMQ", "DNS", "HTTP", "HTTPS", "ICMP", "SNMP", "SSH", "StrafePing" ]
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = ElementList.class),
+                            examples = @ExampleObject(value = """
+                                    <elements count="43" offset="0" totalCount="43">
+                                      <element>ActiveMQ</element>
+                                      <element>ICMP</element>
+                                      <element>SNMP</element>
+                                    </elements>"""))
+            })
+    public ElementList getServices(@Parameter(required = true, description = "Foreign source (provisioning group) name whose detector names are folded into the list.", example = "selfmonitor") @PathParam("groupName") String groupName) {
         ElementList elements = new ElementList(m_pollerConfig.getServiceMonitorNames());
         m_collectdConfigFactory.getCollectors().forEach(c -> {
             if (!elements.contains(c.getService())) {
@@ -370,6 +520,34 @@ public class ForeignSourceConfigRestService extends OnmsRestService implements I
     @GET
     @Path("assets")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "List the asset field names a requisition may set",
+            description = """
+                    Derived from the bean properties of the node asset record, sorted, with `id`, `class`,
+                    `geolocation` and `node` removed. These are the names accepted as the `name` of a
+                    requisition asset, for example in
+                    `POST /requisitions/{foreignSource}/nodes/{foreignId}/assets`.""",
+            operationId = "getForeignSourceConfigAssets")
+    @ApiResponse(responseCode = "200", description = "Asset field names, sorted.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ElementList.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "totalCount": 65,
+                                      "count": 65,
+                                      "offset": 0,
+                                      "element": [ "address1", "building", "category", "city", "country", "department", "description", "region", "serialNumber", "vendor" ]
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = ElementList.class),
+                            examples = @ExampleObject(value = """
+                                    <elements count="65" offset="0" totalCount="65">
+                                      <element>building</element>
+                                      <element>city</element>
+                                      <element>region</element>
+                                    </elements>"""))
+            })
     public ElementList getAssets() {
         final List<String> blackList = Lists.newArrayList("id", "class", "geolocation", "node");
         final Collection<String> assets = PropertyUtils.getProperties(new OnmsAssetRecord())
@@ -387,6 +565,33 @@ public class ForeignSourceConfigRestService extends OnmsRestService implements I
     @GET
     @Path("categories")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "List the surveillance categories that exist",
+            description = """
+                    Every category name in the database, sorted. A requisition category does not have to name
+                    one of these: a category on a requisitioned node is created on import if it does not yet
+                    exist, so this is the list of categories already known rather than the set of permitted
+                    values.""",
+            operationId = "getForeignSourceConfigCategories")
+    @ApiResponse(responseCode = "200", description = "Category names, sorted.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ElementList.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "totalCount": 4,
+                                      "count": 4,
+                                      "offset": 0,
+                                      "element": [ "Development", "Production", "Routers", "Servers" ]
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = ElementList.class),
+                            examples = @ExampleObject(value = """
+                                    <elements count="4" offset="0" totalCount="4">
+                                      <element>Development</element>
+                                      <element>Production</element>
+                                    </elements>"""))
+            })
     public ElementList getCategories() {
         final Set<String> categories = m_categoryDao.findAll().stream()
                 .map(c -> c.getName())

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ForeignSourceConfigRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ForeignSourceConfigRestService.java
@@ -80,12 +80,12 @@ import com.google.common.collect.Lists;
 @Tag(name = "ForeignSourcesConfig", description = """
         Foreign Sources Config API.
 
-        Read-only lookups that back the provisioning UI: the detector and policy plugin classes this
-        installation can load, the parameters each one accepts, the service names a detector may be bound
-        to, the surveillance categories that exist, and the asset field names a requisition may set.
+        Read-only lookups: the detector and policy plugin classes this installation can load, the parameters
+        each one accepts, the service names a detector may be bound to, the surveillance categories that
+        exist, and the asset field names a requisition may set.
 
-        These describe what is *available*, not what any one foreign source is configured with. For the
-        configured detectors and policies of a foreign source, use `/foreignSources/{foreignSource}`.""")
+        These list what is available, not what any one foreign source is configured with. The configured
+        detectors and policies of a foreign source are on `/foreignSources/{foreignSource}`.""")
 public class ForeignSourceConfigRestService extends OnmsRestService implements InitializingBean {
     private static final Logger LOG = LoggerFactory.getLogger(ForeignSourceConfigRestService.class);
 
@@ -460,7 +460,7 @@ public class ForeignSourceConfigRestService extends OnmsRestService implements I
                     de-duplicated.
 
                     An unknown `groupName` is not reported as an error: the foreign source lookup falls back to
-                    the default definition, so the response is still a 200 and simply carries the default
+                    the default definition, so the response is still a 200 and carries the default
                     definition's detector names.""",
             operationId = "getForeignSourceConfigServices")
     @ApiResponse(responseCode = "200", description = "Service names, sorted.",

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ForeignSourceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ForeignSourceRestService.java
@@ -137,9 +137,9 @@ import org.springframework.transaction.annotation.Transactional;
 
         Reads resolve pending first and fall back to deployed. A name with no definition in either
         repository is **not** a 404: the repository synthesizes a copy of the default definition under the
-        requested name, so `GET /foreignSources/{name}` answers 200 for any name. Compare the returned
-        `detectors` and `policies` against `GET /foreignSources/default` if you need to know whether a
-        definition of your own exists.
+        requested name, so `GET /foreignSources/{name}` answers 200 for any name. A response whose
+        `detectors` and `policies` match `GET /foreignSources/default` is a synthesized default rather
+        than a stored definition.
 
         `date-stamp` is epoch milliseconds in JSON and an ISO-8601 timestamp in XML.""")
 public class ForeignSourceRestService extends OnmsRestService {
@@ -219,8 +219,8 @@ public class ForeignSourceRestService extends OnmsRestService {
             description = """
                     Only definitions in the deployed repository, that is, definitions provisiond has written
                     out because the matching requisition was imported. A definition that has been `POST`ed but
-                    whose requisition has not been imported yet does not appear here; use `GET /foreignSources`
-                    for the pending-and-deployed view.
+                    whose requisition has not been imported yet does not appear here; `GET /foreignSources`
+                    returns the pending-and-deployed view.
 
                     The handler declares no `@Produces`, so the response media type is negotiated from the
                     `Accept` header. In JSON the list appears twice, once under `foreignSources` and once under
@@ -417,8 +417,8 @@ public class ForeignSourceRestService extends OnmsRestService {
             summary = "Get a foreign source definition",
             description = """
                     Resolves the pending repository first and falls back to deployed. An unknown name answers
-                    200 with a copy of the default definition renamed to the requested name, so a 200 here is
-                    not evidence that a definition of your own exists.""",
+                    200 with a copy of the default definition renamed to the requested name, so a 200 does not
+                    mean a stored definition exists.""",
             operationId = "getForeignSource")
     @ApiResponse(responseCode = "200", description = "The definition, or the default definition renamed, when the name has none of its own.",
             content = {
@@ -577,8 +577,8 @@ public class ForeignSourceRestService extends OnmsRestService {
             summary = "List the policies on a foreign source definition",
             description = """
                     The `policies` element of the resolved definition. An unknown foreign source name answers
-                    200 with the default definition's policies, which is normally an empty list. In JSON the
-                    list is repeated under `policies` and `policy`.""",
+                    200 with the default definition's policies, an empty list in the shipped default. In JSON
+                    the list is repeated under `policies` and `policy`.""",
             operationId = "getForeignSourcePolicies")
     @ApiResponse(responseCode = "200", description = "The policies.",
             content = {
@@ -875,11 +875,11 @@ public class ForeignSourceRestService extends OnmsRestService {
                     Form-encoded key/value pairs, applied to the resolved definition and saved to the pending
                     repository. Keys are matched against **bean property names**, not the hyphenated XML
                     attribute names: `scanInterval=2d` is applied, `scan-interval=2d` is not. Unrecognized keys
-                    are silently ignored.
+                    are ignored.
 
                     If no key matched a writable property, or the body was empty, nothing is saved and the
                     response is 304 with no body. Detectors and policies are collections and are not settable
-                    this way; use the `/detectors` and `/policies` sub-resources.""",
+                    this way.""",
             operationId = "updateForeignSource")
     @RequestBody(required = true, description = "Form-encoded bean property names and values.",
             content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ForeignSourceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ForeignSourceRestService.java
@@ -39,6 +39,14 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.joda.time.Duration;
 import org.opennms.netmgt.provision.persist.ForeignSourceRepository;
@@ -119,7 +127,21 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component("foreignSourceRestService")
 @Path("foreignSources")
-@Tag(name = "ForeignSources", description = "Foreign Sources API")
+@Tag(name = "ForeignSources", description = """
+        Foreign Sources API.
+
+        A foreign source definition holds the scan interval, the service detectors and the provisioning
+        policies applied to the nodes of the requisition with the same name. Definitions live in two
+        repositories: *pending* (`etc/foreign-sources/pending`), written by `POST` and `PUT`, and *deployed*
+        (`etc/foreign-sources`), written by provisiond when the matching requisition is imported.
+
+        Reads resolve pending first and fall back to deployed. A name with no definition in either
+        repository is **not** a 404: the repository synthesizes a copy of the default definition under the
+        requested name, so `GET /foreignSources/{name}` answers 200 for any name. Compare the returned
+        `detectors` and `policies` against `GET /foreignSources/default` if you need to know whether a
+        definition of your own exists.
+
+        `date-stamp` is epoch milliseconds in JSON and an ISO-8601 timestamp in XML.""")
 public class ForeignSourceRestService extends OnmsRestService {
 	
 	private static final Logger LOG = LoggerFactory.getLogger(ForeignSourceRestService.class);
@@ -141,6 +163,40 @@ public class ForeignSourceRestService extends OnmsRestService {
     @GET
     @Path("default")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get the default foreign source definition",
+            description = """
+                    The definition applied to any requisition that has no definition of its own. This is the
+                    same document that a read of an unknown foreign source name returns, except for the `name`
+                    field.""",
+            operationId = "getDefaultForeignSource")
+    @ApiResponse(responseCode = "200", description = "The default definition.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ForeignSource.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "name": "default",
+                                      "date-stamp": 1787727258567,
+                                      "scan-interval": "1d",
+                                      "detectors": [
+                                        { "name": "ICMP", "class": "org.opennms.netmgt.provision.detector.icmp.IcmpDetector", "parameter": [] },
+                                        { "name": "SNMP", "class": "org.opennms.netmgt.provision.detector.snmp.SnmpDetector", "parameter": [] }
+                                      ],
+                                      "policies": []
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = ForeignSource.class),
+                            examples = @ExampleObject(value = """
+                                    <foreign-source xmlns="http://xmlns.opennms.org/xsd/config/foreign-source" name="default" date-stamp="2026-08-26T02:54:18.567-04:00">
+                                      <scan-interval>1d</scan-interval>
+                                      <detectors>
+                                        <detector name="ICMP" class="org.opennms.netmgt.provision.detector.icmp.IcmpDetector"/>
+                                        <detector name="SNMP" class="org.opennms.netmgt.provision.detector.snmp.SnmpDetector"/>
+                                      </detectors>
+                                      <policies/>
+                                    </foreign-source>"""))
+            })
     public ForeignSource getDefaultForeignSource() {
         readLock();
         try {
@@ -158,6 +214,61 @@ public class ForeignSourceRestService extends OnmsRestService {
      */
     @GET
     @Path("deployed")
+    @Operation(
+            summary = "List the deployed foreign source definitions",
+            description = """
+                    Only definitions in the deployed repository, that is, definitions provisiond has written
+                    out because the matching requisition was imported. A definition that has been `POST`ed but
+                    whose requisition has not been imported yet does not appear here; use `GET /foreignSources`
+                    for the pending-and-deployed view.
+
+                    The handler declares no `@Produces`, so the response media type is negotiated from the
+                    `Accept` header. In JSON the list appears twice, once under `foreignSources` and once under
+                    `foreign-source`, both holding the same objects.""",
+            operationId = "getDeployedForeignSources")
+    @ApiResponse(responseCode = "200", description = "Deployed definitions.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ForeignSourceCollection.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "foreignSources": [
+                                        {
+                                          "name": "selfmonitor",
+                                          "date-stamp": 1787727258593,
+                                          "scan-interval": "1d",
+                                          "detectors": [
+                                            { "name": "ICMP", "class": "org.opennms.netmgt.provision.detector.icmp.IcmpDetector", "parameter": [] }
+                                          ],
+                                          "policies": []
+                                        }
+                                      ],
+                                      "count": 1,
+                                      "foreign-source": [
+                                        {
+                                          "name": "selfmonitor",
+                                          "date-stamp": 1787727258593,
+                                          "scan-interval": "1d",
+                                          "detectors": [
+                                            { "name": "ICMP", "class": "org.opennms.netmgt.provision.detector.icmp.IcmpDetector", "parameter": [] }
+                                          ],
+                                          "policies": []
+                                        }
+                                      ]
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = ForeignSourceCollection.class),
+                            examples = @ExampleObject(value = """
+                                    <foreign-sources xmlns="http://xmlns.opennms.org/xsd/config/foreign-source" count="1">
+                                      <foreign-source name="selfmonitor" date-stamp="2026-08-26T02:54:18.609-04:00">
+                                        <scan-interval>1d</scan-interval>
+                                        <detectors>
+                                          <detector name="ICMP" class="org.opennms.netmgt.provision.detector.icmp.IcmpDetector"/>
+                                        </detectors>
+                                        <policies/>
+                                      </foreign-source>
+                                    </foreign-sources>"""))
+            })
     public ForeignSourceCollection getDeployedForeignSources() {
         readLock();
         try {
@@ -178,6 +289,14 @@ public class ForeignSourceRestService extends OnmsRestService {
     @GET
     @Path("deployed/count")
     @Produces(MediaType.TEXT_PLAIN)
+    @Operation(
+            summary = "Count the deployed foreign source definitions",
+            description = "Plain-text decimal count of the definitions in the deployed repository. The default definition is not counted.",
+            operationId = "getDeployedForeignSourceCount")
+    @ApiResponse(responseCode = "200", description = "The count.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                    schema = @Schema(type = "string", example = "1"),
+                    examples = @ExampleObject(value = "1")))
     public String getDeployedCount() {
         readLock();
         try {
@@ -196,6 +315,52 @@ public class ForeignSourceRestService extends OnmsRestService {
      */
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "List a definition for every active foreign source name",
+            description = """
+                    The union of the active names in the pending and deployed repositories, resolved one at a
+                    time through the pending-then-deployed lookup. A name is active when a requisition or a
+                    foreign source definition exists for it, so a requisition with no definition of its own
+                    still produces an entry here: a copy of the default definition carrying that name. Deleting
+                    a definition therefore does not remove the entry while the requisition still exists.
+
+                    As with `/foreignSources/deployed`, the JSON body repeats the list under `foreignSources`
+                    and `foreign-source`.""",
+            operationId = "getForeignSources")
+    @ApiResponse(responseCode = "200", description = "One definition per active foreign source name.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ForeignSourceCollection.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "foreignSources": [
+                                        {
+                                          "name": "selfmonitor",
+                                          "date-stamp": 1787727258535,
+                                          "scan-interval": "1d",
+                                          "detectors": [
+                                            { "name": "ICMP", "class": "org.opennms.netmgt.provision.detector.icmp.IcmpDetector", "parameter": [] },
+                                            { "name": "SNMP", "class": "org.opennms.netmgt.provision.detector.snmp.SnmpDetector", "parameter": [] }
+                                          ],
+                                          "policies": []
+                                        }
+                                      ],
+                                      "count": 1,
+                                      "foreign-source": [ { "name": "selfmonitor", "date-stamp": 1787727258535, "scan-interval": "1d", "detectors": [], "policies": [] } ]
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = ForeignSourceCollection.class),
+                            examples = @ExampleObject(value = """
+                                    <foreign-sources xmlns="http://xmlns.opennms.org/xsd/config/foreign-source" count="1">
+                                      <foreign-source name="selfmonitor" date-stamp="2026-08-26T02:54:18.535-04:00">
+                                        <scan-interval>1d</scan-interval>
+                                        <detectors>
+                                          <detector name="ICMP" class="org.opennms.netmgt.provision.detector.icmp.IcmpDetector"/>
+                                        </detectors>
+                                        <policies/>
+                                      </foreign-source>
+                                    </foreign-sources>"""))
+            })
     public ForeignSourceCollection getForeignSources() {
         readLock();
         try {
@@ -219,6 +384,17 @@ public class ForeignSourceRestService extends OnmsRestService {
     @GET
     @Path("count")
     @Produces(MediaType.TEXT_PLAIN)
+    @Operation(
+            summary = "Count the active foreign source names",
+            description = """
+                    Plain-text decimal size of the list `GET /foreignSources` returns, that is, the number of
+                    distinct active names across the pending and deployed repositories. This counts names, not
+                    stored definitions, so it includes names that only have a synthesized default definition.""",
+            operationId = "getForeignSourceCount")
+    @ApiResponse(responseCode = "200", description = "The count.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                    schema = @Schema(type = "string", example = "1"),
+                    examples = @ExampleObject(value = "1")))
     public String getTotalCount() {
         readLock();
         try {
@@ -237,7 +413,41 @@ public class ForeignSourceRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    public ForeignSource getForeignSource(@PathParam("foreignSource") String foreignSource) {
+    @Operation(
+            summary = "Get a foreign source definition",
+            description = """
+                    Resolves the pending repository first and falls back to deployed. An unknown name answers
+                    200 with a copy of the default definition renamed to the requested name, so a 200 here is
+                    not evidence that a definition of your own exists.""",
+            operationId = "getForeignSource")
+    @ApiResponse(responseCode = "200", description = "The definition, or the default definition renamed, when the name has none of its own.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ForeignSource.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "name": "selfmonitor",
+                                      "date-stamp": 1787727462179,
+                                      "scan-interval": "1d",
+                                      "detectors": [
+                                        { "name": "ICMP", "class": "org.opennms.netmgt.provision.detector.icmp.IcmpDetector", "parameter": [] },
+                                        { "name": "OpenNMS-JVM", "class": "org.opennms.netmgt.provision.detector.jmx.Jsr160Detector",
+                                          "parameter": [ { "key": "port", "value": "18980" }, { "key": "protocol", "value": "rmi" } ] }
+                                      ],
+                                      "policies": []
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = ForeignSource.class),
+                            examples = @ExampleObject(value = """
+                                    <foreign-source xmlns="http://xmlns.opennms.org/xsd/config/foreign-source" name="selfmonitor" date-stamp="2026-08-26T02:57:42.179-04:00">
+                                      <scan-interval>1d</scan-interval>
+                                      <detectors>
+                                        <detector name="ICMP" class="org.opennms.netmgt.provision.detector.icmp.IcmpDetector"/>
+                                      </detectors>
+                                      <policies/>
+                                    </foreign-source>"""))
+            })
+    public ForeignSource getForeignSource(@Parameter(required = true, description = "Foreign source name.", example = "selfmonitor") @PathParam("foreignSource") String foreignSource) {
         readLock();
         try {
             final ForeignSource fs = getActiveForeignSource(foreignSource);
@@ -259,7 +469,40 @@ public class ForeignSourceRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}/detectors")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    public DetectorCollection getDetectors(@PathParam("foreignSource") String foreignSource) {
+    @Operation(
+            summary = "List the detectors on a foreign source definition",
+            description = """
+                    The `detectors` element of the resolved definition. An unknown foreign source name answers
+                    200 with the default definition's detectors. In JSON the list is repeated under `detectors`
+                    and `detector`.""",
+            operationId = "getForeignSourceDetectors")
+    @ApiResponse(responseCode = "200", description = "The detectors.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DetectorCollection.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "detectors": [
+                                        { "name": "ICMP", "class": "org.opennms.netmgt.provision.detector.icmp.IcmpDetector", "parameter": [] },
+                                        { "name": "SNMP", "class": "org.opennms.netmgt.provision.detector.snmp.SnmpDetector", "parameter": [ { "key": "timeout", "value": "3000" } ] }
+                                      ],
+                                      "count": 2,
+                                      "detector": [
+                                        { "name": "ICMP", "class": "org.opennms.netmgt.provision.detector.icmp.IcmpDetector", "parameter": [] },
+                                        { "name": "SNMP", "class": "org.opennms.netmgt.provision.detector.snmp.SnmpDetector", "parameter": [ { "key": "timeout", "value": "3000" } ] }
+                                      ]
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = DetectorCollection.class),
+                            examples = @ExampleObject(value = """
+                                    <detectors xmlns="http://xmlns.opennms.org/xsd/config/foreign-source" count="2">
+                                      <detector name="ICMP" class="org.opennms.netmgt.provision.detector.icmp.IcmpDetector"/>
+                                      <detector name="SNMP" class="org.opennms.netmgt.provision.detector.snmp.SnmpDetector">
+                                        <parameter key="timeout" value="3000"/>
+                                      </detector>
+                                    </detectors>"""))
+            })
+    public DetectorCollection getDetectors(@Parameter(required = true, description = "Foreign source name.", example = "selfmonitor") @PathParam("foreignSource") String foreignSource) {
         readLock();
         try {
             DetectorCollection retval = new DetectorCollection();
@@ -280,7 +523,34 @@ public class ForeignSourceRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}/detectors/{detector}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    public DetectorWrapper getDetector(@PathParam("foreignSource") String foreignSource, @PathParam("detector") String detector) {
+    @Operation(
+            summary = "Get one detector from a foreign source definition",
+            description = """
+                    Matched on the detector's `name`, not its class. The foreign source name itself cannot 404,
+                    but a detector name that is absent from the resolved definition does.""",
+            operationId = "getForeignSourceDetector")
+    @ApiResponse(responseCode = "200", description = "The detector.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DetectorWrapper.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "name": "SNMP",
+                                      "class": "org.opennms.netmgt.provision.detector.snmp.SnmpDetector",
+                                      "parameter": [ { "key": "timeout", "value": "3000" } ]
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = DetectorWrapper.class),
+                            examples = @ExampleObject(value = """
+                                    <detector xmlns="http://xmlns.opennms.org/xsd/config/foreign-source" name="SNMP" class="org.opennms.netmgt.provision.detector.snmp.SnmpDetector">
+                                      <parameter key="timeout" value="3000"/>
+                                    </detector>"""))
+            })
+    @ApiResponse(responseCode = "404", description = "No detector of that name on the resolved definition.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                    schema = @Schema(type = "string"),
+                    examples = @ExampleObject(value = "Detector NoSuch on foreign source definition 'selfmonitor' not found.")))
+    public DetectorWrapper getDetector(@Parameter(required = true, description = "Foreign source name.", example = "selfmonitor") @PathParam("foreignSource") String foreignSource, @Parameter(required = true, description = "Detector name as it appears in the definition.", example = "SNMP") @PathParam("detector") String detector) {
         readLock();
         try {
             for (final PluginConfig pc : getActiveForeignSource(foreignSource).getDetectors()) {
@@ -303,7 +573,50 @@ public class ForeignSourceRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}/policies")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    public PolicyCollection getPolicies(@PathParam("foreignSource") String foreignSource) {
+    @Operation(
+            summary = "List the policies on a foreign source definition",
+            description = """
+                    The `policies` element of the resolved definition. An unknown foreign source name answers
+                    200 with the default definition's policies, which is normally an empty list. In JSON the
+                    list is repeated under `policies` and `policy`.""",
+            operationId = "getForeignSourcePolicies")
+    @ApiResponse(responseCode = "200", description = "The policies.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = PolicyCollection.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "policies": [
+                                        {
+                                          "name": "no-link-local",
+                                          "class": "org.opennms.netmgt.provision.persist.policies.MatchingIpInterfacePolicy",
+                                          "parameter": [
+                                            { "key": "action", "value": "DO_NOT_PERSIST" },
+                                            { "key": "ipAddress", "value": "~^169\\\\.254\\\\..*" },
+                                            { "key": "matchBehavior", "value": "ALL_PARAMETERS" }
+                                          ]
+                                        }
+                                      ],
+                                      "count": 1,
+                                      "policy": [
+                                        {
+                                          "name": "no-link-local",
+                                          "class": "org.opennms.netmgt.provision.persist.policies.MatchingIpInterfacePolicy",
+                                          "parameter": [ { "key": "action", "value": "DO_NOT_PERSIST" } ]
+                                        }
+                                      ]
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = PolicyCollection.class),
+                            examples = @ExampleObject(value = """
+                                    <policies xmlns="http://xmlns.opennms.org/xsd/config/foreign-source" count="1">
+                                      <policy name="no-link-local" class="org.opennms.netmgt.provision.persist.policies.MatchingIpInterfacePolicy">
+                                        <parameter key="action" value="DO_NOT_PERSIST"/>
+                                        <parameter key="matchBehavior" value="ALL_PARAMETERS"/>
+                                      </policy>
+                                    </policies>"""))
+            })
+    public PolicyCollection getPolicies(@Parameter(required = true, description = "Foreign source name.", example = "selfmonitor") @PathParam("foreignSource") String foreignSource) {
         readLock();
         try {
             PolicyCollection retval = new PolicyCollection();
@@ -324,7 +637,37 @@ public class ForeignSourceRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}/policies/{policy}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    public PolicyWrapper getPolicy(@PathParam("foreignSource") String foreignSource, @PathParam("policy") String policy) {
+    @Operation(
+            summary = "Get one policy from a foreign source definition",
+            description = "Matched on the policy's `name`, not its class. A policy name absent from the resolved definition answers 404.",
+            operationId = "getForeignSourcePolicy")
+    @ApiResponse(responseCode = "200", description = "The policy.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = PolicyWrapper.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "name": "no-link-local",
+                                      "class": "org.opennms.netmgt.provision.persist.policies.MatchingIpInterfacePolicy",
+                                      "parameter": [
+                                        { "key": "action", "value": "DO_NOT_PERSIST" },
+                                        { "key": "ipAddress", "value": "~^169\\\\.254\\\\..*" },
+                                        { "key": "matchBehavior", "value": "ALL_PARAMETERS" }
+                                      ]
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = PolicyWrapper.class),
+                            examples = @ExampleObject(value = """
+                                    <policy xmlns="http://xmlns.opennms.org/xsd/config/foreign-source" name="no-link-local" class="org.opennms.netmgt.provision.persist.policies.MatchingIpInterfacePolicy">
+                                      <parameter key="action" value="DO_NOT_PERSIST"/>
+                                      <parameter key="matchBehavior" value="ALL_PARAMETERS"/>
+                                    </policy>"""))
+            })
+    @ApiResponse(responseCode = "404", description = "No policy of that name on the resolved definition.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                    schema = @Schema(type = "string"),
+                    examples = @ExampleObject(value = "Policy NoSuch on foreign source definition 'selfmonitor' not found.")))
+    public PolicyWrapper getPolicy(@Parameter(required = true, description = "Foreign source name.", example = "selfmonitor") @PathParam("foreignSource") String foreignSource, @Parameter(required = true, description = "Policy name as it appears in the definition.", example = "no-link-local") @PathParam("policy") String policy) {
         readLock();
         try {
             for (final PluginConfig pc : getActiveForeignSource(foreignSource).getPolicies()) {
@@ -347,6 +690,49 @@ public class ForeignSourceRestService extends OnmsRestService {
     @POST
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
+    @Operation(
+            summary = "Add or replace a foreign source definition",
+            description = """
+                    Writes the whole definition to the pending repository under the `name` carried in the body;
+                    the definition is replaced outright rather than merged. The definition takes effect for the
+                    requisition of the same name at the next import, which is also when it is copied into the
+                    deployed repository.
+
+                    `date-stamp` in the body is ignored: the repository stamps the definition on save. The body
+                    is not validated against the available plugin classes, so a detector or policy `class` that
+                    cannot be loaded is accepted here and fails later during the scan.""",
+            operationId = "addForeignSource")
+    @RequestBody(required = true, description = "The complete foreign source definition.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ForeignSource.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "name": "datacenter-east",
+                                      "scan-interval": "1d",
+                                      "detectors": [
+                                        { "name": "ICMP", "class": "org.opennms.netmgt.provision.detector.icmp.IcmpDetector", "parameter": [] },
+                                        { "name": "SNMP", "class": "org.opennms.netmgt.provision.detector.snmp.SnmpDetector", "parameter": [ { "key": "timeout", "value": "3000" } ] }
+                                      ],
+                                      "policies": []
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = ForeignSource.class),
+                            examples = @ExampleObject(value = """
+                                    <foreign-source xmlns="http://xmlns.opennms.org/xsd/config/foreign-source" name="datacenter-east">
+                                      <scan-interval>1d</scan-interval>
+                                      <detectors>
+                                        <detector name="ICMP" class="org.opennms.netmgt.provision.detector.icmp.IcmpDetector"/>
+                                        <detector name="SNMP" class="org.opennms.netmgt.provision.detector.snmp.SnmpDetector">
+                                          <parameter key="timeout" value="3000"/>
+                                        </detector>
+                                      </detectors>
+                                      <policies/>
+                                    </foreign-source>"""))
+            })
+    @ApiResponse(responseCode = "202", description = "Saved to the pending repository. No body; `Location` addresses the saved definition.",
+            headers = @Header(name = "Location", description = "URI of the saved definition.",
+                    schema = @Schema(type = "string", example = "http://localhost:8980/opennms/rest/foreignSources/datacenter-east")))
     public Response addForeignSource(@Context final UriInfo uriInfo, ForeignSource foreignSource) {
         writeLock();
         try {
@@ -369,7 +755,35 @@ public class ForeignSourceRestService extends OnmsRestService {
     @Path("{foreignSource}/detectors")
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
-    public Response addDetector(@Context final UriInfo uriInfo, @PathParam("foreignSource") String foreignSource, DetectorWrapper detector) {
+    @Operation(
+            summary = "Add a detector to a foreign source definition",
+            description = """
+                    Appends the detector to the resolved definition and saves the whole definition to the
+                    pending repository. Because the resolved definition for an unknown name is a copy of the
+                    default, calling this on a name that has no definition of its own creates one seeded with
+                    every default detector plus the one posted.""",
+            operationId = "addForeignSourceDetector")
+    @RequestBody(required = true, description = "The detector to add.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DetectorWrapper.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "name": "SNMP",
+                                      "class": "org.opennms.netmgt.provision.detector.snmp.SnmpDetector",
+                                      "parameter": [ { "key": "timeout", "value": "3000" } ]
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = DetectorWrapper.class),
+                            examples = @ExampleObject(value = """
+                                    <detector xmlns="http://xmlns.opennms.org/xsd/config/foreign-source" name="SNMP" class="org.opennms.netmgt.provision.detector.snmp.SnmpDetector">
+                                      <parameter key="timeout" value="3000"/>
+                                    </detector>"""))
+            })
+    @ApiResponse(responseCode = "202", description = "Saved. No body.",
+            headers = @Header(name = "Location", description = "URI of the added detector.",
+                    schema = @Schema(type = "string", example = "http://localhost:8980/opennms/rest/foreignSources/datacenter-east/detectors/SNMP")))
+    public Response addDetector(@Context final UriInfo uriInfo, @Parameter(required = true, description = "Foreign source name.", example = "datacenter-east") @PathParam("foreignSource") String foreignSource, DetectorWrapper detector) {
         writeLock();
         try {
             LOG.debug("addDetector: Adding detector {}", detector.getName());
@@ -394,7 +808,43 @@ public class ForeignSourceRestService extends OnmsRestService {
     @Path("{foreignSource}/policies")
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
-    public Response addPolicy(@Context final UriInfo uriInfo, @PathParam("foreignSource") String foreignSource, PolicyWrapper policy) {
+    @Operation(
+            summary = "Add a policy to a foreign source definition",
+            description = """
+                    Appends the policy to the resolved definition and saves the whole definition to the pending
+                    repository. As with adding a detector, doing this to a name that has no definition of its
+                    own creates one seeded from the default definition.
+
+                    `GET /foreignSourcesConfig/policies` lists the policy classes available and the parameter
+                    keys and permitted values each accepts. The parameters are not validated here.""",
+            operationId = "addForeignSourcePolicy")
+    @RequestBody(required = true, description = "The policy to add.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = PolicyWrapper.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "name": "no-link-local",
+                                      "class": "org.opennms.netmgt.provision.persist.policies.MatchingIpInterfacePolicy",
+                                      "parameter": [
+                                        { "key": "action", "value": "DO_NOT_PERSIST" },
+                                        { "key": "matchBehavior", "value": "ALL_PARAMETERS" },
+                                        { "key": "ipAddress", "value": "~^169\\\\.254\\\\..*" }
+                                      ]
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = PolicyWrapper.class),
+                            examples = @ExampleObject(value = """
+                                    <policy xmlns="http://xmlns.opennms.org/xsd/config/foreign-source" name="no-link-local" class="org.opennms.netmgt.provision.persist.policies.MatchingIpInterfacePolicy">
+                                      <parameter key="action" value="DO_NOT_PERSIST"/>
+                                      <parameter key="matchBehavior" value="ALL_PARAMETERS"/>
+                                      <parameter key="ipAddress" value="~^169\\.254\\..*"/>
+                                    </policy>"""))
+            })
+    @ApiResponse(responseCode = "202", description = "Saved. No body.",
+            headers = @Header(name = "Location", description = "URI of the added policy.",
+                    schema = @Schema(type = "string", example = "http://localhost:8980/opennms/rest/foreignSources/datacenter-east/policies/no-link-local")))
+    public Response addPolicy(@Context final UriInfo uriInfo, @Parameter(required = true, description = "Foreign source name.", example = "datacenter-east") @PathParam("foreignSource") String foreignSource, PolicyWrapper policy) {
         writeLock();
         try {
             LOG.debug("addPolicy: Adding policy {}", policy.getName());
@@ -419,7 +869,27 @@ public class ForeignSourceRestService extends OnmsRestService {
     @Path("{foreignSource}")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Transactional
-    public Response updateForeignSource(@Context final UriInfo uriInfo, @PathParam("foreignSource") String foreignSource, MultivaluedMapImpl params) {
+    @Operation(
+            summary = "Update scalar fields of a foreign source definition",
+            description = """
+                    Form-encoded key/value pairs, applied to the resolved definition and saved to the pending
+                    repository. Keys are matched against **bean property names**, not the hyphenated XML
+                    attribute names: `scanInterval=2d` is applied, `scan-interval=2d` is not. Unrecognized keys
+                    are silently ignored.
+
+                    If no key matched a writable property, or the body was empty, nothing is saved and the
+                    response is 304 with no body. Detectors and policies are collections and are not settable
+                    this way; use the `/detectors` and `/policies` sub-resources.""",
+            operationId = "updateForeignSource")
+    @RequestBody(required = true, description = "Form-encoded bean property names and values.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(implementation = MultivaluedMapImpl.class),
+                    examples = @ExampleObject(value = "scanInterval=2d")))
+    @ApiResponse(responseCode = "202", description = "At least one property was written and the definition was saved. No body.",
+            headers = @Header(name = "Location", description = "URI of the updated definition.",
+                    schema = @Schema(type = "string", example = "http://localhost:8980/opennms/rest/foreignSources/datacenter-east")))
+    @ApiResponse(responseCode = "304", description = "Empty body, or no key matched a writable property. Nothing was saved.")
+    public Response updateForeignSource(@Context final UriInfo uriInfo, @Parameter(required = true, description = "Foreign source name.", example = "datacenter-east") @PathParam("foreignSource") String foreignSource, MultivaluedMapImpl params) {
         writeLock();
         try {
             ForeignSource fs = getActiveForeignSource(foreignSource);
@@ -461,7 +931,18 @@ public class ForeignSourceRestService extends OnmsRestService {
     @DELETE
     @Path("{foreignSource}")
     @Transactional
-    public Response deletePendingForeignSource(@PathParam("foreignSource") final String foreignSource) {
+    @Operation(
+            summary = "Delete a foreign source definition from the pending repository",
+            description = """
+                    Removes the pending definition file only; the deployed copy, if any, survives. A name with
+                    no pending definition is not reported as an error, the response is still 202.
+
+                    Deleting the definition does not remove the name from `GET /foreignSources` while a
+                    requisition of that name still exists: reads then fall back to a synthesized copy of the
+                    default definition.""",
+            operationId = "deletePendingForeignSource")
+    @ApiResponse(responseCode = "202", description = "Delete attempted. No body. Returned whether or not a pending definition existed.")
+    public Response deletePendingForeignSource(@Parameter(required = true, description = "Foreign source name.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource) {
         writeLock();
         try {
             ForeignSource fs = getForeignSource(foreignSource);
@@ -482,7 +963,19 @@ public class ForeignSourceRestService extends OnmsRestService {
     @DELETE
     @Path("deployed/{foreignSource}")
     @Transactional
-    public Response deleteDeployedForeignSource(@PathParam("foreignSource") final String foreignSource) {
+    @Operation(
+            summary = "Delete a foreign source definition from the deployed repository",
+            description = """
+                    Removes the deployed definition file only; the pending copy, if any, survives. The name
+                    `default` is treated specially: rather than being deleted, the default definition is reset
+                    to the built-in one.
+
+                    A name with no deployed definition is not reported as an error, the response is still 202.
+                    Nodes already provisioned from the matching requisition are untouched; the definition is
+                    only consulted during a scan.""",
+            operationId = "deleteDeployedForeignSource")
+    @ApiResponse(responseCode = "202", description = "Delete attempted. No body. Returned whether or not a deployed definition existed.")
+    public Response deleteDeployedForeignSource(@Parameter(required = true, description = "Foreign source name. `default` resets the built-in default definition instead of deleting it.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource) {
         writeLock();
         try {
             ForeignSource fs = getForeignSource(foreignSource);
@@ -508,7 +1001,16 @@ public class ForeignSourceRestService extends OnmsRestService {
     @DELETE
     @Path("{foreignSource}/detectors/{detector}")
     @Transactional
-    public Response deleteDetector(@PathParam("foreignSource") final String foreignSource, @PathParam("detector") final String detector) {
+    @Operation(
+            summary = "Remove a detector from a foreign source definition",
+            description = """
+                    Removes the first detector whose `name` matches and saves the definition to the pending
+                    repository. If no detector matched, nothing is saved and the response is 304 with no
+                    body.""",
+            operationId = "deleteForeignSourceDetector")
+    @ApiResponse(responseCode = "202", description = "The detector was removed and the definition saved. No body.")
+    @ApiResponse(responseCode = "304", description = "No detector of that name on the resolved definition. Nothing was saved.")
+    public Response deleteDetector(@Parameter(required = true, description = "Foreign source name.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource, @Parameter(required = true, description = "Detector name as it appears in the definition.", example = "SNMP") @PathParam("detector") final String detector) {
         writeLock();
         try {
             ForeignSource fs = getActiveForeignSource(foreignSource);
@@ -536,7 +1038,15 @@ public class ForeignSourceRestService extends OnmsRestService {
     @DELETE
     @Path("{foreignSource}/policies/{policy}")
     @Transactional
-    public Response deletePolicy(@PathParam("foreignSource") final String foreignSource, @PathParam("policy") final String policy) {
+    @Operation(
+            summary = "Remove a policy from a foreign source definition",
+            description = """
+                    Removes the first policy whose `name` matches and saves the definition to the pending
+                    repository. If no policy matched, nothing is saved and the response is 304 with no body.""",
+            operationId = "deleteForeignSourcePolicy")
+    @ApiResponse(responseCode = "202", description = "The policy was removed and the definition saved. No body.")
+    @ApiResponse(responseCode = "304", description = "No policy of that name on the resolved definition. Nothing was saved.")
+    public Response deletePolicy(@Parameter(required = true, description = "Foreign source name.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource, @Parameter(required = true, description = "Policy name as it appears in the definition.", example = "no-link-local") @PathParam("policy") final String policy) {
         writeLock();
         try {
             ForeignSource fs = getActiveForeignSource(foreignSource);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/GraphRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/GraphRestService.java
@@ -38,6 +38,13 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.netmgt.dao.api.GraphDao;
 import org.opennms.netmgt.dao.api.NodeDao;
@@ -63,7 +70,16 @@ import com.google.common.collect.Maps;
  */
 @Component("graphRestService")
 @Path("graphs")
-@Tag(name = "Graphs", description = "Graphs API")
+@Tag(name = "Graphs", description = """
+        Graphs API: the prefabricated graph definitions from `snmp-graph.properties` and the
+        `snmp-graph.properties.d` directory, and which of them apply to a given resource.
+
+        A definition is identified by its name and carries the RRDtool command template used to render it,
+        the columns it needs and the resource types it applies to. These operations only report definitions;
+        rendering happens elsewhere.
+
+        Whether a definition applies to a resource is decided by the attributes the resource actually has, so
+        two nodes of the same type can offer different graphs.""")
 public class GraphRestService extends OnmsRestService {
 
     @Autowired
@@ -78,6 +94,33 @@ public class GraphRestService extends OnmsRestService {
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional(readOnly=true)
+    @Operation(
+            summary = "List all prefabricated graph names",
+            description = """
+        List the names of every prefabricated graph definition known to the running instance, sorted. This is
+        the whole catalogue, not the subset that applies to any particular resource, and on a default install
+        it runs to well over a thousand entries.""",
+            operationId = "getGraphNames"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The graph names.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = GraphNameCollection.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 1763,
+                      "count": 1763,
+                      "offset": 0,
+                      "name": [
+                        "mib2.HCbits",
+                        "http-8080"
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = GraphNameCollection.class))
+                    })
+    })
     public GraphNameCollection getGraphNames() {
         List<String> graphNames = Lists.newLinkedList();
         for (PrefabGraph prefabGraph : m_graphDao.getAllPrefabGraphs()) {
@@ -92,7 +135,53 @@ public class GraphRestService extends OnmsRestService {
     @Path("{graphName}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional(readOnly=true)
-    public PrefabGraph getGraphByName(@PathParam("graphName") final String graphName) {
+    @Operation(
+            summary = "Get one prefabricated graph definition",
+            description = """
+        Return a single graph definition: its title, the columns it reads, the RRDtool command template and
+        the resource types it applies to. `{rrd1}`, `{rrd2}` and similar placeholders in `command` are
+        substituted at render time.""",
+            operationId = "getGraphByName"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The graph definition.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = PrefabGraph.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "name": "mib2.HCbits",
+                      "title": "Bits In/Out (High Speed)",
+                      "columns": [
+                        "ifHCInOctets",
+                        "ifHCOutOctets"
+                      ],
+                      "command": "--title=\"Bits In/Out (High Speed)\" --vertical-label=\"Bits per second\" DEF:octIn={rrd1}:ifHCInOctets:AVERAGE DEF:octOut={rrd2}:ifHCOutOctets:AVERAGE",
+                      "externalValues": [],
+                      "propertiesValues": [],
+                      "order": 4222,
+                      "types": [
+                        "interfaceSnmp"
+                      ],
+                      "description": null,
+                      "width": null,
+                      "height": null,
+                      "suppress": [
+                        "mib2.bits"
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = PrefabGraph.class))
+                    }),
+            @ApiResponse(responseCode = "404", description = "No definition with that name exists.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "No graph with name 'nope' found.")))
+    })
+    public PrefabGraph getGraphByName(
+            @Parameter(description = "Graph definition name, as listed by `GET /graphs`.", required = true,
+                    example = "mib2.HCbits")
+            @PathParam("graphName") final String graphName) {
         try {
             return m_graphDao.getPrefabGraph(graphName);
         } catch (ObjectRetrievalFailureException e) {
@@ -104,7 +193,44 @@ public class GraphRestService extends OnmsRestService {
     @Path("for/{resourceId}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional(readOnly=true)
-    public GraphNameCollection getGraphNamesForResource(@PathParam("resourceId") final String resourceId) {
+    @Operation(
+            summary = "List the graphs that apply to a resource",
+            description = """
+        Return the names of the graph definitions that apply to one resource, decided from the attributes the
+        resource actually has. The path segment is a resource id and has to be percent-encoded, since ids
+        contain `[`, `]` and often `:`. An id whose grammar does not parse fails with 500 rather than 400.""",
+            operationId = "getGraphNamesForResource"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The applicable graph names.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = GraphNameCollection.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 1,
+                      "count": 1,
+                      "offset": 0,
+                      "name": [
+                        "http-8080"
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = GraphNameCollection.class))
+                    }),
+            @ApiResponse(responseCode = "404", description = "The id parses but names no resource.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "No resource with id 'node[99999]' found."))),
+            @ApiResponse(responseCode = "500", description = "The id does not match the resource-id grammar.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Ill-formed resource ID: not-an-id")))
+    })
+    public GraphNameCollection getGraphNamesForResource(
+            @Parameter(description = "Percent-encoded resource id.", required = true,
+                    example = "node[loopback-lab:lb-001].responseTime[127.0.0.1]")
+            @PathParam("resourceId") final String resourceId) {
         OnmsResource resource = m_resourceDao.getResourceById(ResourceId.fromString(resourceId));
         if (resource == null) {
             throw getException(Status.NOT_FOUND, "No resource with id '{}' found.", resourceId);
@@ -126,7 +252,103 @@ public class GraphRestService extends OnmsRestService {
     @Path("fornode/{nodeCriteria}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional(readOnly=true)
-    public GraphResourceDTO getGraphResourcesForNode(@PathParam("nodeCriteria") final String nodeCriteria, @DefaultValue("-1") @QueryParam("depth") final int depth) {
+    @Operation(
+            summary = "Get a node's resource tree with its graph definitions",
+            description = """
+        Return the node's resource tree with each resource decorated with the graph names that apply to it,
+        alongside the full definitions of every graph named anywhere in the tree. That makes one request
+        enough to draw a node's whole graph page.
+
+        `nodeCriteria` is either the database node id or `foreignSource:foreignId`. A criteria string that is
+        neither numeric nor contains a colon fails with 500 while trying to parse it as a number, rather than
+        with 404.
+
+        Definitions are listed once each under `prefab-graphs`, keyed `prefab-graph` inside the envelope,
+        however many resources in the tree reference them.""",
+            operationId = "getGraphResourcesForNode"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The node resource tree and the graph definitions it uses.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = GraphResourceDTO.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "resource": {
+                        "id": "node[loopback-lab:lb-004]",
+                        "label": "loopback-004",
+                        "name": "loopback-lab:lb-004",
+                        "link": "element/node.jsp?node=loopback-lab:lb-004",
+                        "typeLabel": "Node",
+                        "parentId": null,
+                        "graphNames": [],
+                        "children": {
+                          "totalCount": 1,
+                          "count": 1,
+                          "offset": 0,
+                          "resource": [
+                            {
+                              "id": "node[loopback-lab:lb-004].responseTime[127.0.0.4]",
+                              "label": "Response Time for 127.0.0.4",
+                              "name": "127.0.0.4",
+                              "typeLabel": "Response Time",
+                              "parentId": "node[loopback-lab:lb-004]",
+                              "graphNames": [
+                                "http-8080"
+                              ],
+                              "rrdGraphAttributes": {
+                                "http-8080": {
+                                  "name": "http-8080",
+                                  "relativePath": "response/127.0.0.4",
+                                  "rrdFile": "http-8080.rrd"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "prefab-graphs": {
+                        "totalCount": 1,
+                        "count": 1,
+                        "offset": 0,
+                        "prefab-graph": [
+                          {
+                            "name": "http-8080",
+                            "title": "HTTP-8080",
+                            "columns": [
+                              "http-8080"
+                            ],
+                            "order": 7,
+                            "types": [
+                              "responseTime",
+                              "perspectiveResponseTime"
+                            ],
+                            "width": null,
+                            "height": null,
+                            "suppress": []
+                          }
+                        ]
+                      }
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = GraphResourceDTO.class))
+                    }),
+            @ApiResponse(responseCode = "404", description = "No such node, or the node has no resource.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "No node found with criteria 'loopback-lab:nope'."))),
+            @ApiResponse(responseCode = "500", description = "The criteria is neither a node id nor a foreignSource:foreignId pair.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"not-a-node\"")))
+    })
+    public GraphResourceDTO getGraphResourcesForNode(
+            @Parameter(description = "Node database id, or foreignSource:foreignId.", required = true,
+                    example = "loopback-lab:lb-004")
+            @PathParam("nodeCriteria") final String nodeCriteria,
+            @Parameter(description = "How many levels of children to include. The default of -1 walks the whole subtree.",
+                    example = "-1")
+            @DefaultValue("-1") @QueryParam("depth") final int depth) {
         OnmsNode node = m_nodeDao.get(nodeCriteria);
         if (node == null) {
             throw getException(Status.NOT_FOUND, "No node found with criteria '{}'.", nodeCriteria);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/GraphRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/GraphRestService.java
@@ -71,12 +71,12 @@ import com.google.common.collect.Maps;
 @Component("graphRestService")
 @Path("graphs")
 @Tag(name = "Graphs", description = """
-        Graphs API: the prefabricated graph definitions from `snmp-graph.properties` and the
-        `snmp-graph.properties.d` directory, and which of them apply to a given resource.
+        The prefabricated graph definitions from `snmp-graph.properties` and the `snmp-graph.properties.d`
+        directory, and which of them apply to a given resource.
 
         A definition is identified by its name and carries the RRDtool command template used to render it,
-        the columns it needs and the resource types it applies to. These operations only report definitions;
-        rendering happens elsewhere.
+        the columns it needs and the resource types it applies to. These operations report definitions and
+        do not render them.
 
         Whether a definition applies to a resource is decided by the attributes the resource actually has, so
         two nodes of the same type can offer different graphs.""")
@@ -98,8 +98,8 @@ public class GraphRestService extends OnmsRestService {
             summary = "List all prefabricated graph names",
             description = """
         List the names of every prefabricated graph definition known to the running instance, sorted. This is
-        the whole catalogue, not the subset that applies to any particular resource, and on a default install
-        it runs to well over a thousand entries.""",
+        the whole catalogue, not the subset that applies to any particular resource; a default install has
+        well over a thousand entries.""",
             operationId = "getGraphNames"
     )
     @ApiResponses(value = {
@@ -256,8 +256,7 @@ public class GraphRestService extends OnmsRestService {
             summary = "Get a node's resource tree with its graph definitions",
             description = """
         Return the node's resource tree with each resource decorated with the graph names that apply to it,
-        alongside the full definitions of every graph named anywhere in the tree. That makes one request
-        enough to draw a node's whole graph page.
+        alongside the full definitions of every graph named anywhere in the tree.
 
         `nodeCriteria` is either the database node id or `foreignSource:foreignId`. A criteria string that is
         neither numeric nor contains a colon fails with 500 while trying to parse it as a number, rather than

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/GraphRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/GraphRestService.java
@@ -156,7 +156,7 @@ public class GraphRestService extends OnmsRestService {
                         "ifHCInOctets",
                         "ifHCOutOctets"
                       ],
-                      "command": "--title=\"Bits In/Out (High Speed)\" --vertical-label=\"Bits per second\" DEF:octIn={rrd1}:ifHCInOctets:AVERAGE DEF:octOut={rrd2}:ifHCOutOctets:AVERAGE",
+                      "command": "--title=\\"Bits In/Out (High Speed)\\" --vertical-label=\\"Bits per second\\" DEF:octIn={rrd1}:ifHCInOctets:AVERAGE DEF:octOut={rrd2}:ifHCOutOctets:AVERAGE",
                       "externalValues": [],
                       "propertiesValues": [],
                       "order": 4222,

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/GroupRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/GroupRestService.java
@@ -147,7 +147,7 @@ public class GroupRestService extends OnmsRestService {
                       "user": [ "admin" ]
                     }"""))),
             @ApiResponse(responseCode = "404", description = "No such group.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Group with name 'NOC' does not exist.")))
     })
@@ -188,7 +188,7 @@ public class GroupRestService extends OnmsRestService {
             @ApiResponse(responseCode = "201", description = "Group stored. `Location` points at the new group."),
             @ApiResponse(responseCode = "415", description = "The body was not `application/xml`."),
             @ApiResponse(responseCode = "500", description = "The body could not be unmarshalled, or the group could not be saved.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Failed to marshal/unmarshal XML file while unmarshalling an object (OnmsGroup)")))
     })
@@ -225,7 +225,7 @@ public class GroupRestService extends OnmsRestService {
             @ApiResponse(responseCode = "204", description = "The group was updated."),
             @ApiResponse(responseCode = "304", description = "No supplied key matched a writable property, so nothing was written."),
             @ApiResponse(responseCode = "404", description = "No such group.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Group with name 'NOC' does not exist.")))
     })
@@ -269,7 +269,7 @@ public class GroupRestService extends OnmsRestService {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "The group was deleted."),
             @ApiResponse(responseCode = "404", description = "No such group.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Group with name 'NOC' does not exist.")))
     })
@@ -300,11 +300,11 @@ public class GroupRestService extends OnmsRestService {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "The user was added to the group."),
             @ApiResponse(responseCode = "400", description = "The user is already a member, or no such user exists.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "User with name 'jroe' already added or does not exist."))),
             @ApiResponse(responseCode = "404", description = "No such group.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Group with name 'NOC' does not exist.")))
     })
@@ -336,11 +336,11 @@ public class GroupRestService extends OnmsRestService {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "The user was removed from the group."),
             @ApiResponse(responseCode = "400", description = "The user is not a member of the group.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "User with name 'jroe' does not exist in group 'NOC'"))),
             @ApiResponse(responseCode = "404", description = "No such group.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Group with name 'NOC' does not exist.")))
     })
@@ -397,7 +397,7 @@ public class GroupRestService extends OnmsRestService {
                       ]
                     }"""))),
             @ApiResponse(responseCode = "404", description = "No such group.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Group with name 'NOC' does not exist.")))
     })
@@ -432,7 +432,7 @@ public class GroupRestService extends OnmsRestService {
                       "role": [ "ROLE_ADMIN" ]
                     }"""))),
             @ApiResponse(responseCode = "404", description = "No such group, or the user is not a member of it.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "User with name 'jroe' does not exist in group 'NOC'")))
     })
@@ -460,11 +460,11 @@ public class GroupRestService extends OnmsRestService {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "The group was authorized for the category."),
             @ApiResponse(responseCode = "400", description = "The group is already authorized, or no such category exists.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Category with name 'Routers' already added or does not exist."))),
             @ApiResponse(responseCode = "404", description = "No such group.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Group with name 'NOC' does not exist.")))
     })
@@ -496,11 +496,11 @@ public class GroupRestService extends OnmsRestService {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "The authorization was removed."),
             @ApiResponse(responseCode = "400", description = "The group was not authorized for that category, or no such category exists.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Category with name 'Routers' does not exist. Remove failed."))),
             @ApiResponse(responseCode = "404", description = "No such group.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Group with name 'NOC' does not exist.")))
     })
@@ -540,7 +540,7 @@ public class GroupRestService extends OnmsRestService {
                       "name": "Routers"
                     }"""))),
             @ApiResponse(responseCode = "404", description = "No such group, or the group is not authorized for that category.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Category with name 'Switches' does not exist for group 'NOC'.")))
     })
@@ -583,7 +583,7 @@ public class GroupRestService extends OnmsRestService {
                       ]
                     }"""))),
             @ApiResponse(responseCode = "404", description = "No such group.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Group with name 'NOC' does not exist.")))
     })

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/GroupRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/GroupRestService.java
@@ -213,8 +213,8 @@ public class GroupRestService extends OnmsRestService {
                     Apply form-encoded fields to an existing group. Keys are matched against the writable
                     `OnmsGroup` bean properties; a key that matches none is skipped, and a request that wrote
                     nothing comes back as 304.
-                    `users` is a list property that the conversion fills with a single element, so use the
-                    `/groups/{groupName}/users/{userName}` endpoints to change membership.""",
+                    `users` is a list property that the conversion fills with a single element, so a
+                    comma-separated value becomes one element containing the commas.""",
             operationId = "updateGroupV1"
     )
     @RequestBody(required = true, description = "Fields to apply.",
@@ -294,7 +294,7 @@ public class GroupRestService extends OnmsRestService {
             description = """
                     Add one user to a group. The request takes no body.
                     A user name that is already a member and a user name that does not exist in `users.xml` share
-                    the same 400 response, so the message does not say which of the two applies.""",
+                    the same 400 response.""",
             operationId = "addGroupUserV1"
     )
     @ApiResponses(value = {
@@ -371,7 +371,7 @@ public class GroupRestService extends OnmsRestService {
             description = """
                     Return the full user records for the group's members. Names in the group that have no
                     `users.xml` entry are skipped rather than reported.
-                    Unlike the `/users` endpoints, this one does not mask password hashes for non-admin callers.""",
+                    Password hashes are not masked for non-admin callers.""",
             operationId = "listGroupUsersV1"
     )
     @ApiResponses(value = {
@@ -453,8 +453,8 @@ public class GroupRestService extends OnmsRestService {
             summary = "Authorize a group for a category",
             description = """
                     Add the group to a surveillance category's authorized-groups list. The request takes no body.
-                    An already-authorized category and a category that does not exist share the same 400 response,
-                    so the message does not say which of the two applies.""",
+                    An already-authorized category and a category that does not exist share the same 400
+                    response.""",
             operationId = "addGroupCategoryV1"
     )
     @ApiResponses(value = {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/GroupRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/GroupRestService.java
@@ -40,6 +40,14 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.netmgt.model.OnmsCategory;
 import org.opennms.netmgt.model.OnmsCategoryCollection;
@@ -48,6 +56,7 @@ import org.opennms.netmgt.model.OnmsGroupList;
 import org.opennms.netmgt.model.OnmsUser;
 import org.opennms.netmgt.model.OnmsUserList;
 import org.opennms.web.rest.support.MultivaluedMapImpl;
+import org.opennms.web.rest.v1.model.GroupUpdateForm;
 import org.opennms.web.svclayer.api.GroupService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,6 +85,30 @@ public class GroupRestService extends OnmsRestService {
 
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "List groups",
+            description = "Return every group defined in `groups.xml`, sorted by name. The list is not paged and "
+                    + "ignores query parameters.",
+            operationId = "getGroupsV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The configured groups.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsGroupList.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 1,
+                      "count": 1,
+                      "offset": 0,
+                      "group": [
+                        {
+                          "name": "Admin",
+                          "comments": "The administrators",
+                          "user": [ "admin" ]
+                        }
+                      ]
+                    }""")))
+    })
     public OnmsGroupList getGroups() {
         readLock();
         
@@ -98,7 +131,29 @@ public class GroupRestService extends OnmsRestService {
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Path("{groupName}")
-    public OnmsGroup getGroup(@PathParam("groupName") final String groupName) {
+    @Operation(
+            summary = "Get a group",
+            description = "Return one group by name, including its member user names.",
+            operationId = "getGroupByNameV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The group.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsGroup.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "name": "Admin",
+                      "comments": "The administrators",
+                      "user": [ "admin" ]
+                    }"""))),
+            @ApiResponse(responseCode = "404", description = "No such group.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Group with name 'NOC' does not exist.")))
+    })
+    public OnmsGroup getGroup(
+            @Parameter(description = "Group name as it appears in `groups.xml`.", example = "Admin", required = true)
+            @PathParam("groupName") final String groupName) {
         readLock();
         
         try {
@@ -110,6 +165,33 @@ public class GroupRestService extends OnmsRestService {
 
     @POST
     @Consumes(MediaType.APPLICATION_XML)
+    @Operation(
+            summary = "Add or replace a group",
+            description = """
+                    Create a group from an XML `<group>` document. Only `application/xml` is consumed; a JSON body
+                    is rejected with 415.
+                    Posting a name that already exists overwrites that group rather than failing. Member user names
+                    are stored as given and are not checked against `users.xml`.
+                    The response carries no entity; the new group's URI is in the `Location` header.""",
+            operationId = "addGroupV1"
+    )
+    @RequestBody(required = true, description = "The group to store.",
+            content = @Content(mediaType = MediaType.APPLICATION_XML,
+                    schema = @Schema(implementation = OnmsGroup.class),
+                    examples = @ExampleObject(value = """
+                    <group>
+                      <name>NOC</name>
+                      <comments>Second-line network operations</comments>
+                      <user>admin</user>
+                    </group>""")))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Group stored. `Location` points at the new group."),
+            @ApiResponse(responseCode = "415", description = "The body was not `application/xml`."),
+            @ApiResponse(responseCode = "500", description = "The body could not be unmarshalled, or the group could not be saved.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Failed to marshal/unmarshal XML file while unmarshalling an object (OnmsGroup)")))
+    })
     public Response addGroup(@Context final UriInfo uriInfo, final OnmsGroup group) {
         writeLock();
         
@@ -125,7 +207,31 @@ public class GroupRestService extends OnmsRestService {
     @PUT
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("{groupName}")
-    public Response updateGroup(@PathParam("groupName") final String groupName, final MultivaluedMapImpl params) {
+    @Operation(
+            summary = "Update a group",
+            description = """
+                    Apply form-encoded fields to an existing group. Keys are matched against the writable
+                    `OnmsGroup` bean properties; a key that matches none is skipped, and a request that wrote
+                    nothing comes back as 304.
+                    `users` is a list property that the conversion fills with a single element, so use the
+                    `/groups/{groupName}/users/{userName}` endpoints to change membership.""",
+            operationId = "updateGroupV1"
+    )
+    @RequestBody(required = true, description = "Fields to apply.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(implementation = GroupUpdateForm.class),
+                    examples = @ExampleObject(value = "comments=Second-line+network+operations")))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The group was updated."),
+            @ApiResponse(responseCode = "304", description = "No supplied key matched a writable property, so nothing was written."),
+            @ApiResponse(responseCode = "404", description = "No such group.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Group with name 'NOC' does not exist.")))
+    })
+    public Response updateGroup(
+            @Parameter(description = "Group name as it appears in `groups.xml`.", example = "Admin", required = true)
+            @PathParam("groupName") final String groupName, final MultivaluedMapImpl params) {
         writeLock();
         
         try {
@@ -154,7 +260,22 @@ public class GroupRestService extends OnmsRestService {
     
     @DELETE
     @Path("{groupName}")
-    public Response deleteGroup(@PathParam("groupName") final String groupName) {
+    @Operation(
+            summary = "Delete a group",
+            description = "Remove a group from `groups.xml`. Its category authorizations go with it; the member "
+                    + "users are left alone.",
+            operationId = "deleteGroupV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The group was deleted."),
+            @ApiResponse(responseCode = "404", description = "No such group.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Group with name 'NOC' does not exist.")))
+    })
+    public Response deleteGroup(
+            @Parameter(description = "Group name as it appears in `groups.xml`.", example = "Admin", required = true)
+            @PathParam("groupName") final String groupName) {
         writeLock();
         try {
             final OnmsGroup group = getOnmsGroup(groupName);
@@ -168,7 +289,30 @@ public class GroupRestService extends OnmsRestService {
 
     @PUT
     @Path("{groupName}/users/{userName}")
-    public Response addUser(@PathParam("groupName") final String groupName, @PathParam("userName") final String userName) {
+    @Operation(
+            summary = "Add a user to a group",
+            description = """
+                    Add one user to a group. The request takes no body.
+                    A user name that is already a member and a user name that does not exist in `users.xml` share
+                    the same 400 response, so the message does not say which of the two applies.""",
+            operationId = "addGroupUserV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The user was added to the group."),
+            @ApiResponse(responseCode = "400", description = "The user is already a member, or no such user exists.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User with name 'jroe' already added or does not exist."))),
+            @ApiResponse(responseCode = "404", description = "No such group.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Group with name 'NOC' does not exist.")))
+    })
+    public Response addUser(
+            @Parameter(description = "Group name as it appears in `groups.xml`.", example = "Admin", required = true)
+            @PathParam("groupName") final String groupName,
+            @Parameter(description = "User name as it appears in `users.xml`.", example = "admin", required = true)
+            @PathParam("userName") final String userName) {
         writeLock();
         try {
             getOnmsGroup(groupName); // just ensure that group exists
@@ -184,7 +328,27 @@ public class GroupRestService extends OnmsRestService {
 
     @DELETE
     @Path("{groupName}/users/{userName}")
-    public Response removeUser(@PathParam("groupName") final String groupName, @PathParam("userName") final String userName) {
+    @Operation(
+            summary = "Remove a user from a group",
+            description = "Drop one user from a group's member list. The user itself is not deleted.",
+            operationId = "removeGroupUserV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The user was removed from the group."),
+            @ApiResponse(responseCode = "400", description = "The user is not a member of the group.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User with name 'jroe' does not exist in group 'NOC'"))),
+            @ApiResponse(responseCode = "404", description = "No such group.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Group with name 'NOC' does not exist.")))
+    })
+    public Response removeUser(
+            @Parameter(description = "Group name as it appears in `groups.xml`.", example = "Admin", required = true)
+            @PathParam("groupName") final String groupName,
+            @Parameter(description = "User name as it appears in `users.xml`.", example = "admin", required = true)
+            @PathParam("userName") final String userName) {
         writeLock();
         try {
             final OnmsGroup group = getOnmsGroup(groupName);
@@ -202,14 +366,81 @@ public class GroupRestService extends OnmsRestService {
     
     @GET
     @Path("{groupName}/users/")
-    public OnmsUserList listUsersOfGroup(@PathParam("groupName") final String groupName) {
+    @Operation(
+            summary = "List the users in a group",
+            description = """
+                    Return the full user records for the group's members. Names in the group that have no
+                    `users.xml` entry are skipped rather than reported.
+                    Unlike the `/users` endpoints, this one does not mask password hashes for non-admin callers.""",
+            operationId = "listGroupUsersV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The group's members.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsUserList.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 1,
+                      "count": 1,
+                      "offset": 0,
+                      "user": [
+                        {
+                          "user-id": "admin",
+                          "full-name": "Administrator",
+                          "user-comments": "Default administrator, do not delete",
+                          "email": "",
+                          "password": "gU2wmSW7k9v1xg4/MrAsaI+VyddBAhJJt4zPX5SGG0BK+qiASGnJsqM8JOug/aEL",
+                          "passwordSalt": true,
+                          "duty-schedule": [],
+                          "role": [ "ROLE_ADMIN" ]
+                        }
+                      ]
+                    }"""))),
+            @ApiResponse(responseCode = "404", description = "No such group.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Group with name 'NOC' does not exist.")))
+    })
+    public OnmsUserList listUsersOfGroup(
+            @Parameter(description = "Group name as it appears in `groups.xml`.", example = "Admin", required = true)
+            @PathParam("groupName") final String groupName) {
         getOnmsGroup(groupName); // check if group exists.
         return m_groupService.getUsersOfGroup(groupName);
     }
     
     @GET
     @Path("{groupName}/users/{userName}")
-    public OnmsUser getUser(@PathParam("groupName") final String groupName, @PathParam("userName") final String userName) {
+    @Operation(
+            summary = "Get one user of a group",
+            description = "Return the full user record for one member of the group. The password hash is not "
+                    + "masked for non-admin callers.",
+            operationId = "getGroupUserV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The group member.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsUser.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "user-id": "admin",
+                      "full-name": "Administrator",
+                      "user-comments": "Default administrator, do not delete",
+                      "email": "",
+                      "password": "gU2wmSW7k9v1xg4/MrAsaI+VyddBAhJJt4zPX5SGG0BK+qiASGnJsqM8JOug/aEL",
+                      "passwordSalt": true,
+                      "duty-schedule": [],
+                      "role": [ "ROLE_ADMIN" ]
+                    }"""))),
+            @ApiResponse(responseCode = "404", description = "No such group, or the user is not a member of it.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User with name 'jroe' does not exist in group 'NOC'")))
+    })
+    public OnmsUser getUser(
+            @Parameter(description = "Group name as it appears in `groups.xml`.", example = "Admin", required = true)
+            @PathParam("groupName") final String groupName,
+            @Parameter(description = "User name as it appears in `users.xml`.", example = "admin", required = true)
+            @PathParam("userName") final String userName) {
         getOnmsGroup(groupName); // check if group exists.
         OnmsUser user = m_groupService.getUserForGroup(groupName,  userName);
         if (user != null) return user;
@@ -218,7 +449,30 @@ public class GroupRestService extends OnmsRestService {
 
     @PUT
     @Path("{groupName}/categories/{categoryName}")
-    public Response addCategory(@PathParam("groupName") final String groupName, @PathParam("categoryName") final String categoryName) {
+    @Operation(
+            summary = "Authorize a group for a category",
+            description = """
+                    Add the group to a surveillance category's authorized-groups list. The request takes no body.
+                    An already-authorized category and a category that does not exist share the same 400 response,
+                    so the message does not say which of the two applies.""",
+            operationId = "addGroupCategoryV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The group was authorized for the category."),
+            @ApiResponse(responseCode = "400", description = "The group is already authorized, or no such category exists.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Category with name 'Routers' already added or does not exist."))),
+            @ApiResponse(responseCode = "404", description = "No such group.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Group with name 'NOC' does not exist.")))
+    })
+    public Response addCategory(
+            @Parameter(description = "Group name as it appears in `groups.xml`.", example = "Admin", required = true)
+            @PathParam("groupName") final String groupName,
+            @Parameter(description = "Surveillance category name.", example = "Routers", required = true)
+            @PathParam("categoryName") final String categoryName) {
         writeLock();
         try {
             getOnmsGroup(groupName); // check if group exists.
@@ -234,7 +488,27 @@ public class GroupRestService extends OnmsRestService {
 
     @DELETE
     @Path("{groupName}/categories/{categoryName}")
-    public Response removeCategory(@PathParam("groupName") final String groupName, @PathParam("categoryName") final String categoryName) {
+    @Operation(
+            summary = "Revoke a group's authorization for a category",
+            description = "Remove the group from a surveillance category's authorized-groups list.",
+            operationId = "removeGroupCategoryV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The authorization was removed."),
+            @ApiResponse(responseCode = "400", description = "The group was not authorized for that category, or no such category exists.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Category with name 'Routers' does not exist. Remove failed."))),
+            @ApiResponse(responseCode = "404", description = "No such group.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Group with name 'NOC' does not exist.")))
+    })
+    public Response removeCategory(
+            @Parameter(description = "Group name as it appears in `groups.xml`.", example = "Admin", required = true)
+            @PathParam("groupName") final String groupName,
+            @Parameter(description = "Surveillance category name.", example = "Routers", required = true)
+            @PathParam("categoryName") final String categoryName) {
         writeLock();
         try {
             getOnmsGroup(groupName); // check if group exists.
@@ -250,7 +524,31 @@ public class GroupRestService extends OnmsRestService {
 
     @GET
     @Path("{groupName}/categories/{categoryName}")
-    public OnmsCategory getCategoryForGroup(@PathParam("groupName") final String groupName, @PathParam("categoryName") final String categoryName) {
+    @Operation(
+            summary = "Get one category a group is authorized for",
+            description = "Return the category record, provided the group is authorized for it.",
+            operationId = "getGroupCategoryV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The category.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsCategory.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "id": 1,
+                      "authorizedGroups": [ "NOC" ],
+                      "name": "Routers"
+                    }"""))),
+            @ApiResponse(responseCode = "404", description = "No such group, or the group is not authorized for that category.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Category with name 'Switches' does not exist for group 'NOC'.")))
+    })
+    public OnmsCategory getCategoryForGroup(
+            @Parameter(description = "Group name as it appears in `groups.xml`.", example = "Admin", required = true)
+            @PathParam("groupName") final String groupName,
+            @Parameter(description = "Surveillance category name.", example = "Routers", required = true)
+            @PathParam("categoryName") final String categoryName) {
         getOnmsGroup(groupName); // check if group exists.
         List<OnmsCategory> categories = m_groupService.getAuthorizedCategories(groupName);
         for (OnmsCategory eachCategory : categories) {
@@ -261,7 +559,37 @@ public class GroupRestService extends OnmsRestService {
     
     @GET
     @Path("{groupName}/categories")
-    public OnmsCategoryCollection listCategories(@PathParam("groupName") final String groupName) {
+    @Operation(
+            summary = "List the categories a group is authorized for",
+            description = "Return every surveillance category whose authorized-groups list names this group. "
+                    + "`totalCount` and `count` are `null` when the list is empty.",
+            operationId = "listGroupCategoriesV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The authorized categories.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsCategoryCollection.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 1,
+                      "count": 1,
+                      "offset": 0,
+                      "category": [
+                        {
+                          "id": 1,
+                          "authorizedGroups": [ "NOC" ],
+                          "name": "Routers"
+                        }
+                      ]
+                    }"""))),
+            @ApiResponse(responseCode = "404", description = "No such group.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Group with name 'NOC' does not exist.")))
+    })
+    public OnmsCategoryCollection listCategories(
+            @Parameter(description = "Group name as it appears in `groups.xml`.", example = "Admin", required = true)
+            @PathParam("groupName") final String groupName) {
         writeLock();
         try {
             getOnmsGroup(groupName); // check if group exists.

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/HardwareInventoryResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/HardwareInventoryResource.java
@@ -37,6 +37,14 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.netmgt.dao.api.HwEntityAttributeTypeDao;
 import org.opennms.netmgt.dao.api.HwEntityDao;
@@ -79,7 +87,22 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component("hardwareInventoryResource")
 @Path("hardwareInventory")
-@Tag(name = "HardwareInventory", description = "Hardware Inventory API")
+@Tag(name = "HardwareInventory", description = """
+        Hardware Inventory API.
+
+        A node's hardware inventory is the ENTITY-MIB physical tree: one root entity per node, each entity
+        addressed by its `entPhysicalIndex`, with vendor-specific values hanging off each entity as
+        `vendorAttributes`. Reach it through the node: `/nodes/{nodeCriteria}/hardwareInventory`.
+
+        The class also carries a root `@Path` of its own, so the V1 document additionally lists these
+        operations with no node in the path. Every handler needs a `nodeCriteria` path parameter that a
+        path without a node cannot supply, so all six of them fail with HTTP 500 on every such request.
+        Use the node-scoped paths.
+
+        In the request and response bodies `entPhysicalIndex`, `parentPhysicalIndex`, `entityId` and `nodeId` are
+        XML *attributes*, while `entPhysicalDescr` and the other `entPhysical*` values are XML *elements*. An
+        `entPhysical*` value sent as the wrong kind of node is dropped silently. Sending `nodeId` is unnecessary;
+        it is taken from the path.""")
 @Transactional
 public class HardwareInventoryResource extends OnmsRestService {
     private static final Logger LOG = LoggerFactory.getLogger(HardwareInventoryResource.class);
@@ -104,7 +127,92 @@ public class HardwareInventoryResource extends OnmsRestService {
      */
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-    public OnmsHwEntity getHardwareInventory(@PathParam("nodeCriteria") String nodeCriteria) {
+    @Operation(
+            summary = "Get a node's whole hardware inventory",
+            description = """
+                    Returns the root hardware entity for the node with its descendants nested under `children`.
+                    A node that has never been scanned for ENTITY-MIB data, or whose inventory has been deleted,
+                    has no root entity and returns 404.
+
+                    Reached with no node in the path this fails with HTTP 500.""",
+            operationId = "getNodeHardwareInventory"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The root entity and its subtree.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsHwEntity.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "entPhysicalName": "Chassis",
+                      "entPhysicalIndex": 1,
+                      "entPhysicalDescr": "Example 9000 chassis",
+                      "entPhysicalClass": "chassis",
+                      "entPhysicalSerialNum": "SN0001",
+                      "entPhysicalModelName": "X-9000",
+                      "entPhysicalIsFRU": false,
+                      "children": [
+                        {
+                          "entPhysicalName": "Slot 1",
+                          "entPhysicalIndex": 2,
+                          "entPhysicalDescr": "Example line card",
+                          "entPhysicalClass": "module",
+                          "entPhysicalSerialNum": "SN0002",
+                          "entPhysicalIsFRU": true,
+                          "children": [],
+                          "parentPhysicalIndex": 1,
+                          "hwEntityAliases": [],
+                          "entityId": "23658",
+                          "vendorAttributes": [],
+                          "nodeId": 258
+                        }
+                      ],
+                      "parentPhysicalIndex": null,
+                      "hwEntityAliases": [],
+                      "entityId": "23657",
+                      "vendorAttributes": [
+                        { "value": "1", "name": "entPhysicalFanState", "class": "integer", "oid": ".1.3.6.1.4.1.9.9.13.1.4.1.3" }
+                      ],
+                      "nodeId": 258
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsHwEntity.class),
+                                    examples = @ExampleObject(value = """
+                    <hwEntity entPhysicalIndex="1" nodeId="258" entityId="23657">
+                      <children>
+                        <hwEntity entPhysicalIndex="2" nodeId="258" entityId="23658" parentPhysicalIndex="1">
+                          <children/>
+                          <entPhysicalClass>module</entPhysicalClass>
+                          <entPhysicalDescr>Example line card</entPhysicalDescr>
+                          <entPhysicalIsFRU>true</entPhysicalIsFRU>
+                          <entPhysicalName>Slot 1</entPhysicalName>
+                          <vendorAttributes/>
+                        </hwEntity>
+                      </children>
+                      <entPhysicalClass>chassis</entPhysicalClass>
+                      <entPhysicalDescr>Example 9000 chassis</entPhysicalDescr>
+                      <entPhysicalModelName>X-9000</entPhysicalModelName>
+                      <entPhysicalName>Chassis</entPhysicalName>
+                      <vendorAttributes>
+                        <hwEntityAttribute class="integer" name="entPhysicalFanState" oid=".1.3.6.1.4.1.9.9.13.1.4.1.3" value="1"/>
+                      </vendorAttributes>
+                    </hwEntity>"""))
+                    }),
+            @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Node 999999 was not found."))),
+            @ApiResponse(responseCode = "404", description = "The node has no hardware inventory.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Can't find root hardware entity for node 258."))),
+            @ApiResponse(responseCode = "500", description = "Returned unconditionally when the operation is reached with no node in the path.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot invoke \"String.contains(java.lang.CharSequence)\" because \"lookupCriteria\" is null")))
+    })
+    public OnmsHwEntity getHardwareInventory(@Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                             @PathParam("nodeCriteria") String nodeCriteria) {
         final OnmsNode node = getOnmsNode(nodeCriteria);
         final OnmsHwEntity entity = m_hwEntityDao.findRootByNodeId(node.getId());
         if (entity == null) {
@@ -123,7 +231,65 @@ public class HardwareInventoryResource extends OnmsRestService {
     @GET
     @Path("{entPhysicalIndex}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-    public OnmsHwEntity getHwEntityByIndex(@PathParam("nodeCriteria") String nodeCriteria, @PathParam("entPhysicalIndex") Integer entPhysicalIndex) {
+    @Operation(
+            summary = "Get one hardware entity by its physical index",
+            description = """
+                    Returns a single entity from the node's inventory, with its own subtree nested under
+                    `children`. The index is the ENTITY-MIB `entPhysicalIndex`, unique per node, not a database
+                    key.
+
+                    Reached with no node in the path this fails with HTTP 500.""",
+            operationId = "getNodeHardwareEntity"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The entity and its subtree.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsHwEntity.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "entPhysicalName": "Slot 1",
+                      "entPhysicalIndex": 2,
+                      "entPhysicalDescr": "Example line card",
+                      "entPhysicalClass": "module",
+                      "entPhysicalSerialNum": "SN0002",
+                      "entPhysicalIsFRU": true,
+                      "children": [],
+                      "parentPhysicalIndex": 1,
+                      "hwEntityAliases": [],
+                      "entityId": "23658",
+                      "vendorAttributes": [],
+                      "nodeId": 258
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsHwEntity.class),
+                                    examples = @ExampleObject(value = """
+                    <hwEntity entPhysicalIndex="2" nodeId="258" entityId="23658" parentPhysicalIndex="1">
+                      <children/>
+                      <entPhysicalClass>module</entPhysicalClass>
+                      <entPhysicalDescr>Example line card</entPhysicalDescr>
+                      <entPhysicalIsFRU>true</entPhysicalIsFRU>
+                      <entPhysicalName>Slot 1</entPhysicalName>
+                      <vendorAttributes/>
+                    </hwEntity>"""))
+                    }),
+            @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Node 999999 was not found."))),
+            @ApiResponse(responseCode = "404", description = "The node has no entity with that index.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Can't find entity with index 99 on node 258."))),
+            @ApiResponse(responseCode = "500", description = "Returned unconditionally when the operation is reached with no node in the path.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot invoke \"String.contains(java.lang.CharSequence)\" because \"lookupCriteria\" is null")))
+    })
+    public OnmsHwEntity getHwEntityByIndex(@Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                           @PathParam("nodeCriteria") String nodeCriteria,
+                                           @Parameter(description = "ENTITY-MIB entPhysicalIndex of the entity, unique within the node.", example = "2")
+                                           @PathParam("entPhysicalIndex") Integer entPhysicalIndex) {
         final OnmsNode node = getOnmsNode(nodeCriteria);
         return getHwEntity(node.getId(), entPhysicalIndex);
     }
@@ -137,7 +303,95 @@ public class HardwareInventoryResource extends OnmsRestService {
      */
     @POST
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-    public Response setHardwareInventory(@PathParam("nodeCriteria") String nodeCriteria, OnmsHwEntity entity) {
+    @Operation(
+            summary = "Replace a node's whole hardware inventory",
+            description = """
+                    Stores the posted entity as the node's root entity, together with everything nested under
+                    `children`. Any inventory the node already had is deleted first, so this replaces rather than
+                    merges.
+
+                    Attribute types named in `vendorAttributes` are created on demand from the `name`, `oid` and
+                    `class` given, and are keyed by name, so an existing type keeps its stored OID and class.
+                    A new type whose `oid` is not a dotted-numeric string is rejected with 400.
+
+                    The handler tests `isRoot()` on the deserialized entity and that test passes whenever the
+                    parent reference is unset, which a request body cannot set, so the "not a root entity"
+                    rejection is not reachable over ReST.
+
+                    Reached with no node in the path this fails with HTTP 500.""",
+            operationId = "setNodeHardwareInventory"
+    )
+    @RequestBody(
+            required = true,
+            description = "The root entity, with any descendants nested under `children`.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = OnmsHwEntity.class),
+                            examples = @ExampleObject(value = """
+                    <hwEntity entPhysicalIndex="1">
+                      <entPhysicalClass>chassis</entPhysicalClass>
+                      <entPhysicalDescr>Example 9000 chassis</entPhysicalDescr>
+                      <entPhysicalModelName>X-9000</entPhysicalModelName>
+                      <entPhysicalName>Chassis</entPhysicalName>
+                      <entPhysicalSerialNum>SN0001</entPhysicalSerialNum>
+                      <entPhysicalIsFRU>false</entPhysicalIsFRU>
+                      <vendorAttributes>
+                        <hwEntityAttribute class="integer" name="entPhysicalFanState" oid=".1.3.6.1.4.1.9.9.13.1.4.1.3" value="1"/>
+                      </vendorAttributes>
+                      <children>
+                        <hwEntity entPhysicalIndex="2">
+                          <entPhysicalClass>module</entPhysicalClass>
+                          <entPhysicalDescr>Example line card</entPhysicalDescr>
+                          <entPhysicalName>Slot 1</entPhysicalName>
+                          <entPhysicalSerialNum>SN0002</entPhysicalSerialNum>
+                          <entPhysicalIsFRU>true</entPhysicalIsFRU>
+                        </hwEntity>
+                      </children>
+                    </hwEntity>""")),
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsHwEntity.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "entPhysicalIndex": 1,
+                      "entPhysicalClass": "chassis",
+                      "entPhysicalDescr": "Example 9000 chassis",
+                      "entPhysicalModelName": "X-9000",
+                      "entPhysicalName": "Chassis",
+                      "entPhysicalSerialNum": "SN0001",
+                      "entPhysicalIsFRU": false,
+                      "vendorAttributes": [
+                        { "name": "entPhysicalFanState", "oid": ".1.3.6.1.4.1.9.9.13.1.4.1.3", "class": "integer", "value": "1" }
+                      ],
+                      "children": [
+                        {
+                          "entPhysicalIndex": 2,
+                          "entPhysicalClass": "module",
+                          "entPhysicalDescr": "Example line card",
+                          "entPhysicalName": "Slot 1",
+                          "entPhysicalSerialNum": "SN0002",
+                          "entPhysicalIsFRU": true
+                        }
+                      ]
+                    }"""))
+            }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The inventory was stored. No body."),
+            @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`, or a new attribute type carries a non-numeric OID.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "unknownNode", value = "Node 999999 was not found."),
+                                    @ExampleObject(name = "badOid", value = "OID {not-an-oid} provided in entity is not valid.")
+                            })),
+            @ApiResponse(responseCode = "415", description = "The body was form-encoded. Send XML or JSON."),
+            @ApiResponse(responseCode = "500", description = "Returned unconditionally when the operation is reached with no node in the path.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot invoke \"String.contains(java.lang.CharSequence)\" because \"lookupCriteria\" is null")))
+    })
+    public Response setHardwareInventory(@Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                         @PathParam("nodeCriteria") String nodeCriteria, OnmsHwEntity entity) {
         if (!entity.isRoot()) {
             throw getException(Status.BAD_REQUEST, "The hardware entity is not a root entity {}.", entity.toString());
         }
@@ -171,7 +425,63 @@ public class HardwareInventoryResource extends OnmsRestService {
     @POST
     @Path("{parentEntPhysicalIndex}")
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-    public Response addOrReplaceChild(@PathParam("nodeCriteria") String nodeCriteria, @PathParam("parentEntPhysicalIndex") Integer parentEntPhysicalIndex, OnmsHwEntity child) {
+    @Operation(
+            summary = "Add or replace one child entity",
+            description = """
+                    Attaches the posted entity, and anything nested under its `children`, beneath the entity whose
+                    index is in the path. If the parent already has a child with the same `entPhysicalIndex`, that
+                    child and its subtree are removed first, so posting twice replaces rather than duplicates.
+
+                    Attribute types are created on demand exactly as for the root POST.
+
+                    Reached with no node in the path this fails with HTTP 500.""",
+            operationId = "addNodeHardwareChildEntity"
+    )
+    @RequestBody(
+            required = true,
+            description = "The child entity to attach. `entPhysicalIndex` identifies it within the node.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = OnmsHwEntity.class),
+                            examples = @ExampleObject(value = """
+                    <hwEntity entPhysicalIndex="3">
+                      <entPhysicalClass>port</entPhysicalClass>
+                      <entPhysicalDescr>Example gigabit port</entPhysicalDescr>
+                      <entPhysicalName>Gi0/1</entPhysicalName>
+                      <entPhysicalIsFRU>false</entPhysicalIsFRU>
+                    </hwEntity>""")),
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsHwEntity.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "entPhysicalIndex": 3,
+                      "entPhysicalClass": "port",
+                      "entPhysicalDescr": "Example gigabit port",
+                      "entPhysicalName": "Gi0/1",
+                      "entPhysicalIsFRU": false
+                    }"""))
+            }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The child was attached, replacing any previous child with the same index. No body."),
+            @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`, or a new attribute type carries a non-numeric OID.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Node 999999 was not found."))),
+            @ApiResponse(responseCode = "404", description = "The node has no entity with the parent index.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Can't find entity with index 77 on node 258."))),
+            @ApiResponse(responseCode = "415", description = "The body was form-encoded. Send XML or JSON."),
+            @ApiResponse(responseCode = "500", description = "Returned unconditionally when the operation is reached with no node in the path.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot invoke \"String.contains(java.lang.CharSequence)\" because \"lookupCriteria\" is null")))
+    })
+    public Response addOrReplaceChild(@Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                      @PathParam("nodeCriteria") String nodeCriteria,
+                                      @Parameter(description = "entPhysicalIndex of the entity the child is attached to.", example = "1")
+                                      @PathParam("parentEntPhysicalIndex") Integer parentEntPhysicalIndex, OnmsHwEntity child) {
         writeLock();
         try {
             final OnmsNode node = getOnmsNode(nodeCriteria);
@@ -203,7 +513,60 @@ public class HardwareInventoryResource extends OnmsRestService {
     @PUT
     @Path("{entPhysicalIndex}")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-    public Response updateHwEntity(@PathParam("nodeCriteria") String nodeCriteria, @PathParam("entPhysicalIndex") Integer entPhysicalIndex, MultivaluedMapImpl params) {
+    @Operation(
+            summary = "Update one hardware entity",
+            description = """
+                    Applies form-encoded fields to a single entity. Keys are routed by their prefix: a key that
+                    starts with `entPhysical` is set as a bean property on the entity, and any other key is
+                    matched against the names of the entity's existing `vendorAttributes` and sets that
+                    attribute's value. A vendor attribute the entity does not already carry cannot be added here;
+                    post the entity again instead.
+
+                    Two consequences of that routing are worth knowing. A vendor attribute whose type name itself
+                    begins with `entPhysical` is unreachable, because the key is taken as a bean property. And
+                    `entPhysicalMfgDate` is a `Date` property with no registered string converter, so sending it
+                    fails with 500.
+
+                    The handler's modified flag starts out true, so a request whose keys match nothing still
+                    returns 204 and rewrites the entity unchanged. It never returns 304.
+
+                    Reached with no node in the path this fails with HTTP 500.""",
+            operationId = "updateNodeHardwareEntity"
+    )
+    @RequestBody(
+            required = true,
+            description = "Form-encoded entity properties and vendor attribute values.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "string"),
+                    examples = {
+                            @ExampleObject(name = "entityProperties", summary = "Set properties on the entity itself",
+                                    value = "entPhysicalName=Slot+1&entPhysicalSerialNum=SN0002-B&entPhysicalAlias=uplink+card"),
+                            @ExampleObject(name = "vendorAttribute", summary = "Set an existing vendor attribute by its type name",
+                                    value = "entPhysicalFanState=2")
+                    })
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The entity was saved. Returned even when no key matched anything."),
+            @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Node 999999 was not found."))),
+            @ApiResponse(responseCode = "404", description = "The node has no entity with that index.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Can't find entity with index 77 on node 258."))),
+            @ApiResponse(responseCode = "500", description = "A value could not be converted to the property's type, or the operation was reached with no node in the path.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "dateProperty", value = "Failed to convert value of type 'java.lang.String' to required type 'java.util.Date'; nested exception is java.lang.IllegalStateException: Cannot convert value of type 'java.lang.String' to required type 'java.util.Date': no matching editors or conversion strategy found"),
+                                    @ExampleObject(name = "noNodeInPath", value = "Cannot invoke \"String.contains(java.lang.CharSequence)\" because \"lookupCriteria\" is null")
+                            }))
+    })
+    public Response updateHwEntity(@Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                   @PathParam("nodeCriteria") String nodeCriteria,
+                                   @Parameter(description = "entPhysicalIndex of the entity to update.", example = "2")
+                                   @PathParam("entPhysicalIndex") Integer entPhysicalIndex, MultivaluedMapImpl params) {
         writeLock();
         try {
             final OnmsNode node = getOnmsNode(nodeCriteria);
@@ -246,7 +609,38 @@ public class HardwareInventoryResource extends OnmsRestService {
      */
     @DELETE
     @Path("{entPhysicalIndex}")
-    public Response deleteHwEntity(@PathParam("nodeCriteria") final String nodeCriteria, @PathParam("entPhysicalIndex") Integer entPhysicalIndex) {
+    @Operation(
+            summary = "Delete one hardware entity",
+            description = """
+                    Deletes the entity with the given index. Deleting the root entity clears the node's whole
+                    inventory, which is the supported way to reset it.
+
+                    Deleting a non-root entity has been observed to remove the entire tree, root included, rather
+                    than just that entity and its descendants. Re-read the inventory after such a delete instead
+                    of assuming the rest of the tree survived.
+
+                    Reached with no node in the path this fails with HTTP 500.""",
+            operationId = "deleteNodeHardwareEntity"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Deleted. No body."),
+            @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Node 999999 was not found."))),
+            @ApiResponse(responseCode = "404", description = "The node has no entity with that index.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Can't find entity with index 2 on node 258."))),
+            @ApiResponse(responseCode = "500", description = "Returned unconditionally when the operation is reached with no node in the path.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot invoke \"String.contains(java.lang.CharSequence)\" because \"lookupCriteria\" is null")))
+    })
+    public Response deleteHwEntity(@Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                   @PathParam("nodeCriteria") final String nodeCriteria,
+                                   @Parameter(description = "entPhysicalIndex of the entity to delete. Index 1 is normally the root.", example = "2")
+                                   @PathParam("entPhysicalIndex") Integer entPhysicalIndex) {
         writeLock();
         try {
             final OnmsNode node = getOnmsNode(nodeCriteria);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/HardwareInventoryResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/HardwareInventoryResource.java
@@ -91,18 +91,16 @@ import org.springframework.transaction.annotation.Transactional;
         Hardware Inventory API.
 
         A node's hardware inventory is the ENTITY-MIB physical tree: one root entity per node, each entity
-        addressed by its `entPhysicalIndex`, with vendor-specific values hanging off each entity as
-        `vendorAttributes`. Reach it through the node: `/nodes/{nodeCriteria}/hardwareInventory`.
+        addressed by its `entPhysicalIndex`, with vendor-specific values on each entity as `vendorAttributes`.
+        The node-scoped path is `/nodes/{nodeCriteria}/hardwareInventory`.
 
-        The class also carries a root `@Path` of its own, so the V1 document additionally lists these
-        operations with no node in the path. Every handler needs a `nodeCriteria` path parameter that a
-        path without a node cannot supply, so all six of them fail with HTTP 500 on every such request.
-        Use the node-scoped paths.
+        The document also lists all six operations at paths with no node in them. Those paths cannot supply the
+        required `nodeCriteria`, and every such request returns HTTP 500.
 
         In the request and response bodies `entPhysicalIndex`, `parentPhysicalIndex`, `entityId` and `nodeId` are
         XML *attributes*, while `entPhysicalDescr` and the other `entPhysical*` values are XML *elements*. An
-        `entPhysical*` value sent as the wrong kind of node is dropped silently. Sending `nodeId` is unnecessary;
-        it is taken from the path.""")
+        `entPhysical*` value sent as the wrong kind of node is dropped silently. `nodeId` in the body is
+        overwritten with the node from the path.""")
 @Transactional
 public class HardwareInventoryResource extends OnmsRestService {
     private static final Logger LOG = LoggerFactory.getLogger(HardwareInventoryResource.class);
@@ -132,9 +130,7 @@ public class HardwareInventoryResource extends OnmsRestService {
             description = """
                     Returns the root hardware entity for the node with its descendants nested under `children`.
                     A node that has never been scanned for ENTITY-MIB data, or whose inventory has been deleted,
-                    has no root entity and returns 404.
-
-                    Reached with no node in the path this fails with HTTP 500.""",
+                    has no root entity and returns 404.""",
             operationId = "getNodeHardwareInventory"
     )
     @ApiResponses(value = {
@@ -236,9 +232,7 @@ public class HardwareInventoryResource extends OnmsRestService {
             description = """
                     Returns a single entity from the node's inventory, with its own subtree nested under
                     `children`. The index is the ENTITY-MIB `entPhysicalIndex`, unique per node, not a database
-                    key.
-
-                    Reached with no node in the path this fails with HTTP 500.""",
+                    key.""",
             operationId = "getNodeHardwareEntity"
     )
     @ApiResponses(value = {
@@ -314,11 +308,8 @@ public class HardwareInventoryResource extends OnmsRestService {
                     `class` given, and are keyed by name, so an existing type keeps its stored OID and class.
                     A new type whose `oid` is not a dotted-numeric string is rejected with 400.
 
-                    The handler tests `isRoot()` on the deserialized entity and that test passes whenever the
-                    parent reference is unset, which a request body cannot set, so the "not a root entity"
-                    rejection is not reachable over ReST.
-
-                    Reached with no node in the path this fails with HTTP 500.""",
+                    The "not a root entity" 400 is unreachable: the check passes whenever the parent reference is
+                    unset, and a request body cannot set it.""",
             operationId = "setNodeHardwareInventory"
     )
     @RequestBody(
@@ -432,9 +423,7 @@ public class HardwareInventoryResource extends OnmsRestService {
                     index is in the path. If the parent already has a child with the same `entPhysicalIndex`, that
                     child and its subtree are removed first, so posting twice replaces rather than duplicates.
 
-                    Attribute types are created on demand exactly as for the root POST.
-
-                    Reached with no node in the path this fails with HTTP 500.""",
+                    Attribute types are created on demand exactly as for the root POST.""",
             operationId = "addNodeHardwareChildEntity"
     )
     @RequestBody(
@@ -519,18 +508,14 @@ public class HardwareInventoryResource extends OnmsRestService {
                     Applies form-encoded fields to a single entity. Keys are routed by their prefix: a key that
                     starts with `entPhysical` is set as a bean property on the entity, and any other key is
                     matched against the names of the entity's existing `vendorAttributes` and sets that
-                    attribute's value. A vendor attribute the entity does not already carry cannot be added here;
-                    post the entity again instead.
+                    attribute's value. A vendor attribute the entity does not already carry cannot be added here.
 
-                    Two consequences of that routing are worth knowing. A vendor attribute whose type name itself
-                    begins with `entPhysical` is unreachable, because the key is taken as a bean property. And
-                    `entPhysicalMfgDate` is a `Date` property with no registered string converter, so sending it
-                    fails with 500.
+                    A vendor attribute whose type name itself begins with `entPhysical` is unreachable, because
+                    the key is taken as a bean property. `entPhysicalMfgDate` is a `Date` property with no
+                    registered string converter, so sending it fails with 500.
 
-                    The handler's modified flag starts out true, so a request whose keys match nothing still
-                    returns 204 and rewrites the entity unchanged. It never returns 304.
-
-                    Reached with no node in the path this fails with HTTP 500.""",
+                    The modified flag starts out true, so a request whose keys match nothing still returns 204 and
+                    rewrites the entity unchanged. It never returns 304.""",
             operationId = "updateNodeHardwareEntity"
     )
     @RequestBody(
@@ -613,13 +598,10 @@ public class HardwareInventoryResource extends OnmsRestService {
             summary = "Delete one hardware entity",
             description = """
                     Deletes the entity with the given index. Deleting the root entity clears the node's whole
-                    inventory, which is the supported way to reset it.
+                    inventory.
 
                     Deleting a non-root entity has been observed to remove the entire tree, root included, rather
-                    than just that entity and its descendants. Re-read the inventory after such a delete instead
-                    of assuming the rest of the tree survived.
-
-                    Reached with no node in the path this fails with HTTP 500.""",
+                    than just that entity and its descendants.""",
             operationId = "deleteNodeHardwareEntity"
     )
     @ApiResponses(value = {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/HeatMapRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/HeatMapRestService.java
@@ -33,6 +33,13 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.netmgt.dao.api.AlarmDao;
 import org.opennms.netmgt.dao.api.OutageDao;
@@ -49,7 +56,29 @@ import com.google.common.collect.Lists;
 
 @Component("heatMapRestService")
 @Path("heatmap")
-@Tag(name = "Heatmap", description = "Heatmap API")
+@Tag(name = "Heatmap", description = """
+        Heatmap API.
+
+        Every operation returns the same envelope: a `children` array of boxes, each with an `id` (the
+        entity name), an `elementId` (the numeric id of the entity, or 0 when the grouping column has no
+        id), a single-element `color` array and a single-element `size` array. `color` and `size` are
+        arrays only because of the wire format; one value per box is all that is ever produced.
+
+        `size` is the box's share of the total number of monitored services across the boxes that survived
+        filtering, so the sizes in one response sum to 1. Entities with no monitored services are omitted
+        entirely, which means an empty `children` array is the normal answer for an entity that exists but
+        carries nothing monitored.
+
+        `color` differs between the two families. For the `outages` operations it is the fraction of
+        services currently down, from 0.0 to 1.0. For the `alarms` operations it is a step value derived
+        from the highest unresolved alarm severity on the entity: 0.0 for normal, cleared, indeterminate or
+        no alarm, 0.1 warning, 0.2 minor, 0.4 major, 1.0 critical.
+
+        The three top-level groupings honour regular-expression filters taken from system properties, each
+        defaulting to `.*`: `org.opennms.heatmap.categoryFilter`, `org.opennms.heatmap.foreignSourceFilter`
+        and `org.opennms.heatmap.serviceFilter`. The filter is matched against the whole entity name. The
+        per-entity node drilldowns apply no filter. Setting `org.opennms.heatmap.onlyUnacknowledged` to
+        true makes the `alarms` operations skip acknowledged alarms.""")
 public class HeatMapRestService extends OnmsRestService {
     /**
      * Property and default value for category filtering
@@ -149,6 +178,36 @@ public class HeatMapRestService extends OnmsRestService {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     @Transactional
     @Path("outages/categories")
+    @Operation(
+            summary = "Outage heatmap by surveillance category",
+            description = """
+        One box per surveillance category that has at least one monitored service, coloured by the fraction of\n        services in the category that are currently down. Filtered by `org.opennms.heatmap.categoryFilter`.""",
+            operationId = "getOutageHeatMapByCategory"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Boxes for the surveillance categories.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = HeatMapDTOCollection.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "children": [
+                        {
+                          "id": "Routers",
+                          "elementId": 1,
+                          "color": [
+                            0.3333333333333333
+                          ],
+                          "size": [
+                            0.007334963325183374
+                          ]
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = HeatMapDTOCollection.class))
+                    })
+    })
     public Response outagesByCategories() throws IOException {
         final List<HeatMapElement> heatMapElements = m_outageDao.getHeatMapItemsForEntity("categories.categoryname", "categories.categoryid", null, null);
         return Response.ok(transformResults(heatMapElements, System.getProperty(CATEGORY_FILTER_PROPERTY_KEY, CATEGORY_FILTER_PROPERTY_DEFAULT))).build();
@@ -158,6 +217,36 @@ public class HeatMapRestService extends OnmsRestService {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     @Transactional
     @Path("outages/foreignSources")
+    @Operation(
+            summary = "Outage heatmap by foreign source",
+            description = """
+        One box per requisition (foreign source) that has at least one monitored service, coloured by the\n        fraction of services in it that are currently down. `elementId` is 0 because a foreign source has no\n        numeric id. Filtered by `org.opennms.heatmap.foreignSourceFilter`.""",
+            operationId = "getOutageHeatMapByForeignSource"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Boxes for the foreign sources.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = HeatMapDTOCollection.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "children": [
+                        {
+                          "id": "loopback-lab",
+                          "elementId": 0,
+                          "color": [
+                            0.00392156862745098
+                          ],
+                          "size": [
+                            1.0
+                          ]
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = HeatMapDTOCollection.class))
+                    })
+    })
     public Response outagesByForeignsources() throws IOException {
         final List<HeatMapElement> heatMapElements = m_outageDao.getHeatMapItemsForEntity("node.foreignsource", null, null, null, "node.foreignsource");
         return Response.ok(transformResults(heatMapElements, System.getProperty(FOREIGNSOURCE_FILTER_PROPERTY_KEY, FOREIGNSOURCE_FILTER_PROPERTY_DEFAULT))).build();
@@ -167,6 +256,36 @@ public class HeatMapRestService extends OnmsRestService {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     @Transactional
     @Path("outages/monitoredServices")
+    @Operation(
+            summary = "Outage heatmap by monitored service",
+            description = """
+        One box per service type that is monitored somewhere, coloured by the fraction of instances of that\n        service that are currently down. Filtered by `org.opennms.heatmap.serviceFilter`.""",
+            operationId = "getOutageHeatMapByMonitoredService"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Boxes for the monitored service types.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = HeatMapDTOCollection.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "children": [
+                        {
+                          "id": "SNMP",
+                          "elementId": 3,
+                          "color": [
+                            1.0
+                          ],
+                          "size": [
+                            0.00392156862745098
+                          ]
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = HeatMapDTOCollection.class))
+                    })
+    })
     public Response outagesByServices() throws IOException {
         final List<HeatMapElement> heatMapElements = m_outageDao.getHeatMapItemsForEntity("service.servicename", "service.serviceid", null, null);
         return Response.ok(transformResults(heatMapElements, System.getProperty(SERVICE_FILTER_PROPERTY_KEY, SERVICE_FILTER_PROPERTY_DEFAULT))).build();
@@ -176,7 +295,38 @@ public class HeatMapRestService extends OnmsRestService {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     @Transactional
     @Path("outages/nodesByCategory/{category}")
-    public Response outagesOfNodesByCategory(@PathParam("category") final String category) throws IOException {
+    @Operation(
+            summary = "Outage heatmap of the nodes in a category",
+            description = """
+        One box per node in the given surveillance category, coloured by the fraction of that node's monitored\n        services which are currently down. A category that does not exist, or whose nodes have nothing\n        monitored, yields an empty `children` array rather than a 404.""",
+            operationId = "getOutageHeatMapForNodesByCategory"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Boxes for the nodes in the category, or an empty array.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = HeatMapDTOCollection.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "children": [
+                        {
+                          "id": "loopback-001",
+                          "elementId": 2,
+                          "color": [
+                            0.5
+                          ],
+                          "size": [
+                            0.6666666666666666
+                          ]
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = HeatMapDTOCollection.class))
+                    })
+    })
+    public Response outagesOfNodesByCategory(@Parameter(description = "Surveillance category name, matched exactly. Case sensitive.", required = true, example = "Routers")
+            @PathParam("category") final String category) throws IOException {
         final List<HeatMapElement> heatMapElements = m_outageDao.getHeatMapItemsForEntity("node.nodelabel", "node.nodeid", "categories.categoryname", category);
         return Response.ok(transformResults(heatMapElements, null)).build();
     }
@@ -185,7 +335,38 @@ public class HeatMapRestService extends OnmsRestService {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     @Transactional
     @Path("outages/nodesByForeignSource/{foreignSource}")
-    public Response outagesOfNodesByForeignSource(@PathParam("foreignSource") final String foreignSource) throws IOException {
+    @Operation(
+            summary = "Outage heatmap of the nodes in a foreign source",
+            description = """
+        One box per node in the given requisition, coloured by the fraction of that node's monitored services\n        which are currently down. A foreign source that does not exist yields an empty `children` array\n        rather than a 404.""",
+            operationId = "getOutageHeatMapForNodesByForeignSource"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Boxes for the nodes in the foreign source, or an empty array.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = HeatMapDTOCollection.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "children": [
+                        {
+                          "id": "loopback-001",
+                          "elementId": 2,
+                          "color": [
+                            0.5
+                          ],
+                          "size": [
+                            0.00784313725490196
+                          ]
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = HeatMapDTOCollection.class))
+                    })
+    })
+    public Response outagesOfNodesByForeignSource(@Parameter(description = "Foreign source (requisition) name, matched exactly. Case sensitive.", required = true, example = "loopback-lab")
+            @PathParam("foreignSource") final String foreignSource) throws IOException {
         final List<HeatMapElement> heatMapElements = m_outageDao.getHeatMapItemsForEntity("node.nodelabel", "node.nodeid", "node.foreignsource", foreignSource);
         return Response.ok(transformResults(heatMapElements, null)).build();
     }
@@ -194,7 +375,38 @@ public class HeatMapRestService extends OnmsRestService {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     @Transactional
     @Path("outages/nodesByMonitoredService/{monitoredService}")
-    public Response outagesOfNodesByService(@PathParam("monitoredService") final String monitoredService) throws IOException {
+    @Operation(
+            summary = "Outage heatmap of the nodes running a service",
+            description = """
+        One box per node on which the given service type is monitored, coloured by the fraction of that node's\n        monitored services which are currently down. A service name that is not monitored anywhere yields an\n        empty `children` array rather than a 404.""",
+            operationId = "getOutageHeatMapForNodesByMonitoredService"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Boxes for the nodes running the service, or an empty array.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = HeatMapDTOCollection.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "children": [
+                        {
+                          "id": "loopback-001",
+                          "elementId": 2,
+                          "color": [
+                            1.0
+                          ],
+                          "size": [
+                            1.0
+                          ]
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = HeatMapDTOCollection.class))
+                    })
+    })
+    public Response outagesOfNodesByService(@Parameter(description = "Service type name as it appears in the service table, matched exactly. Case sensitive.", required = true, example = "SNMP")
+            @PathParam("monitoredService") final String monitoredService) throws IOException {
         final List<HeatMapElement> heatMapElements = m_outageDao.getHeatMapItemsForEntity("node.nodelabel", "node.nodeid", "service.servicename", monitoredService);
         return Response.ok(transformResults(heatMapElements, null)).build();
     }
@@ -203,6 +415,36 @@ public class HeatMapRestService extends OnmsRestService {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     @Transactional
     @Path("alarms/categories")
+    @Operation(
+            summary = "Alarm heatmap by surveillance category",
+            description = """
+        One box per surveillance category that has at least one monitored service, coloured by the highest\n        unresolved alarm severity in the category. Filtered by `org.opennms.heatmap.categoryFilter`.""",
+            operationId = "getAlarmHeatMapByCategory"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Boxes for the surveillance categories.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = HeatMapDTOCollection.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "children": [
+                        {
+                          "id": "Routers",
+                          "elementId": 1,
+                          "color": [
+                            0.2
+                          ],
+                          "size": [
+                            0.007334963325183374
+                          ]
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = HeatMapDTOCollection.class))
+                    })
+    })
     public Response alarmsByCategories() throws IOException {
         boolean processAcknowledged = !Boolean.parseBoolean(System.getProperty(ONLY_UNACKNOWLEDGED_PROPERTY_KEY, ONLY_UNACKNOWLEDGED_PROPERTY_DEFAULT));
         final List<HeatMapElement> heatMapElements = m_alarmDao.getHeatMapItemsForEntity("categories.categoryname", "categories.categoryid", processAcknowledged, null, null);
@@ -213,6 +455,36 @@ public class HeatMapRestService extends OnmsRestService {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     @Transactional
     @Path("alarms/foreignSources")
+    @Operation(
+            summary = "Alarm heatmap by foreign source",
+            description = """
+        One box per requisition (foreign source) that has at least one monitored service, coloured by the\n        highest unresolved alarm severity in it. `elementId` is 0 because a foreign source has no numeric id.\n        Filtered by `org.opennms.heatmap.foreignSourceFilter`.""",
+            operationId = "getAlarmHeatMapByForeignSource"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Boxes for the foreign sources.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = HeatMapDTOCollection.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "children": [
+                        {
+                          "id": "loopback-lab",
+                          "elementId": 0,
+                          "color": [
+                            0.2
+                          ],
+                          "size": [
+                            1.0
+                          ]
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = HeatMapDTOCollection.class))
+                    })
+    })
     public Response alarmsByForeignsources() throws IOException {
         boolean processAcknowledged = !Boolean.parseBoolean(System.getProperty(ONLY_UNACKNOWLEDGED_PROPERTY_KEY, ONLY_UNACKNOWLEDGED_PROPERTY_DEFAULT));
         final List<HeatMapElement> heatMapElements = m_alarmDao.getHeatMapItemsForEntity("node.foreignsource", null, processAcknowledged, null, null, "node.foreignsource");
@@ -223,6 +495,36 @@ public class HeatMapRestService extends OnmsRestService {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     @Transactional
     @Path("alarms/monitoredServices")
+    @Operation(
+            summary = "Alarm heatmap by monitored service",
+            description = """
+        One box per service type that is monitored somewhere, coloured by the highest unresolved alarm severity\n        recorded against it. Filtered by `org.opennms.heatmap.serviceFilter`.""",
+            operationId = "getAlarmHeatMapByMonitoredService"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Boxes for the monitored service types.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = HeatMapDTOCollection.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "children": [
+                        {
+                          "id": "SNMP",
+                          "elementId": 3,
+                          "color": [
+                            0.2
+                          ],
+                          "size": [
+                            0.00392156862745098
+                          ]
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = HeatMapDTOCollection.class))
+                    })
+    })
     public Response alarmsByServices() throws IOException {
         boolean processAcknowledged = !Boolean.parseBoolean(System.getProperty(ONLY_UNACKNOWLEDGED_PROPERTY_KEY, ONLY_UNACKNOWLEDGED_PROPERTY_DEFAULT));
         final List<HeatMapElement> heatMapElements = m_alarmDao.getHeatMapItemsForEntity("service.servicename", "service.serviceid", processAcknowledged, null, null);
@@ -233,7 +535,38 @@ public class HeatMapRestService extends OnmsRestService {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     @Transactional
     @Path("alarms/nodesByCategory/{category}")
-    public Response alarmsOfNodesByCategory(@PathParam("category") final String category) throws IOException {
+    @Operation(
+            summary = "Alarm heatmap of the nodes in a category",
+            description = """
+        One box per node in the given surveillance category, coloured by the highest unresolved alarm severity\n        on that node. A category that does not exist, or whose nodes have nothing monitored, yields an empty\n        `children` array rather than a 404.""",
+            operationId = "getAlarmHeatMapForNodesByCategory"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Boxes for the nodes in the category, or an empty array.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = HeatMapDTOCollection.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "children": [
+                        {
+                          "id": "loopback-001",
+                          "elementId": 2,
+                          "color": [
+                            0.2
+                          ],
+                          "size": [
+                            0.6666666666666666
+                          ]
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = HeatMapDTOCollection.class))
+                    })
+    })
+    public Response alarmsOfNodesByCategory(@Parameter(description = "Surveillance category name, matched exactly. Case sensitive.", required = true, example = "Routers")
+            @PathParam("category") final String category) throws IOException {
         boolean processAcknowledged = !Boolean.parseBoolean(System.getProperty(ONLY_UNACKNOWLEDGED_PROPERTY_KEY, ONLY_UNACKNOWLEDGED_PROPERTY_DEFAULT));
         final List<HeatMapElement> heatMapElements = m_alarmDao.getHeatMapItemsForEntity("node.nodelabel", "node.nodeid", processAcknowledged, "categories.categoryname", category);
         return Response.ok(transformResults(heatMapElements, null)).build();
@@ -243,7 +576,38 @@ public class HeatMapRestService extends OnmsRestService {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     @Transactional
     @Path("alarms/nodesByForeignSource/{foreignSource}")
-    public Response alarmsOfNodesByForeignSource(@PathParam("foreignSource") final String foreignSource) throws IOException {
+    @Operation(
+            summary = "Alarm heatmap of the nodes in a foreign source",
+            description = """
+        One box per node in the given requisition, coloured by the highest unresolved alarm severity on that\n        node. A foreign source that does not exist yields an empty `children` array rather than a 404.""",
+            operationId = "getAlarmHeatMapForNodesByForeignSource"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Boxes for the nodes in the foreign source, or an empty array.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = HeatMapDTOCollection.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "children": [
+                        {
+                          "id": "loopback-001",
+                          "elementId": 2,
+                          "color": [
+                            0.2
+                          ],
+                          "size": [
+                            0.00784313725490196
+                          ]
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = HeatMapDTOCollection.class))
+                    })
+    })
+    public Response alarmsOfNodesByForeignSource(@Parameter(description = "Foreign source (requisition) name, matched exactly. Case sensitive.", required = true, example = "loopback-lab")
+            @PathParam("foreignSource") final String foreignSource) throws IOException {
         boolean processAcknowledged = !Boolean.parseBoolean(System.getProperty(ONLY_UNACKNOWLEDGED_PROPERTY_KEY, ONLY_UNACKNOWLEDGED_PROPERTY_DEFAULT));
         final List<HeatMapElement> heatMapElements = m_alarmDao.getHeatMapItemsForEntity("node.nodelabel", "node.nodeid", processAcknowledged, "node.foreignsource", foreignSource);
         return Response.ok(transformResults(heatMapElements, null)).build();
@@ -253,7 +617,38 @@ public class HeatMapRestService extends OnmsRestService {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     @Transactional
     @Path("alarms/nodesByMonitoredService/{monitoredService}")
-    public Response alarmsOfNodesByService(@PathParam("monitoredService") final String monitoredService) throws IOException {
+    @Operation(
+            summary = "Alarm heatmap of the nodes running a service",
+            description = """
+        One box per node on which the given service type is monitored, coloured by the highest unresolved alarm\n        severity on that node. A service name that is not monitored anywhere yields an empty `children` array\n        rather than a 404.""",
+            operationId = "getAlarmHeatMapForNodesByMonitoredService"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Boxes for the nodes running the service, or an empty array.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = HeatMapDTOCollection.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "children": [
+                        {
+                          "id": "loopback-001",
+                          "elementId": 2,
+                          "color": [
+                            0.2
+                          ],
+                          "size": [
+                            1.0
+                          ]
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = HeatMapDTOCollection.class))
+                    })
+    })
+    public Response alarmsOfNodesByService(@Parameter(description = "Service type name as it appears in the service table, matched exactly. Case sensitive.", required = true, example = "SNMP")
+            @PathParam("monitoredService") final String monitoredService) throws IOException {
         boolean processAcknowledged = !Boolean.parseBoolean(System.getProperty(ONLY_UNACKNOWLEDGED_PROPERTY_KEY, ONLY_UNACKNOWLEDGED_PROPERTY_DEFAULT));
         final List<HeatMapElement> heatMapElements = m_alarmDao.getHeatMapItemsForEntity("node.nodelabel", "node.nodeid", processAcknowledged, "service.servicename", monitoredService);
         return Response.ok(transformResults(heatMapElements, null)).build();

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/HeatMapRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/HeatMapRestService.java
@@ -1,21 +1,21 @@
 /*
  * Licensed to The OpenNMS Group, Inc (TOG) under one or more
- * contributor license agreements.  See the LICENSE.md file
+ * contributor license agreements. See the LICENSE.md file
  * distributed with this work for additional information
  * regarding copyright ownership.
  *
  * TOG licenses this file to You under the GNU Affero General
  * Public License Version 3 (the "License") or (at your option)
- * any later version.  You may not use this file except in
- * compliance with the License.  You may obtain a copy of the
+ * any later version. You may not use this file except in
+ * compliance with the License. You may obtain a copy of the
  * License at:
  *
- *      https://www.gnu.org/licenses/agpl-3.0.txt
+ * https://www.gnu.org/licenses/agpl-3.0.txt
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
- * either express or implied.  See the License for the specific
+ * either express or implied. See the License for the specific
  * language governing permissions and limitations under the
  * License.
  */
@@ -57,22 +57,17 @@ import com.google.common.collect.Lists;
 @Component("heatMapRestService")
 @Path("heatmap")
 @Tag(name = "Heatmap", description = """
-        Heatmap API.
-
         Every operation returns the same envelope: a `children` array of boxes, each with an `id` (the
         entity name), an `elementId` (the numeric id of the entity, or 0 when the grouping column has no
-        id), a single-element `color` array and a single-element `size` array. `color` and `size` are
-        arrays only because of the wire format; one value per box is all that is ever produced.
+        id), a `color` array and a `size` array. Each of those two arrays holds exactly one value.
 
         `size` is the box's share of the total number of monitored services across the boxes that survived
-        filtering, so the sizes in one response sum to 1. Entities with no monitored services are omitted
-        entirely, which means an empty `children` array is the normal answer for an entity that exists but
-        carries nothing monitored.
+        filtering, so the sizes in one response sum to 1. Entities with no monitored services are omitted.
 
-        `color` differs between the two families. For the `outages` operations it is the fraction of
-        services currently down, from 0.0 to 1.0. For the `alarms` operations it is a step value derived
-        from the highest unresolved alarm severity on the entity: 0.0 for normal, cleared, indeterminate or
-        no alarm, 0.1 warning, 0.2 minor, 0.4 major, 1.0 critical.
+        For the `outages` operations `color` is the fraction of services currently down, from 0.0 to 1.0.
+        For the `alarms` operations it is a step value derived from the highest unresolved alarm severity on
+        the entity: 0.0 for normal, cleared, indeterminate or no alarm, 0.1 warning, 0.2 minor, 0.4 major,
+        1.0 critical.
 
         The three top-level groupings honour regular-expression filters taken from system properties, each
         defaulting to `.*`: `org.opennms.heatmap.categoryFilter`, `org.opennms.heatmap.foreignSourceFilter`
@@ -181,7 +176,7 @@ public class HeatMapRestService extends OnmsRestService {
     @Operation(
             summary = "Outage heatmap by surveillance category",
             description = """
-        One box per surveillance category that has at least one monitored service, coloured by the fraction of\n        services in the category that are currently down. Filtered by `org.opennms.heatmap.categoryFilter`.""",
+        One box per surveillance category that has at least one monitored service, coloured by the fraction of services in the category that are currently down. Filtered by `org.opennms.heatmap.categoryFilter`.""",
             operationId = "getOutageHeatMapByCategory"
     )
     @ApiResponses(value = {
@@ -220,7 +215,7 @@ public class HeatMapRestService extends OnmsRestService {
     @Operation(
             summary = "Outage heatmap by foreign source",
             description = """
-        One box per requisition (foreign source) that has at least one monitored service, coloured by the\n        fraction of services in it that are currently down. `elementId` is 0 because a foreign source has no\n        numeric id. Filtered by `org.opennms.heatmap.foreignSourceFilter`.""",
+        One box per requisition (foreign source) that has at least one monitored service, coloured by the fraction of services in it that are currently down. `elementId` is 0 because a foreign source has no numeric id. Filtered by `org.opennms.heatmap.foreignSourceFilter`.""",
             operationId = "getOutageHeatMapByForeignSource"
     )
     @ApiResponses(value = {
@@ -259,7 +254,7 @@ public class HeatMapRestService extends OnmsRestService {
     @Operation(
             summary = "Outage heatmap by monitored service",
             description = """
-        One box per service type that is monitored somewhere, coloured by the fraction of instances of that\n        service that are currently down. Filtered by `org.opennms.heatmap.serviceFilter`.""",
+        One box per service type that is monitored somewhere, coloured by the fraction of instances of that service that are currently down. Filtered by `org.opennms.heatmap.serviceFilter`.""",
             operationId = "getOutageHeatMapByMonitoredService"
     )
     @ApiResponses(value = {
@@ -298,7 +293,7 @@ public class HeatMapRestService extends OnmsRestService {
     @Operation(
             summary = "Outage heatmap of the nodes in a category",
             description = """
-        One box per node in the given surveillance category, coloured by the fraction of that node's monitored\n        services which are currently down. A category that does not exist, or whose nodes have nothing\n        monitored, yields an empty `children` array rather than a 404.""",
+        One box per node in the given surveillance category, coloured by the fraction of that node's monitored services which are currently down. A category that does not exist, or whose nodes have nothing monitored, yields an empty `children` array rather than a 404.""",
             operationId = "getOutageHeatMapForNodesByCategory"
     )
     @ApiResponses(value = {
@@ -338,7 +333,7 @@ public class HeatMapRestService extends OnmsRestService {
     @Operation(
             summary = "Outage heatmap of the nodes in a foreign source",
             description = """
-        One box per node in the given requisition, coloured by the fraction of that node's monitored services\n        which are currently down. A foreign source that does not exist yields an empty `children` array\n        rather than a 404.""",
+        One box per node in the given requisition, coloured by the fraction of that node's monitored services which are currently down. A foreign source that does not exist yields an empty `children` array rather than a 404.""",
             operationId = "getOutageHeatMapForNodesByForeignSource"
     )
     @ApiResponses(value = {
@@ -378,7 +373,7 @@ public class HeatMapRestService extends OnmsRestService {
     @Operation(
             summary = "Outage heatmap of the nodes running a service",
             description = """
-        One box per node on which the given service type is monitored, coloured by the fraction of that node's\n        monitored services which are currently down. A service name that is not monitored anywhere yields an\n        empty `children` array rather than a 404.""",
+        One box per node on which the given service type is monitored, coloured by the fraction of that node's monitored services which are currently down. A service name that is not monitored anywhere yields an empty `children` array rather than a 404.""",
             operationId = "getOutageHeatMapForNodesByMonitoredService"
     )
     @ApiResponses(value = {
@@ -418,7 +413,7 @@ public class HeatMapRestService extends OnmsRestService {
     @Operation(
             summary = "Alarm heatmap by surveillance category",
             description = """
-        One box per surveillance category that has at least one monitored service, coloured by the highest\n        unresolved alarm severity in the category. Filtered by `org.opennms.heatmap.categoryFilter`.""",
+        One box per surveillance category that has at least one monitored service, coloured by the highest unresolved alarm severity in the category. Filtered by `org.opennms.heatmap.categoryFilter`.""",
             operationId = "getAlarmHeatMapByCategory"
     )
     @ApiResponses(value = {
@@ -458,7 +453,7 @@ public class HeatMapRestService extends OnmsRestService {
     @Operation(
             summary = "Alarm heatmap by foreign source",
             description = """
-        One box per requisition (foreign source) that has at least one monitored service, coloured by the\n        highest unresolved alarm severity in it. `elementId` is 0 because a foreign source has no numeric id.\n        Filtered by `org.opennms.heatmap.foreignSourceFilter`.""",
+        One box per requisition (foreign source) that has at least one monitored service, coloured by the highest unresolved alarm severity in it. `elementId` is 0 because a foreign source has no numeric id. Filtered by `org.opennms.heatmap.foreignSourceFilter`.""",
             operationId = "getAlarmHeatMapByForeignSource"
     )
     @ApiResponses(value = {
@@ -498,7 +493,7 @@ public class HeatMapRestService extends OnmsRestService {
     @Operation(
             summary = "Alarm heatmap by monitored service",
             description = """
-        One box per service type that is monitored somewhere, coloured by the highest unresolved alarm severity\n        recorded against it. Filtered by `org.opennms.heatmap.serviceFilter`.""",
+        One box per service type that is monitored somewhere, coloured by the highest unresolved alarm severity recorded against it. Filtered by `org.opennms.heatmap.serviceFilter`.""",
             operationId = "getAlarmHeatMapByMonitoredService"
     )
     @ApiResponses(value = {
@@ -538,7 +533,7 @@ public class HeatMapRestService extends OnmsRestService {
     @Operation(
             summary = "Alarm heatmap of the nodes in a category",
             description = """
-        One box per node in the given surveillance category, coloured by the highest unresolved alarm severity\n        on that node. A category that does not exist, or whose nodes have nothing monitored, yields an empty\n        `children` array rather than a 404.""",
+        One box per node in the given surveillance category, coloured by the highest unresolved alarm severity on that node. A category that does not exist, or whose nodes have nothing monitored, yields an empty `children` array rather than a 404.""",
             operationId = "getAlarmHeatMapForNodesByCategory"
     )
     @ApiResponses(value = {
@@ -579,7 +574,7 @@ public class HeatMapRestService extends OnmsRestService {
     @Operation(
             summary = "Alarm heatmap of the nodes in a foreign source",
             description = """
-        One box per node in the given requisition, coloured by the highest unresolved alarm severity on that\n        node. A foreign source that does not exist yields an empty `children` array rather than a 404.""",
+        One box per node in the given requisition, coloured by the highest unresolved alarm severity on that node. A foreign source that does not exist yields an empty `children` array rather than a 404.""",
             operationId = "getAlarmHeatMapForNodesByForeignSource"
     )
     @ApiResponses(value = {
@@ -620,7 +615,7 @@ public class HeatMapRestService extends OnmsRestService {
     @Operation(
             summary = "Alarm heatmap of the nodes running a service",
             description = """
-        One box per node on which the given service type is monitored, coloured by the highest unresolved alarm\n        severity on that node. A service name that is not monitored anywhere yields an empty `children` array\n        rather than a 404.""",
+        One box per node on which the given service type is monitored, coloured by the highest unresolved alarm severity on that node. A service name that is not monitored anywhere yields an empty `children` array rather than a 404.""",
             operationId = "getAlarmHeatMapForNodesByMonitoredService"
     )
     @ApiResponses(value = {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/HeatMapRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/HeatMapRestService.java
@@ -1,21 +1,21 @@
 /*
  * Licensed to The OpenNMS Group, Inc (TOG) under one or more
- * contributor license agreements. See the LICENSE.md file
+ * contributor license agreements.  See the LICENSE.md file
  * distributed with this work for additional information
  * regarding copyright ownership.
  *
  * TOG licenses this file to You under the GNU Affero General
  * Public License Version 3 (the "License") or (at your option)
- * any later version. You may not use this file except in
- * compliance with the License. You may obtain a copy of the
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
  * License at:
  *
- * https://www.gnu.org/licenses/agpl-3.0.txt
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
- * either express or implied. See the License for the specific
+ * either express or implied.  See the License for the specific
  * language governing permissions and limitations under the
  * License.
  */

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/IfServicesRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/IfServicesRestService.java
@@ -146,7 +146,7 @@ public class IfServicesRestService extends OnmsRestService {
                             schema = @Schema(type = "string", defaultValue = "all", allowableValues = {"all", "any"}),
                             example = "any"),
                     @Parameter(in = ParameterIn.QUERY, name = "node.label",
-                            description = "Restrict to services on nodes with this label. Example of the generic property-restriction form.",
+                            description = "Restrict to services on nodes with this label. One of the generic property restrictions.",
                             schema = @Schema(type = "string"), example = "core-sw-01"),
                     @Parameter(in = ParameterIn.QUERY, name = "ipInterface.ipAddress",
                             description = "Restrict to services on this IP address.",
@@ -229,8 +229,8 @@ public class IfServicesRestService extends OnmsRestService {
                     Looks the monitored service up by its `ifservices` primary key, which is the `id` reported by
                     the search endpoint. This is the numeric service id, not a node id and not a service name.
 
-                    The method carries no `@Produces`, so the representation follows the request `Accept` header
-                    and defaults to XML when none is sent.""",
+                    The representation follows the request `Accept` header and defaults to XML when none is
+                    sent.""",
             operationId = "getIfServiceById"
     )
     @ApiResponses(value = {
@@ -279,8 +279,7 @@ public class IfServicesRestService extends OnmsRestService {
                     works exactly as it does for GET /ifservices, and `limit` and `offset` are cleared before the
                     update, so every match is affected, not just the first page.
 
-                    With no query parameters the selection is every monitored service in the system. Scope the
-                    request with something like `node.label` or `category.name` unless that is what is wanted.
+                    With no query parameters the selection is every monitored service in the system.
 
                     `status=S` and a transition from `A` to `F` store `F` and send both
                     `serviceUnmanaged` and `suspendPollingService`. `status=R` and a transition from `F` to `A`
@@ -305,8 +304,8 @@ public class IfServicesRestService extends OnmsRestService {
                     comma-separated list of service names within the selection; names that match nothing simply
                     leave the selection untouched.
 
-                    The method declares no `@Consumes`, so it will accept any content type, but only a
-                    form-encoded body deserializes. A JSON body fails with HTTP 500.""",
+                    Any content type is accepted, but only a form-encoded body deserializes; a JSON body fails
+                    with HTTP 500.""",
             content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
                     schema = @Schema(type = "string"),
                     examples = {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/IfServicesRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/IfServicesRestService.java
@@ -119,7 +119,7 @@ public class IfServicesRestService extends OnmsRestService {
                     `ipInterface.snmpInterface` as `snmpInterface` and `serviceType`, so restrictions such as
                     `node.label`, `ipInterface.ipAddress`, `category.name` and `serviceType.name` all resolve.
                     A value of `null` or `notnull` becomes an is-null / is-not-null test instead of an equality
-                    test. Unknown property names are logged and ignored rather than rejected.
+                    test. Unknown property names are not ignored: the filter still binds them and the query fails with 500 `Unknown entity: null`.
 
                     Results are ordered by `id`. `totalCount` counts all matches, `count` the returned page.""",
             operationId = "searchIfServices",
@@ -281,9 +281,10 @@ public class IfServicesRestService extends OnmsRestService {
 
                     With no query parameters the selection is every monitored service in the system.
 
-                    `status=S` and a transition from `A` to `F` store `F` and send both
-                    `serviceUnmanaged` and `suspendPollingService`. `status=R` and a transition from `F` to `A`
-                    store `A` and send `resumePollingService`.""",
+                    The supplied `status` letter is stored as-is, including the literal `S` or `R`; unlike the
+                    per-service endpoint there is no rewrite to `F` or `A`. `status=S`, and a transition from
+                    `A` to `F`, send `serviceUnmanaged` and `suspendPollingService`; `status=R`, and a
+                    transition from `F` to `A`, send `resumePollingService`.""",
             operationId = "updateIfServices",
             parameters = {
                     @Parameter(in = ParameterIn.QUERY, name = "node.label",

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/IfServicesRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/IfServicesRestService.java
@@ -36,6 +36,15 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.criteria.Alias.JoinType;
 import org.opennms.core.criteria.Criteria;
@@ -99,6 +108,105 @@ public class IfServicesRestService extends OnmsRestService {
 
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Search monitored services",
+            description = """
+                    Returns a flat list of monitored services across all nodes, each with its polling status.
+
+                    Every query parameter that is not one of the paging parameters below is read as a property
+                    restriction on `OnmsMonitoredService`. Joins are pre-registered for `ipInterface`,
+                    `ipInterface.node` as `node`, `ipInterface.node.categories` as `category`,
+                    `ipInterface.snmpInterface` as `snmpInterface` and `serviceType`, so restrictions such as
+                    `node.label`, `ipInterface.ipAddress`, `category.name` and `serviceType.name` all resolve.
+                    A value of `null` or `notnull` becomes an is-null / is-not-null test instead of an equality
+                    test. Unknown property names are logged and ignored rather than rejected.
+
+                    Results are ordered by `id`. `totalCount` counts all matches, `count` the returned page.""",
+            operationId = "searchIfServices",
+            parameters = {
+                    @Parameter(in = ParameterIn.QUERY, name = "limit",
+                            description = "Maximum rows to return. 0 disables the limit.",
+                            schema = @Schema(type = "integer", defaultValue = "10"), example = "25"),
+                    @Parameter(in = ParameterIn.QUERY, name = "offset",
+                            description = "Zero-based index of the first row to return.",
+                            schema = @Schema(type = "integer"), example = "0"),
+                    @Parameter(in = ParameterIn.QUERY, name = "orderBy",
+                            description = "Property to sort on, replacing the default `id` ordering.",
+                            schema = @Schema(type = "string"), example = "serviceType.name"),
+                    @Parameter(in = ParameterIn.QUERY, name = "order",
+                            description = "Sort direction for `orderBy`. Anything other than `desc` is read as ascending.",
+                            schema = @Schema(type = "string", allowableValues = {"asc", "desc"}), example = "asc"),
+                    @Parameter(in = ParameterIn.QUERY, name = "comparator",
+                            description = "Comparison applied to every property restriction in the query.",
+                            schema = @Schema(type = "string", defaultValue = "eq",
+                                    allowableValues = {"eq", "ne", "gt", "lt", "ge", "le", "like", "ilike", "contains", "iplike"}),
+                            example = "ilike"),
+                    @Parameter(in = ParameterIn.QUERY, name = "match",
+                            description = "Whether the property restrictions are combined with AND or OR.",
+                            schema = @Schema(type = "string", defaultValue = "all", allowableValues = {"all", "any"}),
+                            example = "any"),
+                    @Parameter(in = ParameterIn.QUERY, name = "node.label",
+                            description = "Restrict to services on nodes with this label. Example of the generic property-restriction form.",
+                            schema = @Schema(type = "string"), example = "core-sw-01"),
+                    @Parameter(in = ParameterIn.QUERY, name = "ipInterface.ipAddress",
+                            description = "Restrict to services on this IP address.",
+                            schema = @Schema(type = "string"), example = "192.0.2.10"),
+                    @Parameter(in = ParameterIn.QUERY, name = "category.name",
+                            description = "Restrict to services on nodes in this surveillance category.",
+                            schema = @Schema(type = "string"), example = "Production"),
+                    @Parameter(in = ParameterIn.QUERY, name = "serviceType.name",
+                            description = "Restrict to services of this type.",
+                            schema = @Schema(type = "string"), example = "ICMP")
+            }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Matching monitored services.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsMonitoredServiceDetailList.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 2,
+                      "count": 2,
+                      "offset": 0,
+                      "monitored-service": [
+                        {
+                          "id": "23616",
+                          "status": "Managed",
+                          "serviceName": "ICMP",
+                          "statusCode": "A",
+                          "ipAddress": "192.0.2.10",
+                          "ipInterfaceId": 23601,
+                          "isMonitored": true,
+                          "node": "core-sw-01",
+                          "isDown": false
+                        },
+                        {
+                          "id": "23619",
+                          "status": "Forced Unmanaged",
+                          "serviceName": "SNMP",
+                          "statusCode": "F",
+                          "ipAddress": "192.0.2.10",
+                          "ipInterfaceId": 23601,
+                          "isMonitored": false,
+                          "node": "core-sw-01",
+                          "isDown": false
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsMonitoredServiceDetailList.class),
+                                    examples = @ExampleObject(value = """
+                    <monitored-services count="1" offset="0" totalCount="1">
+                      <monitored-service isDown="false" id="23616" ipInterfaceId="23601" isMonitored="true" statusCode="A">
+                        <ipAddress>192.0.2.10</ipAddress>
+                        <node>core-sw-01</node>
+                        <serviceName>ICMP</serviceName>
+                        <status>Managed</status>
+                      </monitored-service>
+                    </monitored-services>"""))
+                    })
+    })
     public OnmsMonitoredServiceDetailList getServices(@Context final UriInfo uriInfo) {
         final Criteria c = getCriteria(uriInfo.getQueryParameters());
         final OnmsMonitoredServiceDetailList servicesList = new OnmsMonitoredServiceDetailList();
@@ -115,7 +223,47 @@ public class IfServicesRestService extends OnmsRestService {
 
     @GET
     @Path("/{id}")
-    public Response getServiceById(@PathParam("id") Integer monitoredServiceId) {
+    @Operation(
+            summary = "Get one monitored service by database id",
+            description = """
+                    Looks the monitored service up by its `ifservices` primary key, which is the `id` reported by
+                    the search endpoint. This is the numeric service id, not a node id and not a service name.
+
+                    The method carries no `@Produces`, so the representation follows the request `Accept` header
+                    and defaults to XML when none is sent.""",
+            operationId = "getIfServiceById"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The monitored service.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsMonitoredServiceDetail.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "id": "23616",
+                      "status": "Managed",
+                      "serviceName": "ICMP",
+                      "statusCode": "A",
+                      "ipAddress": "192.0.2.10",
+                      "ipInterfaceId": 23601,
+                      "isMonitored": true,
+                      "node": "core-sw-01",
+                      "isDown": false
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsMonitoredServiceDetail.class),
+                                    examples = @ExampleObject(value = """
+                    <monitored-service isDown="false" id="23616" ipInterfaceId="23601" isMonitored="true" statusCode="A">
+                      <ipAddress>192.0.2.10</ipAddress>
+                      <node>core-sw-01</node>
+                      <serviceName>ICMP</serviceName>
+                      <status>Managed</status>
+                    </monitored-service>"""))
+                    }),
+            @ApiResponse(responseCode = "404", description = "No monitored service has that id. Also returned when `id` is not an integer, since the path then matches no method. The body is empty.")
+    })
+    public Response getServiceById(@Parameter(description = "Primary key of the monitored service, as reported by GET /ifservices.", example = "23616")
+                                   @PathParam("id") Integer monitoredServiceId) {
         OnmsMonitoredService monitoredService = m_serviceDao.get(monitoredServiceId);
         if (monitoredService == null) {
             return Response.status(Status.NOT_FOUND).build();
@@ -124,6 +272,65 @@ public class IfServicesRestService extends OnmsRestService {
     }
 
     @PUT
+    @Operation(
+            summary = "Set the polling status of every matching monitored service",
+            description = """
+                    Bulk update of the poller status of the services selected by the query string. The selection
+                    works exactly as it does for GET /ifservices, and `limit` and `offset` are cleared before the
+                    update, so every match is affected, not just the first page.
+
+                    With no query parameters the selection is every monitored service in the system. Scope the
+                    request with something like `node.label` or `category.name` unless that is what is wanted.
+
+                    `status=S` and a transition from `A` to `F` store `F` and send both
+                    `serviceUnmanaged` and `suspendPollingService`. `status=R` and a transition from `F` to `A`
+                    store `A` and send `resumePollingService`.""",
+            operationId = "updateIfServices",
+            parameters = {
+                    @Parameter(in = ParameterIn.QUERY, name = "node.label",
+                            description = "Restrict the update to services on nodes with this label. Any `OnmsMonitoredService` property path accepted by GET /ifservices works here too.",
+                            schema = @Schema(type = "string"), example = "core-sw-01"),
+                    @Parameter(in = ParameterIn.QUERY, name = "ipInterface.ipAddress",
+                            description = "Restrict the update to services on this IP address.",
+                            schema = @Schema(type = "string"), example = "192.0.2.10"),
+                    @Parameter(in = ParameterIn.QUERY, name = "category.name",
+                            description = "Restrict the update to services on nodes in this surveillance category.",
+                            schema = @Schema(type = "string"), example = "Production")
+            }
+    )
+    @RequestBody(
+            required = true,
+            description = """
+                    Form-encoded body. `status` is required. `services` optionally narrows the update to a
+                    comma-separated list of service names within the selection; names that match nothing simply
+                    leave the selection untouched.
+
+                    The method declares no `@Consumes`, so it will accept any content type, but only a
+                    form-encoded body deserializes. A JSON body fails with HTTP 500.""",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "string"),
+                    examples = {
+                            @ExampleObject(name = "forceUnmanaged", summary = "Force every selected service unmanaged",
+                                    value = "status=F"),
+                            @ExampleObject(name = "resumeTwoServices", summary = "Resume polling for ICMP and HTTP only",
+                                    value = "status=R&services=ICMP,HTTP")
+                    })
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "At least one service was updated. No body."),
+            @ApiResponse(responseCode = "304", description = "The selection was non-empty but `services` excluded every member of it, so nothing was written."),
+            @ApiResponse(responseCode = "400", description = "`status` is missing or not one of A, F, R, S, or the query string selected no service.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "badStatus", value = "Parameter status must be specified. Possible values: A (Managed), F (Forced Unmanaged), R (Rescan to Resume), S (Rescan to Suspend)"),
+                                    @ExampleObject(name = "noMatch", value = "Can't find any service matching the provided criteria: {node.label=[nosuchnode]}.")
+                            })),
+            @ApiResponse(responseCode = "500", description = "Sending event to the event bus failed, or the body was not form-encoded.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Can not deserialize instance of java.util.ArrayList out of VALUE_STRING token")))
+    })
     public Response updateServices(@Context final UriInfo uriInfo, final MultivaluedMapImpl params) {
         final String status = params.getFirst("status");
         if (status == null || !status.matches("(A|R|S|F)")) {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/InfoRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/InfoRestService.java
@@ -37,6 +37,12 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.resource.Vault;
 import org.opennms.core.time.CentralizedDateTimeFormat;
@@ -66,6 +72,49 @@ public class InfoRestService extends OnmsRestService {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Get instance information",
+            description = """
+        Report the version and package identity of this OpenNMS instance, the ticketer configuration, the
+        date/time format settings that apply to the calling session, and the run state of the daemons.
+
+        `services` is a map of daemon name to state, gathered from the running instance over the management
+        JMX/RMI connection. If that lookup fails the field comes back as an empty object and the rest of
+        the payload is still returned, so an empty `services` means "could not be determined" rather than
+        "no daemons".
+
+        `datetimeformatConfig.zoneId` comes from the HTTP session when the caller has one and falls back to
+        the server's default zone otherwise, so it can differ between a browser session and a plain
+        API call. `ticketerConfig.plugin` is only populated when ticketing is enabled.""",
+            operationId = "getInfo"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Instance information.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = InfoDTO.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "displayVersion": "36.0.4-SNAPSHOT",
+                      "version": "36.0.4",
+                      "packageName": "opennms",
+                      "packageDescription": "OpenNMS",
+                      "ticketerConfig": {
+                        "plugin": null,
+                        "enabled": false
+                      },
+                      "datetimeformatConfig": {
+                        "zoneId": "America/New_York",
+                        "datetimeformat": "yyyy-MM-dd'T'HH:mm:ssxxx"
+                      },
+                      "services": {
+                        "Eventd": "running",
+                        "Alarmd": "running",
+                        "Pollerd": "running",
+                        "Collectd": "running",
+                        "Trapd": "running"
+                      }
+                    }""")))
+    })
     public Response getInfo(@Context HttpServletRequest httpServletRequest) throws ParseException {
         final SystemInfoUtils sysInfoUtils = new SystemInfoUtils();
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/InfoRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/InfoRestService.java
@@ -80,12 +80,11 @@ public class InfoRestService extends OnmsRestService {
 
         `services` is a map of daemon name to state, gathered from the running instance over the management
         JMX/RMI connection. If that lookup fails the field comes back as an empty object and the rest of
-        the payload is still returned, so an empty `services` means "could not be determined" rather than
-        "no daemons".
+        the payload is still returned.
 
         `datetimeformatConfig.zoneId` comes from the HTTP session when the caller has one and falls back to
-        the server's default zone otherwise, so it can differ between a browser session and a plain
-        API call. `ticketerConfig.plugin` is only populated when ticketing is enabled.""",
+        the server's default zone otherwise. `ticketerConfig.plugin` is only populated when ticketing is
+        enabled.""",
             operationId = "getInfo"
     )
     @ApiResponses(value = {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/KscRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/KscRestService.java
@@ -72,7 +72,7 @@ import org.springframework.transaction.annotation.Transactional;
         KSC (Key SNMP Customized) report API, backed by `ksc-performance-reports.xml`.
 
         A KSC report is a numbered collection of graph definitions. The id is chosen by the caller, not
-        assigned by the server, and it is what every other operation addresses.
+        assigned by the server, and every other operation addresses the report by it.
 
         `timespan` on a graph is validated against a fixed list and silently replaced with `7_day` when it
         does not match, so an unrecognised timespan is accepted rather than rejected.
@@ -99,7 +99,7 @@ public class KscRestService extends OnmsRestService {
 
         This listing is terse: only `id` and `label` are populated. `show_timespan_button`,
         `show_graphtype_button` and `graphs_per_line` come back null and `kscGraph` comes back empty even
-        for reports that set them. Fetch a single report to see those fields.""",
+        for reports that set them.""",
             operationId = "getKscReports"
     )
     @ApiResponses(value = {
@@ -142,8 +142,8 @@ public class KscRestService extends OnmsRestService {
             description = """
         Return a single KSC report with all of its graph definitions.
 
-        Unlike the listing, this form populates `show_timespan_button`, `show_graphtype_button`,
-        `graphs_per_line` and the `kscGraph` array. `graphs_per_line` is 0 when the report does not set it.""",
+        `show_timespan_button`, `show_graphtype_button`, `graphs_per_line` and the `kscGraph` array are all
+        populated. `graphs_per_line` is 0 when the report does not set it.""",
             operationId = "getKscReport"
     )
     @ApiResponses(value = {
@@ -221,8 +221,7 @@ public class KscRestService extends OnmsRestService {
             summary = "Reload the KSC report configuration",
             description = """
         Re-read `ksc-performance-reports.xml` from disk and replace the in-memory report set with what it
-        contains. Use this after editing the file directly, including to drop a report that the API has no
-        delete operation for.""",
+        contains.""",
             operationId = "reloadKscConfig"
     )
     @ApiResponses(value = {
@@ -255,9 +254,9 @@ public class KscRestService extends OnmsRestService {
 
         `reportName` is a prefabricated graph name (see `GET /graphs`) and `resourceId` is a resource id
         (see `GET /resources`). Both are required and neither is checked for existence, so a graph naming a
-        resource that does not exist is stored and only fails when something tries to render it.
+        resource that does not exist is stored.
 
-        Graphs are only ever appended. There is no operation to replace or remove one.""",
+        Graphs are only appended; there is no operation to replace or remove one.""",
             operationId = "addGraphToKscReport"
     )
     @ApiResponses(value = {
@@ -346,7 +345,7 @@ public class KscRestService extends OnmsRestService {
 
         This operation consumes XML only; a JSON body is rejected by the container with 415. The body maps
         onto XML attributes rather than elements, and the field names are underscored
-        (`show_timespan_button`, `graphs_per_line`), which is what the derived schema shows.
+        (`show_timespan_button`, `graphs_per_line`).
 
         `Location` on the 201 points at `GET /ksc/{reportId}` for the new report. Graphs may be supplied
         inline as `kscGraph` elements, or added afterwards with `PUT /ksc/{kscReportId}`.""",
@@ -354,7 +353,7 @@ public class KscRestService extends OnmsRestService {
     )
     @RequestBody(
             required = true,
-            description = "The report to create, including any graphs it should start with.",
+            description = "The report to create, including any graphs it starts with.",
             content = @Content(mediaType = MediaType.APPLICATION_XML,
                     schema = @Schema(implementation = KscReport.class),
                     examples = @ExampleObject(value = """
@@ -374,7 +373,8 @@ public class KscRestService extends OnmsRestService {
             @ApiResponse(responseCode = "409", description = "A report with that id already exists.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "Invalid request: Existing KSC report found with ID: 8100.")))
+                            examples = @ExampleObject(value = "Invalid request: Existing KSC report found with ID: 8100."))),
+            @ApiResponse(responseCode = "415", description = "The body was not `application/xml`, or no `Content-Type` was sent. The response has no body.")
     })
     public Response addKscReport(@Context final UriInfo uriInfo, final KscReport kscReport) {
         writeLock();

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/KscRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/KscRestService.java
@@ -261,7 +261,7 @@ public class KscRestService extends OnmsRestService {
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "The graph was appended and the configuration saved."),
-            @ApiResponse(responseCode = "400", description = "`reportName` or `resourceId` was missing or empty.",
+            @ApiResponse(responseCode = "400", description = "`reportName` or `resourceId` was missing. The empty-string check compares by reference, so an empty parameter is not reliably rejected.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Invalid request: reportName and resourceId cannot be empty!"))),
@@ -288,8 +288,7 @@ public class KscRestService extends OnmsRestService {
             @QueryParam("resourceId") final String resourceId,
             @Parameter(description = "Time window for the graph. An unrecognised value is replaced with `7_day` without an error.",
                     example = "7_day",
-                    schema = @Schema(allowableValues = {"1_hour", "2_hour", "4_hour", "6_hour", "8_hour", "12_hour",
-                            "1_day", "2_day", "7_day", "1_month", "3_month", "6_month", "1_year"}))
+                    schema = @Schema(allowableValues = {"1_hour", "2_hour", "4_hour", "6_hour", "8_hour", "12_hour", "1_day", "2_day", "7_day", "1_month", "3_month", "6_month", "1_year", "Today", "Yesterday", "Yesterday 9am-5pm", "Yesterday 5pm-10pm", "This Week", "Last Week", "This Month", "Last Month", "This Quarter", "Last Quarter", "This Year", "Last Year"}))
             @QueryParam("timespan") String timespan) {
         writeLock();
 
@@ -552,8 +551,7 @@ public class KscRestService extends OnmsRestService {
         private String m_title;
 
         @Schema(description = "Time window for the graph. An unrecognised value is stored as `7_day`.", example = "7_day",
-                allowableValues = {"1_hour", "2_hour", "4_hour", "6_hour", "8_hour", "12_hour", "1_day", "2_day",
-                        "7_day", "1_month", "3_month", "6_month", "1_year"})
+                allowableValues = {"1_hour", "2_hour", "4_hour", "6_hour", "8_hour", "12_hour", "1_day", "2_day", "7_day", "1_month", "3_month", "6_month", "1_year", "Today", "Yesterday", "Yesterday 9am-5pm", "Yesterday 5pm-10pm", "This Week", "Last Week", "This Month", "Last Month", "This Quarter", "Last Quarter", "This Year", "Last Year"})
         @XmlAttribute(name = "timespan", required = true)
         private String m_timespan;
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/KscRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/KscRestService.java
@@ -46,6 +46,14 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.config.api.JaxbListWrapper;
 import org.opennms.netmgt.config.KSC_PerformanceReportFactory;
@@ -60,7 +68,17 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Component("kscRestService")
 @Path("ksc")
-@Tag(name = "Ksc", description = "Ksc API")
+@Tag(name = "Ksc", description = """
+        KSC (Key SNMP Customized) report API, backed by `ksc-performance-reports.xml`.
+
+        A KSC report is a numbered collection of graph definitions. The id is chosen by the caller, not
+        assigned by the server, and it is what every other operation addresses.
+
+        `timespan` on a graph is validated against a fixed list and silently replaced with `7_day` when it
+        does not match, so an unrecognised timespan is accepted rather than rejected.
+
+        Writes go straight to `ksc-performance-reports.xml`. There is no delete operation here: removing a
+        report means editing that file and calling `PUT /ksc/reloadConfig`.""")
 public class KscRestService extends OnmsRestService {
 
     private static final Logger LOG = LoggerFactory.getLogger(KscRestService.class);
@@ -74,6 +92,41 @@ public class KscRestService extends OnmsRestService {
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
+    @Operation(
+            summary = "List KSC reports",
+            description = """
+        List every KSC report in `ksc-performance-reports.xml`.
+
+        This listing is terse: only `id` and `label` are populated. `show_timespan_button`,
+        `show_graphtype_button` and `graphs_per_line` come back null and `kscGraph` comes back empty even
+        for reports that set them. Fetch a single report to see those fields.""",
+            operationId = "getKscReports"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The KSC reports, in terse form.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = KscReportCollection.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 1,
+                      "count": 1,
+                      "offset": 0,
+                      "kscReport": [
+                        {
+                          "id": 8100,
+                          "label": "Response time overview",
+                          "show_timespan_button": null,
+                          "show_graphtype_button": null,
+                          "graphs_per_line": null,
+                          "kscGraph": []
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = KscReportCollection.class))
+                    })
+    })
     public KscReportCollection getReports() throws ParseException {
         final KscReportCollection reports = new KscReportCollection(m_kscReportService.getReportMap(), true);
         reports.setTotalCount(reports.size());
@@ -84,7 +137,52 @@ public class KscRestService extends OnmsRestService {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Path("{reportId}")
     @Transactional
-    public KscReport getReport(@PathParam("reportId") final Integer reportId) {
+    @Operation(
+            summary = "Get one KSC report",
+            description = """
+        Return a single KSC report with all of its graph definitions.
+
+        Unlike the listing, this form populates `show_timespan_button`, `show_graphtype_button`,
+        `graphs_per_line` and the `kscGraph` array. `graphs_per_line` is 0 when the report does not set it.""",
+            operationId = "getKscReport"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The KSC report.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = KscReport.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "id": 8100,
+                      "label": "Response time overview",
+                      "show_timespan_button": true,
+                      "show_graphtype_button": true,
+                      "graphs_per_line": 2,
+                      "kscGraph": [
+                        {
+                          "title": "Response time, loopback-001",
+                          "timespan": "7_day",
+                          "graphtype": "http-8080",
+                          "resourceId": "node[loopback-lab:lb-001].responseTime[127.0.0.1]",
+                          "nodeId": null,
+                          "nodeSource": null,
+                          "domain": null,
+                          "interfaceId": null,
+                          "extlink": null
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = KscReport.class))
+                    }),
+            @ApiResponse(responseCode = "404", description = "No report with that id exists.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "No such report id 8100.")))
+    })
+    public KscReport getReport(
+            @Parameter(description = "Report id, as assigned when the report was created.", required = true, example = "8100")
+            @PathParam("reportId") final Integer reportId) {
         final Map<Integer, Report> reportList = m_kscReportService.getReportMap();
         final Report report = reportList.get(reportId);
         if (report == null) {
@@ -97,6 +195,21 @@ public class KscRestService extends OnmsRestService {
     @Produces(MediaType.TEXT_PLAIN)
     @Path("count")
     @Transactional
+    @Operation(
+            summary = "Count KSC reports",
+            description = """
+        Return the number of KSC reports as a plain-text integer.
+
+        This operation only produces `text/plain`. A request with `Accept: application/json` does not match
+        it and falls through to `GET /ksc/{reportId}`, which then answers 404 for the literal id `count`.""",
+            operationId = "getKscReportCount"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The number of reports.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "1")))
+    })
     public String getCount() {
         return Integer.toString(m_kscReportService.getReportList().size());
     }
@@ -104,6 +217,20 @@ public class KscRestService extends OnmsRestService {
     @PUT
     @Path("reloadConfig")
     @Transactional
+    @Operation(
+            summary = "Reload the KSC report configuration",
+            description = """
+        Re-read `ksc-performance-reports.xml` from disk and replace the in-memory report set with what it
+        contains. Use this after editing the file directly, including to drop a report that the API has no
+        delete operation for.""",
+            operationId = "reloadKscConfig"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The configuration was reloaded."),
+            @ApiResponse(responseCode = "500", description = "The configuration could not be reloaded, for instance because the file no longer parses.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string")))
+    })
     public Response reloadConfiguration() {
         writeLock();
         try {
@@ -119,7 +246,52 @@ public class KscRestService extends OnmsRestService {
     @PUT
     @Path("{kscReportId}")
     @Transactional
-    public Response addGraph(@PathParam("kscReportId") final Integer kscReportId, @QueryParam("title") final String title, @QueryParam("reportName") final String reportName, @QueryParam("resourceId") final String resourceId, @QueryParam("timespan") String timespan) {
+    @Operation(
+            summary = "Add a graph to a KSC report",
+            description = """
+        Append one graph to an existing KSC report. The graph is described entirely by query parameters;
+        this operation takes no body. The report is written back to `ksc-performance-reports.xml`
+        immediately.
+
+        `reportName` is a prefabricated graph name (see `GET /graphs`) and `resourceId` is a resource id
+        (see `GET /resources`). Both are required and neither is checked for existence, so a graph naming a
+        resource that does not exist is stored and only fails when something tries to render it.
+
+        Graphs are only ever appended. There is no operation to replace or remove one.""",
+            operationId = "addGraphToKscReport"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The graph was appended and the configuration saved."),
+            @ApiResponse(responseCode = "400", description = "`reportName` or `resourceId` was missing or empty.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Invalid request: reportName and resourceId cannot be empty!"))),
+            @ApiResponse(responseCode = "404", description = "No report with that id exists.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Invalid request: No KSC report found with ID: 99999."))),
+            @ApiResponse(responseCode = "500", description = "The configuration could not be written back.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot save report with Id 8100 : <cause>")))
+    })
+    public Response addGraph(
+            @Parameter(description = "Report id to append to.", required = true, example = "8100")
+            @PathParam("kscReportId") final Integer kscReportId,
+            @Parameter(description = "Title shown above the graph. Optional; the graph is stored without a title when omitted.",
+                    example = "Response time, loopback-001")
+            @QueryParam("title") final String title,
+            @Parameter(description = "Name of the prefabricated graph to render, as listed by `GET /graphs`.",
+                    required = true, example = "http-8080")
+            @QueryParam("reportName") final String reportName,
+            @Parameter(description = "Resource id the graph is drawn from, as listed by `GET /resources`.",
+                    required = true, example = "node[loopback-lab:lb-001].responseTime[127.0.0.1]")
+            @QueryParam("resourceId") final String resourceId,
+            @Parameter(description = "Time window for the graph. An unrecognised value is replaced with `7_day` without an error.",
+                    example = "7_day",
+                    schema = @Schema(allowableValues = {"1_hour", "2_hour", "4_hour", "6_hour", "8_hour", "12_hour",
+                            "1_day", "2_day", "7_day", "1_month", "3_month", "6_month", "1_year"}))
+            @QueryParam("timespan") String timespan) {
         writeLock();
 
         try {
@@ -166,6 +338,44 @@ public class KscRestService extends OnmsRestService {
 
     @POST
     @Consumes(MediaType.APPLICATION_XML)
+    @Operation(
+            summary = "Create a KSC report",
+            description = """
+        Create a KSC report and write it to `ksc-performance-reports.xml`. The report id is taken from the
+        body, not assigned by the server, and an id that is already in use is rejected with 409.
+
+        This operation consumes XML only; a JSON body is rejected by the container with 415. The body maps
+        onto XML attributes rather than elements, and the field names are underscored
+        (`show_timespan_button`, `graphs_per_line`), which is what the derived schema shows.
+
+        `Location` on the 201 points at `GET /ksc/{reportId}` for the new report. Graphs may be supplied
+        inline as `kscGraph` elements, or added afterwards with `PUT /ksc/{kscReportId}`.""",
+            operationId = "addKscReport"
+    )
+    @RequestBody(
+            required = true,
+            description = "The report to create, including any graphs it should start with.",
+            content = @Content(mediaType = MediaType.APPLICATION_XML,
+                    schema = @Schema(implementation = KscReport.class),
+                    examples = @ExampleObject(value = """
+                    <kscReport id="8100" label="Response time overview"
+                               show_timespan_button="true" show_graphtype_button="true" graphs_per_line="2">
+                      <kscGraph title="Response time, loopback-001"
+                                timespan="7_day"
+                                graphtype="http-8080"
+                                resourceId="node[loopback-lab:lb-001].responseTime[127.0.0.1]"/>
+                    </kscReport>"""))
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "The report was created. `Location` carries its URI."),
+            @ApiResponse(responseCode = "400", description = "The configuration could not be written back.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"))),
+            @ApiResponse(responseCode = "409", description = "A report with that id already exists.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Invalid request: Existing KSC report found with ID: 8100.")))
+    })
     public Response addKscReport(@Context final UriInfo uriInfo, final KscReport kscReport) {
         writeLock();
         try {
@@ -239,21 +449,27 @@ public class KscRestService extends OnmsRestService {
     @XmlAccessorType(XmlAccessType.NONE)
     public static final class KscReport {
 
+        @Schema(description = "Report id. Chosen by the caller when the report is created.", example = "8100", required = true)
         @XmlAttribute(name = "id", required = true)
         private Integer m_id;
 
+        @Schema(description = "Report title, shown in the KSC report list.", example = "Response time overview", required = true)
         @XmlAttribute(name = "label", required = true)
         private String m_label;
 
+        @Schema(description = "Whether the report page offers a timespan selector. Null in the terse listing.", example = "true")
         @XmlAttribute(name = "show_timespan_button", required = false)
         private Boolean m_show_timespan_button;
 
+        @Schema(description = "Whether the report page offers a graph-type selector. Null in the terse listing.", example = "true")
         @XmlAttribute(name = "show_graphtype_button", required = false)
         private Boolean m_show_graphtype_button;
 
+        @Schema(description = "Graphs to lay out per row. 0 when the report does not set it, null in the terse listing.", example = "2")
         @XmlAttribute(name = "graphs_per_line", required = false)
         private Integer m_graphs_per_line;
 
+        @Schema(description = "Graph definitions in the report. Always empty in the terse listing.")
         @XmlElement(name = "kscGraph")
         private List<KscGraph> m_graphs = new ArrayList<>();
 
@@ -331,30 +547,42 @@ public class KscRestService extends OnmsRestService {
     @XmlAccessorType(XmlAccessType.NONE)
     public static final class KscGraph {
 
+        @Schema(description = "Title shown above the graph.", example = "Response time, loopback-001")
         @XmlAttribute(name = "title", required = true)
         private String m_title;
 
+        @Schema(description = "Time window for the graph. An unrecognised value is stored as `7_day`.", example = "7_day",
+                allowableValues = {"1_hour", "2_hour", "4_hour", "6_hour", "8_hour", "12_hour", "1_day", "2_day",
+                        "7_day", "1_month", "3_month", "6_month", "1_year"})
         @XmlAttribute(name = "timespan", required = true)
         private String m_timespan;
 
+        @Schema(description = "Prefabricated graph name, as listed by `GET /graphs`.", example = "http-8080", required = true)
         @XmlAttribute(name = "graphtype", required = true)
         private String m_graphtype;
 
+        @Schema(description = "Resource id the graph is drawn from, as listed by `GET /resources`.",
+                example = "node[loopback-lab:lb-001].responseTime[127.0.0.1]")
         @XmlAttribute(name = "resourceId", required = false)
         private String m_resourceId;
 
+        @Schema(description = "Legacy way of addressing a node graph, superseded by `resourceId`.", example = "1")
         @XmlAttribute(name = "nodeId", required = false)
         private String m_nodeId;
 
+        @Schema(description = "Legacy foreignSource:foreignId form of `nodeId`.", example = "loopback-lab:lb-001")
         @XmlAttribute(name = "nodeSource", required = false)
         private String m_nodeSource;
 
+        @Schema(description = "Legacy domain name for a domain-scoped graph, superseded by `resourceId`.", example = "example.com")
         @XmlAttribute(name = "domain", required = false)
         private String m_domain;
 
+        @Schema(description = "Legacy interface identifier for an interface-scoped graph, superseded by `resourceId`.", example = "127.0.0.1")
         @XmlAttribute(name = "interfaceId", required = false)
         private String m_interfaceId;
 
+        @Schema(description = "URL the graph links out to when clicked.", example = "https://example.org/dashboard")
         @XmlAttribute(name = "extlink", required = false)
         private String m_extlink;
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/LogRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/LogRestService.java
@@ -46,6 +46,14 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.commons.io.input.ReversedLinesFileReader;
 import org.opennms.web.api.Authentication;
@@ -53,7 +61,14 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Path("logs")
-@Tag(name = "Logs", description = "Logs API")
+@Tag(name = "Logs", description = """
+        Logs API: read access to the `.log` files in the OpenNMS log directory.
+
+        Both operations require `ROLE_ADMIN`, enforced both by the servlet security configuration and again
+        in the handler.
+
+        Only files directly in the log directory whose name ends in `.log` are reachable. Anything else,
+        including a path that would escape the directory, is rejected with 400.""")
 public class LogRestService {
 
     public static final int DEFAULT_NUM_LINES = 5000;
@@ -67,6 +82,27 @@ public class LogRestService {
     @GET
     @Path("/")
     @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "List log files",
+            description = """
+        List the names of the `.log` files directly in the OpenNMS log directory, sorted. Rotated and
+        compressed files are not listed, since only the `.log` suffix is matched.""",
+            operationId = "getLogFiles"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The log file names.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            array = @ArraySchema(schema = @Schema(type = "string")),
+                            examples = @ExampleObject(value = """
+                    [
+                      "alarmd.log",
+                      "collectd.log",
+                      "eventd.log",
+                      "poller.log",
+                      "web.log"
+                    ]"""))),
+            @ApiResponse(responseCode = "403", description = "The caller does not hold `ROLE_ADMIN`.")
+    })
     public List<String> getLogFiles(@Context SecurityContext securityContext) {
         if (!securityContext.isUserInRole(Authentication.ROLE_ADMIN)) {
             throw new ForbiddenException("ADMIN role is required for enumerating log files.");
@@ -85,7 +121,44 @@ public class LogRestService {
 
     @GET
     @Path("/contents")
-    public Response getFileContents(@QueryParam("f") String fileName, @QueryParam("n") Integer numLines, @QueryParam("reverse") @DefaultValue("true") boolean reverse, @Context SecurityContext securityContext) {
+    @Operation(
+            summary = "Read the tail of a log file",
+            description = """
+        Return the last `n` lines of a log file as text. The file is always read backwards from the end, so
+        the cost is bounded by `n` rather than by the size of the file.
+
+        `n` defaults to 5000 and is clamped to the range 1 to 10000, so values outside that are quietly
+        adjusted rather than rejected. `reverse` controls only the order the lines are returned in: true, the
+        default, gives newest first.
+
+        The response media type is probed from the file rather than fixed, so it is typically
+        `application/octet-stream` for a `.log` file. A name that exists in the directory listing but whose
+        file has since gone returns 204 with no body.""",
+            operationId = "getLogFileContents"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The requested lines, newline-separated.",
+                    content = @Content(schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = """
+                    2026-08-26 02:57:48,374 DEBUG [qtp450304221-76882] o.a.c.p.PhaseInterceptorChain: Invoking handleMessage on interceptor"""))),
+            @ApiResponse(responseCode = "204", description = "The file does not exist. No body."),
+            @ApiResponse(responseCode = "400", description = "The name does not end in `.log`, or is not directly inside the log directory.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot access files outside of log folder! Filename given: ../etc/opennms.log"))),
+            @ApiResponse(responseCode = "403", description = "The caller does not hold `ROLE_ADMIN`.")
+    })
+    public Response getFileContents(
+            @Parameter(description = "Log file name, as listed by `GET /logs`. Must end in `.log` and contain no path separators.",
+                    required = true, example = "web.log")
+            @QueryParam("f") String fileName,
+            @Parameter(description = "Number of lines to return, counted from the end of the file. Clamped to 1..10000; defaults to 5000.",
+                    example = "200")
+            @QueryParam("n") Integer numLines,
+            @Parameter(description = "True, the default, returns the lines newest first. False returns them in file order.",
+                    example = "true")
+            @QueryParam("reverse") @DefaultValue("true") boolean reverse,
+            @Context SecurityContext securityContext) {
         if (!securityContext.isUserInRole(Authentication.ROLE_ADMIN)) {
             throw new ForbiddenException("ADMIN role is required for reading log files.");
         }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/LogRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/LogRestService.java
@@ -64,8 +64,8 @@ import org.springframework.stereotype.Component;
 @Tag(name = "Logs", description = """
         Read access to the `.log` files in the OpenNMS log directory.
 
-        Both operations require `ROLE_ADMIN`, enforced both by the servlet security configuration and again
-        in the handler.
+        Both operations require `ROLE_ADMIN`, enforced by the check in the handler itself; the shipped
+        security configuration has no rule for `/rest/logs`.
 
         Only files directly in the log directory whose name ends in `.log` are reachable. Anything else,
         including a path that would escape the directory, is rejected with 400.""")
@@ -141,10 +141,7 @@ public class LogRestService {
                             examples = @ExampleObject(value = """
                     2026-08-26 02:57:48,374 DEBUG [qtp450304221-76882] o.a.c.p.PhaseInterceptorChain: Invoking handleMessage on interceptor"""))),
             @ApiResponse(responseCode = "204", description = "The file does not exist. No body."),
-            @ApiResponse(responseCode = "400", description = "The name does not end in `.log`, or is not directly inside the log directory.",
-                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
-                            schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "Cannot access files outside of log folder! Filename given: ../etc/opennms.log"))),
+            @ApiResponse(responseCode = "400", description = "The name does not end in `.log`, or is not directly inside the log directory. The body is empty: the message-only exception is mapped without its message."),
             @ApiResponse(responseCode = "403", description = "The caller does not hold `ROLE_ADMIN`.")
     })
     public Response getFileContents(

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/LogRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/LogRestService.java
@@ -62,7 +62,7 @@ import org.springframework.stereotype.Component;
 @Component
 @Path("logs")
 @Tag(name = "Logs", description = """
-        Logs API: read access to the `.log` files in the OpenNMS log directory.
+        Read access to the `.log` files in the OpenNMS log directory.
 
         Both operations require `ROLE_ADMIN`, enforced both by the servlet security configuration and again
         in the handler.
@@ -85,8 +85,8 @@ public class LogRestService {
     @Operation(
             summary = "List log files",
             description = """
-        List the names of the `.log` files directly in the OpenNMS log directory, sorted. Rotated and
-        compressed files are not listed, since only the `.log` suffix is matched.""",
+        List the names of the `.log` files directly in the OpenNMS log directory, sorted. Only the `.log`
+        suffix is matched, so rotated and compressed files are not listed.""",
             operationId = "getLogFiles"
     )
     @ApiResponses(value = {
@@ -124,14 +124,13 @@ public class LogRestService {
     @Operation(
             summary = "Read the tail of a log file",
             description = """
-        Return the last `n` lines of a log file as text. The file is always read backwards from the end, so
-        the cost is bounded by `n` rather than by the size of the file.
+        Return the last `n` lines of a log file as text. The file is read backwards from the end.
 
-        `n` defaults to 5000 and is clamped to the range 1 to 10000, so values outside that are quietly
-        adjusted rather than rejected. `reverse` controls only the order the lines are returned in: true, the
-        default, gives newest first.
+        `n` defaults to 5000 and is clamped to the range 1 to 10000, so values outside that are adjusted
+        rather than rejected. `reverse` controls the order the lines are returned in: true, the default,
+        gives newest first.
 
-        The response media type is probed from the file rather than fixed, so it is typically
+        The response media type is probed from the file rather than fixed, and is typically
         `application/octet-stream` for a `.log` file. A name that exists in the directory listing but whose
         file has since gone returns 204 with no body.""",
             operationId = "getLogFileContents"

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/MinionRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/MinionRestService.java
@@ -52,7 +52,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component("minionRestService")
 @Path("minions")
 @Tag(name = "Minions", description = """
-        Minions API: read-only access to the Minions that have registered with this instance.
+        Read-only access to the Minions that have registered with this instance.
 
         Rows appear when a Minion checks in and are not created through this API. An instance with no Minions
         answers with an empty list and a count of 0.
@@ -123,7 +123,7 @@ public class MinionRestService extends OnmsRestService {
             summary = "Get one property of a Minion",
             description = """
         Return a single entry from a Minion's `properties` map as plain text. Which keys exist depends on
-        what the Minion reported, so read the whole Minion first if the key set is not already known.
+        what the Minion reported.
 
         A missing Minion and a missing key are both reported as 404, distinguishable only by the message.""",
             operationId = "getMinionProperty"

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/MinionRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/MinionRestService.java
@@ -33,6 +33,13 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.core.Response.Status;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.netmgt.dao.api.MinionDao;
@@ -44,7 +51,15 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Component("minionRestService")
 @Path("minions")
-@Tag(name = "Minions", description = "Minions API")
+@Tag(name = "Minions", description = """
+        Minions API: read-only access to the Minions that have registered with this instance.
+
+        Rows appear when a Minion checks in and are not created through this API. An instance with no Minions
+        answers with an empty list and a count of 0.
+
+        `date` and `lastCheckedIn` are serialised as epoch milliseconds, not as the date-time strings the
+        derived schema shows. `properties` is whatever the Minion reported about itself, so its keys vary by
+        version and deployment.""")
 public class MinionRestService extends OnmsRestService {
     @Autowired
     private MinionDao m_minionDao;
@@ -53,7 +68,46 @@ public class MinionRestService extends OnmsRestService {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Path("{minionId}")
     @Transactional
-    public OnmsMinion getMinion(@PathParam("minionId") final String minionId) {
+    @Operation(
+            summary = "Get one Minion",
+            description = """
+        Return a single registered Minion by its id. The id is the Minion's system id, normally a UUID, not
+        its label.
+
+        `date` and `lastCheckedIn` come back as epoch milliseconds.""",
+            operationId = "getMinion"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The Minion.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsMinion.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "id": "00000000-0000-0000-0000-000000ddba11",
+                      "label": "minion-01",
+                      "location": "Default",
+                      "type": "Minion",
+                      "date": 1787670300817,
+                      "lastCheckedIn": 1787670300817,
+                      "status": "Started",
+                      "version": "36.0.4",
+                      "properties": {
+                        "org.opennms.instance.id": "OpenNMS"
+                      }
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsMinion.class))
+                    }),
+            @ApiResponse(responseCode = "404", description = "No Minion with that id has registered.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Minion 00000000-0000-0000-0000-000000ddba11 was not found.")))
+    })
+    public OnmsMinion getMinion(
+            @Parameter(description = "Minion system id.", required = true,
+                    example = "00000000-0000-0000-0000-000000ddba11")
+            @PathParam("minionId") final String minionId) {
         final OnmsMinion minion = m_minionDao.get(minionId);
         if (minion == null) {
             throw getException(Status.NOT_FOUND, "Minion {} was not found.", minionId);
@@ -65,7 +119,32 @@ public class MinionRestService extends OnmsRestService {
     @Produces(MediaType.TEXT_PLAIN)
     @Path("{minionId}/{key}")
     @Transactional
-    public String getMinionProperty(@PathParam("minionId") final String minionId, @PathParam("key") final String key) {
+    @Operation(
+            summary = "Get one property of a Minion",
+            description = """
+        Return a single entry from a Minion's `properties` map as plain text. Which keys exist depends on
+        what the Minion reported, so read the whole Minion first if the key set is not already known.
+
+        A missing Minion and a missing key are both reported as 404, distinguishable only by the message.""",
+            operationId = "getMinionProperty"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The property value.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "OpenNMS"))),
+            @ApiResponse(responseCode = "404", description = "No such Minion, or the Minion has no such property.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Property org.opennms.instance.id was not found on Minion 00000000-0000-0000-0000-000000ddba11.")))
+    })
+    public String getMinionProperty(
+            @Parameter(description = "Minion system id.", required = true,
+                    example = "00000000-0000-0000-0000-000000ddba11")
+            @PathParam("minionId") final String minionId,
+            @Parameter(description = "Property key, as it appears in the Minion's `properties` map.", required = true,
+                    example = "org.opennms.instance.id")
+            @PathParam("key") final String key) {
         final OnmsMinion minion = getMinion(minionId);
         final String value = minion.getProperties().get(key);
         if (value == null) {
@@ -78,6 +157,23 @@ public class MinionRestService extends OnmsRestService {
     @Produces(MediaType.TEXT_PLAIN)
     @Path("count")
     @Transactional
+    @Operation(
+            summary = "Count registered Minions",
+            description = """
+        Return the number of registered Minions as a plain-text integer. This is the unfiltered total and
+        ignores any query parameters.
+
+        This operation only produces `text/plain`. A request with `Accept: application/json` does not match
+        it and falls through to `GET /minions/{minionId}`, which then answers 404 for the literal id
+        `count`.""",
+            operationId = "getMinionCount"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The number of registered Minions.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "0")))
+    })
     public String getCount() {
         return Integer.toString(m_minionDao.countAll());
     }
@@ -85,6 +181,37 @@ public class MinionRestService extends OnmsRestService {
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
+    @Operation(
+            summary = "List registered Minions",
+            description = """
+        List the registered Minions. Query parameters are turned into criteria against the Minion entity, so
+        the usual v1 filtering, ordering and paging parameters apply: `limit`, `offset`, `orderBy`, `order`,
+        and `<property>=<value>` for equality on a property of the entity.
+
+        `totalCount` is the number of Minions matching the filter ignoring `limit` and `offset`, while
+        `count` is how many are in this page. An instance with no Minions returns an empty `minion` array
+        with `totalCount` 0 and `count` null.""",
+            operationId = "getMinions"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The matching Minions.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsMinionCollection.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 0,
+                      "count": null,
+                      "offset": 0,
+                      "minion": []
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsMinionCollection.class))
+                    }),
+            @ApiResponse(responseCode = "400", description = "A query parameter did not name a property of the Minion entity, or a value did not convert.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string")))
+    })
     public OnmsMinionCollection getMinions(@Context final UriInfo uriInfo) throws ParseException {
         final CriteriaBuilder builder = getCriteriaBuilder(uriInfo.getQueryParameters());
         final OnmsMinionCollection coll = new OnmsMinionCollection(m_minionDao.findMatching(builder.toCriteria()));

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/MinionRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/MinionRestService.java
@@ -55,7 +55,7 @@ import org.springframework.transaction.annotation.Transactional;
         Read-only access to the Minions that have registered with this instance.
 
         Rows appear when a Minion checks in and are not created through this API. An instance with no Minions
-        answers with an empty list and a count of 0.
+        answers with an empty list whose `count` is null and `totalCount` is 0.
 
         `date` and `lastCheckedIn` are serialised as epoch milliseconds, not as the date-time strings the
         derived schema shows. `properties` is whatever the Minion reported about itself, so its keys vary by
@@ -208,7 +208,7 @@ public class MinionRestService extends OnmsRestService {
                             @Content(mediaType = MediaType.APPLICATION_XML,
                                     schema = @Schema(implementation = OnmsMinionCollection.class))
                     }),
-            @ApiResponse(responseCode = "400", description = "A query parameter did not name a property of the Minion entity, or a value did not convert.",
+            @ApiResponse(responseCode = "500", description = "A query parameter did not name a property of the Minion entity, or a value did not convert.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string")))
     })

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/MonitoringLocationsRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/MonitoringLocationsRestService.java
@@ -69,16 +69,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Component("monitoringLocationsRestService")
 @Path("monitoringLocations")
 @Tag(name = "MonitoringLocations", description = """
-        Monitoring Locations API. A location is what ties a Minion, a node and a polling package together;
-        every installation has a `Default` location.
+        A location ties a Minion, a node and a polling package together; every installation has a `Default`
+        location.
 
-        The primary key is the location name, chosen by the caller. That has two consequences worth knowing
-        before writing: `POST` with a name that already exists overwrites the existing row and still answers
-        201, and a body with no `location-name` fails with 500 rather than 400.
+        The primary key is the location name, chosen by the caller: `POST` with a name that already exists
+        overwrites the existing row and still answers 201, and a body with no `location-name` fails with 500
+        rather than 400.
 
-        JSON and XML bodies are not interchangeable here. In JSON, `tags` is a plain array of strings. In
-        XML, a `<tags>` element cannot be unmarshalled at all and fails with 500, so XML bodies have to omit
-        it; the rest of the fields are attributes, spelled `location-name` and `monitoring-area`.
+        In JSON, `tags` is a plain array of strings. In XML, a `<tags>` element cannot be unmarshalled at all
+        and fails with 500, so XML bodies have to omit it; the rest of the fields are attributes, spelled
+        `location-name` and `monitoring-area`.
 
         `PUT` is separate again: it takes form-encoded parameters, not a JSON or XML body, and the parameter
         names are the Java bean property names (`monitoringArea`, `priority`, `geolocation`, `latitude`,
@@ -102,8 +102,7 @@ public class MonitoringLocationsRestService extends OnmsRestService {
 			summary = "Get the default monitoring location",
 			description = """
         Return the first monitoring location in the table's natural order, which on an untouched installation
-        is `Default`. The choice is not tied to the name `Default`, so on a system whose locations have been
-        edited this can return something else.""",
+        is `Default`. The choice is not tied to the name `Default`.""",
 			operationId = "getDefaultMonitoringLocation"
 	)
 	@ApiResponses(value = {
@@ -249,11 +248,11 @@ public class MonitoringLocationsRestService extends OnmsRestService {
         Create a monitoring location. `location-name` is the primary key and has to be supplied in the body;
         a body without it fails with 500 on the missing identifier rather than with 400.
 
-        This is a save, not an insert. Posting a name that already exists overwrites that location and still
-        answers 201, so it is worth checking with `GET` first if that is not the intent.
+        This is a save, not an insert: posting a name that already exists overwrites that location and still
+        answers 201.
 
-        The XML form differs from the JSON form: XML fields are attributes and a `<tags>` element cannot be
-        unmarshalled, so it has to be omitted. Use JSON when tags are needed.
+        In the XML form the fields are attributes and a `<tags>` element cannot be unmarshalled, so it has to
+        be omitted. `tags` can only be set from a JSON body.
 
         `Location` on the 201 points at `GET /monitoringLocations/{monitoringLocation}` for the new
         location.""",
@@ -321,8 +320,7 @@ public class MonitoringLocationsRestService extends OnmsRestService {
         Parameters that do not match a writable property are ignored. If nothing matched, or the body was
         empty, the answer is 304 and nothing is written. The location name itself cannot be changed this way.
 
-        A name that does not exist fails with 500, not 404: the handler does not check the lookup result
-        before writing to it.""",
+        A name that does not exist fails with 500, not 404.""",
 			operationId = "updateMonitoringLocation"
 	)
 	@RequestBody(
@@ -380,8 +378,7 @@ public class MonitoringLocationsRestService extends OnmsRestService {
 	@Operation(
 			summary = "Delete a monitoring location",
 			description = """
-        Delete a monitoring location by name. Nodes and Minions still referencing it are not checked for, so
-        deleting a location that is in use leaves those references dangling.
+        Delete a monitoring location by name. Nodes and Minions still referencing it are not checked for.
 
         A name that does not exist fails with 500, not 404.""",
 			operationId = "deleteMonitoringLocation"

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/MonitoringLocationsRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/MonitoringLocationsRestService.java
@@ -41,6 +41,14 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.joda.time.Duration;
 import org.opennms.netmgt.dao.api.MonitoringLocationDao;
@@ -60,7 +68,21 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Component("monitoringLocationsRestService")
 @Path("monitoringLocations")
-@Tag(name = "MonitoringLocations", description = "Monitoring Locations API")
+@Tag(name = "MonitoringLocations", description = """
+        Monitoring Locations API. A location is what ties a Minion, a node and a polling package together;
+        every installation has a `Default` location.
+
+        The primary key is the location name, chosen by the caller. That has two consequences worth knowing
+        before writing: `POST` with a name that already exists overwrites the existing row and still answers
+        201, and a body with no `location-name` fails with 500 rather than 400.
+
+        JSON and XML bodies are not interchangeable here. In JSON, `tags` is a plain array of strings. In
+        XML, a `<tags>` element cannot be unmarshalled at all and fails with 500, so XML bodies have to omit
+        it; the rest of the fields are attributes, spelled `location-name` and `monitoring-area`.
+
+        `PUT` is separate again: it takes form-encoded parameters, not a JSON or XML body, and the parameter
+        names are the Java bean property names (`monitoringArea`, `priority`, `geolocation`, `latitude`,
+        `longitude`), not the hyphenated wire names.""")
 public class MonitoringLocationsRestService extends OnmsRestService {
 
 	private static final Logger LOG = LoggerFactory.getLogger(MonitoringLocationsRestService.class);
@@ -76,12 +98,75 @@ public class MonitoringLocationsRestService extends OnmsRestService {
 	@GET
 	@Path("default")
 	@Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+	@Operation(
+			summary = "Get the default monitoring location",
+			description = """
+        Return the first monitoring location in the table's natural order, which on an untouched installation
+        is `Default`. The choice is not tied to the name `Default`, so on a system whose locations have been
+        edited this can return something else.""",
+			operationId = "getDefaultMonitoringLocation"
+	)
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "The location.",
+					content = {
+							@Content(mediaType = MediaType.APPLICATION_JSON,
+									schema = @Schema(implementation = OnmsMonitoringLocation.class),
+									examples = @ExampleObject(value = """
+                    {
+                      "tags": [],
+                      "latitude": null,
+                      "geolocation": null,
+                      "longitude": null,
+                      "priority": 100,
+                      "location-name": "Default",
+                      "monitoring-area": "localhost"
+                    }""")),
+							@Content(mediaType = MediaType.APPLICATION_XML,
+									schema = @Schema(implementation = OnmsMonitoringLocation.class))
+					})
+	})
 	public OnmsMonitoringLocation getDefaultMonitoringLocation() throws ParseException {
 		return m_monitoringLocationDao.findAll().get(0);
 	}
 
 	@GET
 	@Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+	@Operation(
+			summary = "List monitoring locations",
+			description = """
+        List every monitoring location, sorted by name. The response is not paged: `totalCount` and `count`
+        are equal and `offset` is always 0.
+
+        In XML the entries are `location` elements inside `locations`; in JSON the array is keyed
+        `location`.""",
+			operationId = "getMonitoringLocations"
+	)
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "The monitoring locations.",
+					content = {
+							@Content(mediaType = MediaType.APPLICATION_JSON,
+									schema = @Schema(implementation = OnmsMonitoringLocationDefinitionList.class),
+									examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 1,
+                      "count": 1,
+                      "offset": 0,
+                      "location": [
+                        {
+                          "tags": [],
+                          "latitude": null,
+                          "geolocation": null,
+                          "longitude": null,
+                          "priority": 100,
+                          "location-name": "Default",
+                          "monitoring-area": "localhost"
+                        }
+                      ]
+                    }""")),
+							@Content(mediaType = MediaType.APPLICATION_XML,
+									schema = @Schema(implementation = OnmsMonitoringLocationDefinitionList.class))
+					})
+	})
 	public OnmsMonitoringLocationDefinitionList getForeignSources() throws ParseException {
 		final List<OnmsMonitoringLocation> onmsMonitoringLocationList = m_monitoringLocationDao.findAll();
 		Collections.sort(onmsMonitoringLocationList, Comparator.comparing(OnmsMonitoringLocation::getLocationName));
@@ -91,6 +176,22 @@ public class MonitoringLocationsRestService extends OnmsRestService {
 	@GET
 	@Path("count")
 	@Produces(MediaType.TEXT_PLAIN)
+	@Operation(
+			summary = "Count monitoring locations",
+			description = """
+        Return the number of monitoring locations as a plain-text integer.
+
+        This operation only produces `text/plain`. A request with `Accept: application/json` does not match it
+        and falls through to `GET /monitoringLocations/{monitoringLocation}`, which then answers 404 for the
+        literal name `count`.""",
+			operationId = "getMonitoringLocationCount"
+	)
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "The number of locations.",
+					content = @Content(mediaType = MediaType.TEXT_PLAIN,
+							schema = @Schema(type = "string"),
+							examples = @ExampleObject(value = "1")))
+	})
 	public String getTotalCount() throws ParseException {
 		return Integer.toString(m_monitoringLocationDao.findAll().size());
 	}
@@ -98,7 +199,40 @@ public class MonitoringLocationsRestService extends OnmsRestService {
 	@GET
 	@Path("{monitoringLocation}")
 	@Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-	public OnmsMonitoringLocation getMonitoringLocation(@PathParam("monitoringLocation") String monitoringLocation) {
+	@Operation(
+			summary = "Get one monitoring location",
+			description = """
+        Return a single monitoring location by name. The lookup is exact and case sensitive.""",
+			operationId = "getMonitoringLocation"
+	)
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "The location.",
+					content = {
+							@Content(mediaType = MediaType.APPLICATION_JSON,
+									schema = @Schema(implementation = OnmsMonitoringLocation.class),
+									examples = @ExampleObject(value = """
+                    {
+                      "location-name": "ApiDoc-Loc",
+                      "monitoring-area": "raleigh",
+                      "priority": 50,
+                      "geolocation": "Raleigh, NC",
+                      "latitude": 35.7796,
+                      "longitude": -78.6382,
+                      "tags": [
+                        "east"
+                      ]
+                    }""")),
+							@Content(mediaType = MediaType.APPLICATION_XML,
+									schema = @Schema(implementation = OnmsMonitoringLocation.class))
+					}),
+			@ApiResponse(responseCode = "404", description = "No location with that name exists.",
+					content = @Content(mediaType = MediaType.TEXT_PLAIN,
+							schema = @Schema(type = "string"),
+							examples = @ExampleObject(value = "Monitoring location Nowhere was not found.")))
+	})
+	public OnmsMonitoringLocation getMonitoringLocation(
+			@Parameter(description = "Location name. Exact and case sensitive.", required = true, example = "Default")
+			@PathParam("monitoringLocation") String monitoringLocation) {
 	    final OnmsMonitoringLocation loc = m_monitoringLocationDao.get(monitoringLocation);
             if (loc == null) {
                 throw getException(Status.NOT_FOUND, "Monitoring location {} was not found.", monitoringLocation);
@@ -109,6 +243,58 @@ public class MonitoringLocationsRestService extends OnmsRestService {
 	@POST
 	@Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
 	@Transactional
+	@Operation(
+			summary = "Create a monitoring location",
+			description = """
+        Create a monitoring location. `location-name` is the primary key and has to be supplied in the body;
+        a body without it fails with 500 on the missing identifier rather than with 400.
+
+        This is a save, not an insert. Posting a name that already exists overwrites that location and still
+        answers 201, so it is worth checking with `GET` first if that is not the intent.
+
+        The XML form differs from the JSON form: XML fields are attributes and a `<tags>` element cannot be
+        unmarshalled, so it has to be omitted. Use JSON when tags are needed.
+
+        `Location` on the 201 points at `GET /monitoringLocations/{monitoringLocation}` for the new
+        location.""",
+			operationId = "addMonitoringLocation"
+	)
+	@RequestBody(
+			required = true,
+			description = "The location to create. `location-name` is required. In XML, omit `tags`.",
+			content = {
+					@Content(mediaType = MediaType.APPLICATION_JSON,
+							schema = @Schema(implementation = OnmsMonitoringLocation.class),
+							examples = @ExampleObject(value = """
+                    {
+                      "location-name": "ApiDoc-Loc",
+                      "monitoring-area": "raleigh",
+                      "priority": 50,
+                      "geolocation": "Raleigh, NC",
+                      "latitude": 35.7796,
+                      "longitude": -78.6382,
+                      "tags": [
+                        "east"
+                      ]
+                    }""")),
+					@Content(mediaType = MediaType.APPLICATION_XML,
+							schema = @Schema(implementation = OnmsMonitoringLocation.class),
+							examples = @ExampleObject(value = """
+                    <location location-name="ApiDoc-Loc"
+                              monitoring-area="raleigh"
+                              priority="50"
+                              geolocation="Raleigh, NC"
+                              latitude="35.7796"
+                              longitude="-78.6382"/>"""))
+			}
+	)
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "201", description = "The location was created or overwritten. `Location` carries its URI."),
+			@ApiResponse(responseCode = "500", description = "`location-name` was missing, or an XML body contained a `tags` element.",
+					content = @Content(mediaType = MediaType.TEXT_PLAIN,
+							schema = @Schema(type = "string"),
+							examples = @ExampleObject(value = "ids for this class must be manually assigned before calling save(): org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation")))
+	})
 	public Response addMonitoringLocation(@Context final UriInfo uriInfo, OnmsMonitoringLocation monitoringLocation) {
 		writeLock();
 		try {
@@ -124,7 +310,39 @@ public class MonitoringLocationsRestService extends OnmsRestService {
 	@Path("{monitoringLocation}")
 	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 	@Transactional
-	public Response updateMonitoringLocation(@PathParam("monitoringLocation") String monitoringLocation, MultivaluedMapImpl params) {
+	@Operation(
+			summary = "Update a monitoring location",
+			description = """
+        Update fields on an existing location from form-encoded parameters. Each parameter name is matched
+        against the writable bean properties of the location, so the spelling is the Java property name
+        (`monitoringArea`, `priority`, `geolocation`, `latitude`, `longitude`), not the hyphenated name that
+        appears in a JSON or XML representation.
+
+        Parameters that do not match a writable property are ignored. If nothing matched, or the body was
+        empty, the answer is 304 and nothing is written. The location name itself cannot be changed this way.
+
+        A name that does not exist fails with 500, not 404: the handler does not check the lookup result
+        before writing to it.""",
+			operationId = "updateMonitoringLocation"
+	)
+	@RequestBody(
+			required = true,
+			description = "Form-encoded properties to change, named after the bean properties.",
+			content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+					schema = @Schema(type = "object"),
+					examples = @ExampleObject(value = "monitoringArea=raleigh&priority=75&geolocation=Raleigh%2C+NC"))
+	)
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "204", description = "At least one property was changed."),
+			@ApiResponse(responseCode = "304", description = "The body was empty, or no parameter named a writable property. Nothing was written."),
+			@ApiResponse(responseCode = "500", description = "No location with that name exists, or a value did not convert to the property type.",
+					content = @Content(mediaType = MediaType.TEXT_PLAIN,
+							schema = @Schema(type = "string"),
+							examples = @ExampleObject(value = "Target object must not be null")))
+	})
+	public Response updateMonitoringLocation(
+			@Parameter(description = "Location name. Exact and case sensitive.", required = true, example = "ApiDoc-Loc")
+			@PathParam("monitoringLocation") String monitoringLocation, MultivaluedMapImpl params) {
 		writeLock();
 		try {
 			boolean sendEvent = false;
@@ -159,7 +377,25 @@ public class MonitoringLocationsRestService extends OnmsRestService {
 	@DELETE
 	@Path("{monitoringLocation}")
 	@Transactional
-	public Response deleteMonitoringLocation(@PathParam("monitoringLocation") String monitoringLocation) {
+	@Operation(
+			summary = "Delete a monitoring location",
+			description = """
+        Delete a monitoring location by name. Nodes and Minions still referencing it are not checked for, so
+        deleting a location that is in use leaves those references dangling.
+
+        A name that does not exist fails with 500, not 404.""",
+			operationId = "deleteMonitoringLocation"
+	)
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "204", description = "The location was deleted."),
+			@ApiResponse(responseCode = "500", description = "No location with that name exists.",
+					content = @Content(mediaType = MediaType.TEXT_PLAIN,
+							schema = @Schema(type = "string"),
+							examples = @ExampleObject(value = "attempt to create delete event with null entity")))
+	})
+	public Response deleteMonitoringLocation(
+			@Parameter(description = "Location name. Exact and case sensitive.", required = true, example = "ApiDoc-Loc")
+			@PathParam("monitoringLocation") String monitoringLocation) {
 		writeLock();
 		try {
 			LOG.debug("deleteMonitoringLocation: deleting monitoring location {}", monitoringLocation);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NodeRestService.java
@@ -148,7 +148,7 @@ public class NodeRestService extends OnmsRestService {
                     `ipInterfaces.monitoredServices.serviceType` as `serviceType`, so restrictions such as
                     `category.name`, `ipInterface.ipAddress`, `assetRecord.city` and `serviceType.name` all
                     resolve. A value of `null` or `notnull` becomes an is-null / is-not-null test. Unknown
-                    property names are logged and ignored rather than rejected.
+                    property names are logged and ignored rather than rejected.Unknown property names are not ignored: the filter still binds them and the query fails with 500 `Unknown entity: null`.
 
                     The criteria property for the database id is `id`. `nodeId` is not usable as a criteria
                     property and any request that sends it fails with 500, including the comma-separated form.

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NodeRestService.java
@@ -43,6 +43,15 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.criteria.Alias.JoinType;
 import org.opennms.core.criteria.Criteria;
@@ -86,7 +95,21 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component("nodeRestService")
 @Path("nodes")
-@Tag(name = "Nodes", description = "Nodes API")
+@Tag(name = "Nodes", description = """
+        Nodes API.
+
+        Wherever a path contains `nodeCriteria`, two forms are accepted: the database node id (`258`) and
+        `foreignSource:foreignId` (`Router-Requisition:node1`). The colon form is resolved by splitting on the
+        first colon, so a foreign source or foreign id containing a colon cannot be addressed this way, and a
+        purely numeric value is always read as a database id. Both forms work on every operation below.
+
+        Timestamps serialize differently per representation: JSON carries epoch milliseconds
+        (`"createTime": 1787727313802`) while XML carries an ISO-8601 offset date-time
+        (`<createTime>2026-08-26T02:55:13.802-04:00</createTime>`). The schemas shown here are derived from the
+        Java types and say `date-time` for both. Node `id` is a string in JSON and an attribute in XML.
+
+        Interfaces, services, categories, asset data and hardware inventory hang off `/nodes/{nodeCriteria}/...`
+        and are documented under their own operations.""")
 public class NodeRestService extends OnmsRestService {
     private static final Logger LOG = LoggerFactory.getLogger(NodeRestService.class);
 
@@ -116,6 +139,131 @@ public class NodeRestService extends OnmsRestService {
      */
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Search nodes",
+            description = """
+                    Returns a page of nodes ordered by label. Nodes of type `D` (deleted) are excluded unless a
+                    `type` parameter is present, in which case the restriction is left to the caller.
+
+                    Every query parameter that is not one of the paging parameters below is read as a property
+                    restriction on `OnmsNode`. Joins are pre-registered for `snmpInterfaces` as `snmpInterface`,
+                    `ipInterfaces` as `ipInterface`, `categories` as `category`, `assetRecord`, `location` and
+                    `ipInterfaces.monitoredServices.serviceType` as `serviceType`, so restrictions such as
+                    `category.name`, `ipInterface.ipAddress`, `assetRecord.city` and `serviceType.name` all
+                    resolve. A value of `null` or `notnull` becomes an is-null / is-not-null test. Unknown
+                    property names are logged and ignored rather than rejected.
+
+                    Restrict by database id with `id`, not with `nodeId`: `nodeId` is not usable as a criteria
+                    property and any request that sends it fails with 500, including the documented
+                    comma-separated form.
+
+                    `filterRule` is evaluated separately, by the filter engine, and is mutually exclusive with the
+                    property restrictions in the sense that it replaces them: matching node ids are resolved
+                    first, then the remaining parameters are re-applied on top of that id set. A rule that matches
+                    nothing returns an empty list with `totalCount` 0 rather than an error.""",
+            operationId = "searchNodes",
+            parameters = {
+                    @Parameter(in = ParameterIn.QUERY, name = "limit",
+                            description = "Maximum rows to return. 0 disables the limit.",
+                            schema = @Schema(type = "integer", defaultValue = "10"), example = "25"),
+                    @Parameter(in = ParameterIn.QUERY, name = "offset",
+                            description = "Zero-based index of the first row to return.",
+                            schema = @Schema(type = "integer"), example = "0"),
+                    @Parameter(in = ParameterIn.QUERY, name = "orderBy",
+                            description = "Property to sort on, replacing the default `label` ordering.",
+                            schema = @Schema(type = "string"), example = "id"),
+                    @Parameter(in = ParameterIn.QUERY, name = "order",
+                            description = "Sort direction for `orderBy`. Anything other than `desc` is read as ascending.",
+                            schema = @Schema(type = "string", allowableValues = {"asc", "desc"}), example = "desc"),
+                    @Parameter(in = ParameterIn.QUERY, name = "comparator",
+                            description = "Comparison applied to every property restriction in the query.",
+                            schema = @Schema(type = "string", defaultValue = "eq",
+                                    allowableValues = {"eq", "ne", "gt", "lt", "ge", "le", "like", "ilike", "contains", "iplike"}),
+                            example = "contains"),
+                    @Parameter(in = ParameterIn.QUERY, name = "match",
+                            description = "Whether the property restrictions are combined with AND or OR.",
+                            schema = @Schema(type = "string", defaultValue = "all", allowableValues = {"all", "any"}),
+                            example = "any"),
+                    @Parameter(in = ParameterIn.QUERY, name = "filterRule",
+                            description = "Filter-engine expression. Node ids are resolved through the filter engine and the rest of the query is applied to that set.",
+                            schema = @Schema(type = "string"), example = "catincRouters"),
+                    @Parameter(in = ParameterIn.QUERY, name = "type",
+                            description = "Node type. Sending any value, including `A`, also disables the implicit exclusion of deleted nodes.",
+                            schema = @Schema(type = "string", allowableValues = {"A", "D"}), example = "A"),
+                    @Parameter(in = ParameterIn.QUERY, name = "id",
+                            description = "Database node id. Use this rather than `nodeId`.",
+                            schema = @Schema(type = "integer"), example = "258"),
+                    @Parameter(in = ParameterIn.QUERY, name = "label",
+                            description = "Node label. Example of the generic property-restriction form; pair it with `comparator=contains` for a substring search.",
+                            schema = @Schema(type = "string"), example = "core-sw-01"),
+                    @Parameter(in = ParameterIn.QUERY, name = "foreignSource",
+                            description = "Requisition that owns the node.",
+                            schema = @Schema(type = "string"), example = "Router-Requisition"),
+                    @Parameter(in = ParameterIn.QUERY, name = "category.name",
+                            description = "Restrict to nodes in this surveillance category.",
+                            schema = @Schema(type = "string"), example = "Routers")
+            }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Matching nodes. `count` is the size of the page, `totalCount` the size of the whole match.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsNodeList.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 1,
+                      "count": 1,
+                      "offset": 0,
+                      "node": [
+                        {
+                          "location": "Default",
+                          "foreignSource": "Router-Requisition",
+                          "foreignId": "node1",
+                          "categories": [
+                            { "id": 1, "authorizedGroups": [], "name": "Routers" }
+                          ],
+                          "sysContact": "noc@example.org",
+                          "sysDescription": "Example router",
+                          "sysLocation": "Rack 7",
+                          "sysName": "core-sw-01",
+                          "sysObjectId": ".1.3.6.1.4.1.9.1.1",
+                          "labelSource": "U",
+                          "createTime": 1787727313802,
+                          "lastIngressFlow": null,
+                          "lastEgressFlow": null,
+                          "lastCapsdPoll": null,
+                          "type": "A",
+                          "label": "core-sw-01",
+                          "nodeParentID": null,
+                          "id": "258"
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsNodeList.class),
+                                    examples = @ExampleObject(value = """
+                    <nodes count="1" offset="0" totalCount="1">
+                      <node foreignId="node1" foreignSource="Router-Requisition" label="core-sw-01" id="258" type="A">
+                        <createTime>2026-08-26T02:55:13.802-04:00</createTime>
+                        <labelSource>U</labelSource>
+                        <location>Default</location>
+                        <sysContact>noc@example.org</sysContact>
+                        <sysDescription>Example router</sysDescription>
+                        <sysLocation>Rack 7</sysLocation>
+                        <sysName>core-sw-01</sysName>
+                        <sysObjectId>.1.3.6.1.4.1.9.1.1</sysObjectId>
+                      </node>
+                    </nodes>"""))
+                    }),
+            @ApiResponse(responseCode = "400", description = "`filterRule` could not be parsed. The parse error is deliberately not echoed, because it can contain the generated SQL.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Invalid 'filterRule' in request."))),
+            @ApiResponse(responseCode = "500", description = "A query parameter could not be turned into a criteria restriction. `nodeId` does this on every request.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Unknown entity: null; nested exception is org.hibernate.HibernateException: Unknown entity: null")))
+    })
     public OnmsNodeList getNodes(@Context final UriInfo uriInfo) {
         final MultivaluedMap<String, String> params = uriInfo.getQueryParameters();
         final String type = params.getFirst("type");
@@ -194,7 +342,73 @@ public class NodeRestService extends OnmsRestService {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Path("{nodeCriteria}")
     @Transactional
-    public OnmsNode getNode(@PathParam("nodeCriteria") final String nodeCriteria) {
+    @Operation(
+            summary = "Get one node",
+            description = """
+                    Returns a single node, addressed either by database id or by `foreignSource:foreignId`.
+                    Deleted nodes are not filtered out here, unlike in the search endpoint.
+
+                    The node's asset record is embedded in the response, but the search endpoint's paged result
+                    embeds it too, so `/nodes/{nodeCriteria}/assetRecord` is only needed when the asset record is
+                    all that is wanted.""",
+            operationId = "getNode"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The node.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsNode.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "location": "Default",
+                      "foreignSource": "Router-Requisition",
+                      "foreignId": "node1",
+                      "assetRecord": {
+                        "category": "Unspecified",
+                        "id": 23600,
+                        "lastModifiedBy": "admin",
+                        "lastModifiedDate": 1787727690002
+                      },
+                      "categories": [
+                        { "id": 1, "authorizedGroups": [], "name": "Routers" }
+                      ],
+                      "sysContact": "noc@example.org",
+                      "sysName": "core-sw-01",
+                      "sysObjectId": ".1.3.6.1.4.1.9.1.1",
+                      "labelSource": "U",
+                      "createTime": 1787727313802,
+                      "type": "A",
+                      "label": "core-sw-01",
+                      "nodeParentID": null,
+                      "id": "258"
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsNode.class),
+                                    examples = @ExampleObject(value = """
+                    <node foreignId="node1" foreignSource="Router-Requisition" label="core-sw-01" id="258" type="A">
+                      <assetRecord>
+                        <category>Unspecified</category>
+                        <id>23600</id>
+                        <lastModifiedBy>admin</lastModifiedBy>
+                        <lastModifiedDate>2026-08-26T02:55:13.802-04:00</lastModifiedDate>
+                        <node>258</node>
+                      </assetRecord>
+                      <createTime>2026-08-26T02:55:13.802-04:00</createTime>
+                      <labelSource>U</labelSource>
+                      <location>Default</location>
+                      <sysContact>noc@example.org</sysContact>
+                      <sysName>core-sw-01</sysName>
+                      <sysObjectId>.1.3.6.1.4.1.9.1.1</sysObjectId>
+                    </node>"""))
+                    }),
+            @ApiResponse(responseCode = "404", description = "No node matches `nodeCriteria`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Node 999999 was not found.")))
+    })
+    public OnmsNode getNode(@Parameter(description = "Node identifier: either the database node id (`258`) or `foreignSource:foreignId` (`Router-Requisition:node1`). Both forms are accepted.",
+                                       example = "Router-Requisition:node1")
+                            @PathParam("nodeCriteria") final String nodeCriteria) {
         final OnmsNode node = m_nodeDao.get(nodeCriteria);
         if (node == null) {
             throw getException(Status.NOT_FOUND, "Node {} was not found.", nodeCriteria);
@@ -212,7 +426,31 @@ public class NodeRestService extends OnmsRestService {
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("{nodeCriteria}/rescan")
     @Transactional
-    public Response rescanNode(@PathParam("nodeCriteria") final String nodeCriteria) {
+    @Operation(
+            summary = "Request a provisiond rescan of a node",
+            description = """
+                    Publishes `uei.opennms.org/internal/importer/reloadImport` for the node with
+                    `rescanExisting=true` and returns immediately. The scan itself is asynchronous, so a 204 means
+                    the request was queued, not that the node has been rescanned.
+
+                    No request body is read. The method declares `@Consumes(application/x-www-form-urlencoded)`,
+                    so a `Content-Type` is only needed if a body is sent at all; an empty PUT with no
+                    `Content-Type` is accepted.""",
+            operationId = "rescanNode"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The rescan request was published. No body."),
+            @ApiResponse(responseCode = "404", description = "No node matches `nodeCriteria`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Node 999999 was not found."))),
+            @ApiResponse(responseCode = "500", description = "Publishing the rescan event failed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot send event uei.opennms.org/internal/importer/reloadImport : connection refused")))
+    })
+    public Response rescanNode(@Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                               @PathParam("nodeCriteria") final String nodeCriteria) {
         final OnmsNode node = m_nodeDao.get(nodeCriteria);
         if (node == null) {
             throw getException(Status.NOT_FOUND, "Node {} was not found.", nodeCriteria);
@@ -232,6 +470,50 @@ public class NodeRestService extends OnmsRestService {
     @POST
     @Consumes(MediaType.APPLICATION_XML)
     @Transactional
+    @Operation(
+            summary = "Create a node",
+            description = """
+                    Creates a node directly in the database and publishes `nodeAdded`. This bypasses provisioning:
+                    a node created this way is not owned by a requisition unless `foreignSource` and `foreignId`
+                    are supplied, and a later requisition import can delete or duplicate it.
+
+                    XML only. A JSON or form-encoded body is rejected with 415.
+
+                    `type` is required. `location` defaults to the default monitoring location when omitted. An
+                    asset record supplied in the body is attached to the node automatically.
+
+                    `label`, `foreignSource`, `foreignId` and `type` are XML *attributes* on `node`, while
+                    `labelSource`, `location`, `sysContact`, `sysDescription`, `sysLocation`, `sysName` and
+                    `sysObjectId` are *elements*. A value sent as the wrong kind of node is dropped silently.""",
+            operationId = "addNode"
+    )
+    @RequestBody(
+            required = true,
+            description = "The node to create. `type` is required; `A` for an active node.",
+            content = @Content(mediaType = MediaType.APPLICATION_XML,
+                    schema = @Schema(implementation = OnmsNode.class),
+                    examples = @ExampleObject(value = """
+                    <node type="A" label="core-sw-01" foreignSource="Router-Requisition" foreignId="node1">
+                      <labelSource>U</labelSource>
+                      <sysContact>noc@example.org</sysContact>
+                      <sysDescription>Example router</sysDescription>
+                      <sysLocation>Rack 7</sysLocation>
+                      <sysName>core-sw-01</sysName>
+                      <sysObjectId>.1.3.6.1.4.1.9.1.1</sysObjectId>
+                    </node>"""))
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Created. `Location` points at `/nodes/{id}` with the assigned database id."),
+            @ApiResponse(responseCode = "400", description = "`type` was not set.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Node type must be set."))),
+            @ApiResponse(responseCode = "415", description = "The body was not XML."),
+            @ApiResponse(responseCode = "500", description = "Publishing `nodeAdded` failed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot send event uei.opennms.org/nodes/nodeAdded : connection refused")))
+    })
     public Response addNode(@Context final UriInfo uriInfo, final OnmsNode node) {
         writeLock();
         
@@ -275,7 +557,45 @@ public class NodeRestService extends OnmsRestService {
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("{nodeCriteria}")
     @Transactional
-    public Response updateNode(@PathParam("nodeCriteria") final String nodeCriteria, final MultivaluedMapImpl params) {
+    @Operation(
+            summary = "Update a node",
+            description = """
+                    Applies form-encoded fields to the node. Keys are bean property names on `OnmsNode`, and
+                    nested paths such as `assetRecord.city` resolve, so this endpoint also reaches the asset
+                    record. Keys that resolve to nothing writable are ignored, so a request naming only such keys
+                    comes back 304.
+
+                    `id`, `dbId`, `nodeId`, `authorizedGroups`, `foreignSource`, `foreignId` and `type` are
+                    protected and dropped with a log warning, including when reached through a nested path. Node
+                    identity and requisition ownership therefore cannot be changed here.
+
+                    No event is published, so daemons are not told about the change.
+
+                    A missing node is reported as 400, not 404, unlike `GET /nodes/{nodeCriteria}`.""",
+            operationId = "updateNode"
+    )
+    @RequestBody(
+            required = true,
+            description = "Form-encoded node properties to set.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "string"),
+                    examples = {
+                            @ExampleObject(name = "sysFields", summary = "Set the SNMP system fields",
+                                    value = "sysLocation=Rack+7&sysContact=noc%40example.org"),
+                            @ExampleObject(name = "assetThroughNode", summary = "Set an asset field through the node",
+                                    value = "assetRecord.city=Pittsboro&assetRecord.state=NC")
+                    })
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "At least one field was written. No body."),
+            @ApiResponse(responseCode = "304", description = "No key in the body resolved to a writable, unprotected property."),
+            @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Node 999999 was not found.")))
+    })
+    public Response updateNode(@Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                               @PathParam("nodeCriteria") final String nodeCriteria, final MultivaluedMapImpl params) {
         writeLock();
         
         try {
@@ -321,7 +641,31 @@ public class NodeRestService extends OnmsRestService {
     @DELETE
     @Path("{nodeCriteria}")
     @Transactional
-    public Response deleteNode(@PathParam("nodeCriteria") final String nodeCriteria) {
+    @Operation(
+            summary = "Delete a node",
+            description = """
+                    Publishes `deleteNode` and returns immediately. The deletion is carried out asynchronously by
+                    provisiond and takes the node's interfaces, services, asset record, hardware inventory and
+                    category assignments with it, so the node is normally still readable for a moment after the
+                    202 and the caller has to poll to see the effect.
+
+                    Nothing prevents a requisitioned node from being deleted here. The requisition still lists it,
+                    so the next import recreates it.""",
+            operationId = "deleteNode"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "202", description = "The delete request was published. No body. Completion is not confirmed."),
+            @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Node 999999 was not found."))),
+            @ApiResponse(responseCode = "500", description = "Publishing `deleteNode` failed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot send event uei.opennms.org/internal/capsd/deleteNode : connection refused")))
+    })
+    public Response deleteNode(@Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                               @PathParam("nodeCriteria") final String nodeCriteria) {
         writeLock();
         
         try {
@@ -387,7 +731,48 @@ public class NodeRestService extends OnmsRestService {
     @Path("/{nodeCriteria}/categories")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     @Transactional
-    public OnmsCategoryCollection getCategoriesForNode(@PathParam("nodeCriteria") String nodeCriteria) {
+    @Operation(
+            summary = "List the categories assigned to a node",
+            description = """
+                    Returns the categories currently on the node. On a node with no categories the collection comes
+                    back with `totalCount` and `count` null rather than 0.
+
+                    `GET /categories/nodes/{nodeCriteria}` is the same operation under the categories tree.""",
+            operationId = "listNodeCategories"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The node's categories.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsCategoryCollection.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 2,
+                      "count": 2,
+                      "offset": 0,
+                      "category": [
+                        { "id": 1, "authorizedGroups": [], "name": "Routers" },
+                        { "id": 4, "description": "Production estate", "authorizedGroups": ["Admin"], "name": "Production" }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsCategoryCollection.class),
+                                    examples = @ExampleObject(value = """
+                    <categories count="2" offset="0" totalCount="2">
+                      <category id="1" name="Routers"/>
+                      <category id="4" name="Production">
+                        <authorizedGroups>Admin</authorizedGroups>
+                        <description>Production estate</description>
+                      </category>
+                    </categories>"""))
+                    }),
+            @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Node 999999 was not found.")))
+    })
+    public OnmsCategoryCollection getCategoriesForNode(@Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                                       @PathParam("nodeCriteria") String nodeCriteria) {
         OnmsNode node = m_nodeDao.get(nodeCriteria);
         if (node == null) {
             throw getException(Status.BAD_REQUEST, "Node {} was not found.", nodeCriteria);
@@ -398,7 +783,40 @@ public class NodeRestService extends OnmsRestService {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     @Path("/{nodeCriteria}/categories/{categoryName}")
     @Transactional
-    public OnmsCategory getCategoryForNode(@PathParam("nodeCriteria") String nodeCriteria, @PathParam("categoryName") String categoryName) {
+    @Operation(
+            summary = "Check whether a node carries a category",
+            description = """
+                    Returns the category if it is assigned to the node, so this doubles as a membership test. A
+                    category that exists but is not on the node is a 404, not a 200.""",
+            operationId = "getNodeCategory"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The category is assigned to the node.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsCategory.class),
+                                    examples = @ExampleObject(value = """
+                    { "id": 1, "description": "Routing devices", "authorizedGroups": [], "name": "Routers" }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsCategory.class),
+                                    examples = @ExampleObject(value = """
+                    <category id="1" name="Routers">
+                      <description>Routing devices</description>
+                    </category>"""))
+                    }),
+            @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Node 999999 was not found."))),
+            @ApiResponse(responseCode = "404", description = "The node exists but does not carry that category.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Can't find category Test for node 258.")))
+    })
+    public OnmsCategory getCategoryForNode(@Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                           @PathParam("nodeCriteria") String nodeCriteria,
+                                           @Parameter(description = "Category name.", example = "Routers")
+                                           @PathParam("categoryName") String categoryName) {
         OnmsNode node = m_nodeDao.get(nodeCriteria);
         if (node == null) {
             throw getException(Status.BAD_REQUEST, "Node {} was not found.", nodeCriteria);
@@ -414,7 +832,41 @@ public class NodeRestService extends OnmsRestService {
     @Consumes(MediaType.APPLICATION_XML)
     @Path("/{nodeCriteria}/categories")
     @Transactional
-    public Response addCategoryToNode(@Context final UriInfo uriInfo, @PathParam("nodeCriteria") final String nodeCriteria, OnmsCategory category) {
+    @Operation(
+            summary = "Assign an existing category to a node, naming it in the body",
+            description = """
+                    Adds an already-defined category to the node. Only the `name` in the body is used; everything
+                    else, `description` included, is ignored, and no category is created here.
+
+                    XML only. A JSON or form-encoded body is rejected with 415. `name` is an XML *attribute* on
+                    `category`.
+
+                    Unlike the variant that names the category in the path, the 201 `Location` of this operation
+                    is a working URL.""",
+            operationId = "addNodeCategoryFromBody"
+    )
+    @RequestBody(
+            required = true,
+            description = "Names the category to assign. Only `name` is read.",
+            content = @Content(mediaType = MediaType.APPLICATION_XML,
+                    schema = @Schema(implementation = OnmsCategory.class),
+                    examples = @ExampleObject(value = "<category name=\"Routers\"/>"))
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "The category was added. `Location` points at the category on the node."),
+            @ApiResponse(responseCode = "400", description = "No such node, no such category, the category is already on the node, or the body was empty.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "alreadyAssigned", value = "Category 'Routers' already added to node '258'"),
+                                    @ExampleObject(name = "unknownCategory", value = "Category NoSuchCat was not found."),
+                                    @ExampleObject(name = "noBody", value = "Category must not be null.")
+                            })),
+            @ApiResponse(responseCode = "415", description = "The body was not XML.")
+    })
+    public Response addCategoryToNode(@Context final UriInfo uriInfo,
+                                      @Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                      @PathParam("nodeCriteria") final String nodeCriteria, OnmsCategory category) {
         if (category == null) throw getException(Status.BAD_REQUEST, "Category must not be null.");
         return addCategoryToNode(uriInfo, nodeCriteria,  category.getName());
     }
@@ -422,7 +874,34 @@ public class NodeRestService extends OnmsRestService {
     @POST
     @Path("/{nodeCriteria}/categories/{categoryName}")
     @Transactional
-    public Response addCategoryToNode(@Context final UriInfo uriInfo, @PathParam("nodeCriteria") String nodeCriteria, @PathParam("categoryName") final String categoryName) {
+    @Operation(
+            summary = "Assign an existing category to a node, naming it in the path",
+            description = """
+                    Adds an already-defined category to the node. No request body is read and none is required, so
+                    this is the simplest of the three ways to assign a category. The category is not created here;
+                    an unknown name is a 400.
+
+                    The `Location` header of the 201 is built by appending the category name to the request URI,
+                    so it comes back with the name repeated (`/nodes/258/categories/Routers/Routers`) and is not a
+                    usable URL.""",
+            operationId = "addNodeCategory"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "The category was added. `Location` repeats the category name and is not a working URL."),
+            @ApiResponse(responseCode = "400", description = "No such node, no such category, or the category is already on the node.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "alreadyAssigned", value = "Category 'Routers' already added to node '258'"),
+                                    @ExampleObject(name = "unknownCategory", value = "Category NoSuchCat was not found."),
+                                    @ExampleObject(name = "unknownNode", value = "Node 999999 was not found.")
+                            }))
+    })
+    public Response addCategoryToNode(@Context final UriInfo uriInfo,
+                                      @Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                      @PathParam("nodeCriteria") String nodeCriteria,
+                                      @Parameter(description = "Name of an existing category.", example = "Routers")
+                                      @PathParam("categoryName") final String categoryName) {
         writeLock();
 
         try {
@@ -451,7 +930,42 @@ public class NodeRestService extends OnmsRestService {
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("/{nodeCriteria}/categories/{categoryName}")
     @Transactional
-    public Response updateCategoryForNode(@PathParam("nodeCriteria") final String nodeCriteria, @PathParam("categoryName") final String categoryName, MultivaluedMapImpl params) {
+    @Operation(
+            summary = "Update a category definition, addressed through a node that carries it",
+            description = """
+                    Applies form-encoded fields to the category itself, not to the node-category assignment. The
+                    node in the path only selects which category is meant; the write is global, so every other
+                    node in that category sees the change.
+
+                    Keys are bean property names on `OnmsCategory`. `name` is protected here, along with `id`,
+                    `dbId`, `nodeId`, `authorizedGroups`, `foreignSource`, `foreignId` and `type`, so the category
+                    cannot be renamed through this path. `PUT /categories/{categoryName}` does allow a rename.
+
+                    The response is 204 whether or not anything was written; this operation never returns 304.""",
+            operationId = "updateNodeCategory"
+    )
+    @RequestBody(
+            required = true,
+            description = "Form-encoded category fields to set.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "string"),
+                    examples = @ExampleObject(name = "description", summary = "Set the category description",
+                            value = "description=Routing+devices"))
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Request accepted. Returned even when no key matched a writable, unprotected property."),
+            @ApiResponse(responseCode = "400", description = "No such node, or the node does not carry that category.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "notOnNode", value = "Category Test not found on node 258"),
+                                    @ExampleObject(name = "unknownNode", value = "Node 999999 was not found.")
+                            }))
+    })
+    public Response updateCategoryForNode(@Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                          @PathParam("nodeCriteria") final String nodeCriteria,
+                                          @Parameter(description = "Name of a category the node carries.", example = "Routers")
+                                          @PathParam("categoryName") final String categoryName, MultivaluedMapImpl params) {
         writeLock();
 
         try {
@@ -493,7 +1007,27 @@ public class NodeRestService extends OnmsRestService {
     @DELETE
     @Path("/{nodeCriteria}/categories/{categoryName}")
     @Transactional
-    public Response removeCategoryFromNode(@PathParam("nodeCriteria") String nodeCriteria, @PathParam("categoryName") String categoryName) {
+    @Operation(
+            summary = "Remove a category from a node",
+            description = """
+                    Detaches the category from the node. The category definition itself is left alone, so it stays
+                    on every other node that carries it.""",
+            operationId = "removeNodeCategory"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The category is no longer on the node. No body."),
+            @ApiResponse(responseCode = "400", description = "No such node, or the node does not carry that category.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "notOnNode", value = "Category Routers not found on node 258"),
+                                    @ExampleObject(name = "unknownNode", value = "Node 999999 was not found.")
+                            }))
+    })
+    public Response removeCategoryFromNode(@Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                           @PathParam("nodeCriteria") String nodeCriteria,
+                                           @Parameter(description = "Name of a category the node carries.", example = "Routers")
+                                           @PathParam("categoryName") String categoryName) {
         writeLock();
 
         try {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NodeRestService.java
@@ -106,10 +106,7 @@ import org.springframework.transaction.annotation.Transactional;
         Timestamps serialize differently per representation: JSON carries epoch milliseconds
         (`"createTime": 1787727313802`) while XML carries an ISO-8601 offset date-time
         (`<createTime>2026-08-26T02:55:13.802-04:00</createTime>`). The schemas shown here are derived from the
-        Java types and say `date-time` for both. Node `id` is a string in JSON and an attribute in XML.
-
-        Interfaces, services, categories, asset data and hardware inventory hang off `/nodes/{nodeCriteria}/...`
-        and are documented under their own operations.""")
+        Java types and say `date-time` for both. Node `id` is a string in JSON and an attribute in XML.""")
 public class NodeRestService extends OnmsRestService {
     private static final Logger LOG = LoggerFactory.getLogger(NodeRestService.class);
 
@@ -153,14 +150,12 @@ public class NodeRestService extends OnmsRestService {
                     resolve. A value of `null` or `notnull` becomes an is-null / is-not-null test. Unknown
                     property names are logged and ignored rather than rejected.
 
-                    Restrict by database id with `id`, not with `nodeId`: `nodeId` is not usable as a criteria
-                    property and any request that sends it fails with 500, including the documented
-                    comma-separated form.
+                    The criteria property for the database id is `id`. `nodeId` is not usable as a criteria
+                    property and any request that sends it fails with 500, including the comma-separated form.
 
-                    `filterRule` is evaluated separately, by the filter engine, and is mutually exclusive with the
-                    property restrictions in the sense that it replaces them: matching node ids are resolved
-                    first, then the remaining parameters are re-applied on top of that id set. A rule that matches
-                    nothing returns an empty list with `totalCount` 0 rather than an error.""",
+                    `filterRule` is evaluated by the filter engine: matching node ids are resolved first, then the
+                    remaining query parameters are applied to that id set. A rule that matches nothing returns an
+                    empty list with `totalCount` 0 rather than an error.""",
             operationId = "searchNodes",
             parameters = {
                     @Parameter(in = ParameterIn.QUERY, name = "limit",
@@ -191,10 +186,10 @@ public class NodeRestService extends OnmsRestService {
                             description = "Node type. Sending any value, including `A`, also disables the implicit exclusion of deleted nodes.",
                             schema = @Schema(type = "string", allowableValues = {"A", "D"}), example = "A"),
                     @Parameter(in = ParameterIn.QUERY, name = "id",
-                            description = "Database node id. Use this rather than `nodeId`.",
+                            description = "Database node id.",
                             schema = @Schema(type = "integer"), example = "258"),
                     @Parameter(in = ParameterIn.QUERY, name = "label",
-                            description = "Node label. Example of the generic property-restriction form; pair it with `comparator=contains` for a substring search.",
+                            description = "Node label. One of the generic property restrictions; with `comparator=contains` it matches substrings.",
                             schema = @Schema(type = "string"), example = "core-sw-01"),
                     @Parameter(in = ParameterIn.QUERY, name = "foreignSource",
                             description = "Requisition that owns the node.",
@@ -255,7 +250,7 @@ public class NodeRestService extends OnmsRestService {
                       </node>
                     </nodes>"""))
                     }),
-            @ApiResponse(responseCode = "400", description = "`filterRule` could not be parsed. The parse error is deliberately not echoed, because it can contain the generated SQL.",
+            @ApiResponse(responseCode = "400", description = "`filterRule` could not be parsed. The parse error is not echoed.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Invalid 'filterRule' in request."))),
@@ -346,11 +341,8 @@ public class NodeRestService extends OnmsRestService {
             summary = "Get one node",
             description = """
                     Returns a single node, addressed either by database id or by `foreignSource:foreignId`.
-                    Deleted nodes are not filtered out here, unlike in the search endpoint.
-
-                    The node's asset record is embedded in the response, but the search endpoint's paged result
-                    embeds it too, so `/nodes/{nodeCriteria}/assetRecord` is only needed when the asset record is
-                    all that is wanted.""",
+                    Deleted nodes are not filtered out here, unlike in the search endpoint. The node's asset
+                    record is embedded in the response.""",
             operationId = "getNode"
     )
     @ApiResponses(value = {
@@ -433,9 +425,7 @@ public class NodeRestService extends OnmsRestService {
                     `rescanExisting=true` and returns immediately. The scan itself is asynchronous, so a 204 means
                     the request was queued, not that the node has been rescanned.
 
-                    No request body is read. The method declares `@Consumes(application/x-www-form-urlencoded)`,
-                    so a `Content-Type` is only needed if a body is sent at all; an empty PUT with no
-                    `Content-Type` is accepted.""",
+                    No request body is read; an empty PUT with no `Content-Type` is accepted.""",
             operationId = "rescanNode"
     )
     @ApiResponses(value = {
@@ -566,12 +556,10 @@ public class NodeRestService extends OnmsRestService {
                     comes back 304.
 
                     `id`, `dbId`, `nodeId`, `authorizedGroups`, `foreignSource`, `foreignId` and `type` are
-                    protected and dropped with a log warning, including when reached through a nested path. Node
-                    identity and requisition ownership therefore cannot be changed here.
+                    protected and dropped with a log warning, including when reached through a nested path.
 
-                    No event is published, so daemons are not told about the change.
-
-                    A missing node is reported as 400, not 404, unlike `GET /nodes/{nodeCriteria}`.""",
+                    No event is published. A missing node is reported as 400, not 404, unlike
+                    `GET /nodes/{nodeCriteria}`.""",
             operationId = "updateNode"
     )
     @RequestBody(
@@ -647,7 +635,7 @@ public class NodeRestService extends OnmsRestService {
                     Publishes `deleteNode` and returns immediately. The deletion is carried out asynchronously by
                     provisiond and takes the node's interfaces, services, asset record, hardware inventory and
                     category assignments with it, so the node is normally still readable for a moment after the
-                    202 and the caller has to poll to see the effect.
+                    202.
 
                     Nothing prevents a requisitioned node from being deleted here. The requisition still lists it,
                     so the next import recreates it.""",
@@ -786,8 +774,8 @@ public class NodeRestService extends OnmsRestService {
     @Operation(
             summary = "Check whether a node carries a category",
             description = """
-                    Returns the category if it is assigned to the node, so this doubles as a membership test. A
-                    category that exists but is not on the node is a 404, not a 200.""",
+                    Returns the category if it is assigned to the node. A category that exists but is not on the
+                    node is a 404, not a 200.""",
             operationId = "getNodeCategory"
     )
     @ApiResponses(value = {
@@ -877,9 +865,8 @@ public class NodeRestService extends OnmsRestService {
     @Operation(
             summary = "Assign an existing category to a node, naming it in the path",
             description = """
-                    Adds an already-defined category to the node. No request body is read and none is required, so
-                    this is the simplest of the three ways to assign a category. The category is not created here;
-                    an unknown name is a 400.
+                    Adds an already-defined category to the node. No request body is read. The category is not
+                    created here; an unknown name is a 400.
 
                     The `Location` header of the 201 is built by appending the category name to the request URI,
                     so it comes back with the name repeated (`/nodes/258/categories/Routers/Routers`) and is not a

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationRestService.java
@@ -97,8 +97,8 @@ public class NotificationRestService extends OnmsRestService {
                     Return one notification by id, including the per-user delivery records in `destinations`.
                     `ackUser` and `ackTime` carry the `answeredBy` and `respondTime` columns, so they are null
                     while the notification is outstanding.
-                    Timestamps are epoch milliseconds in JSON and ISO-8601 strings in XML, whatever the schema
-                    says.""",
+                    The derived schema shows `date-time`; the wire carries epoch milliseconds in JSON and ISO-8601
+                    strings in XML.""",
             operationId = "getNotificationV1"
     )
     @ApiResponses(value = {
@@ -164,7 +164,7 @@ public class NotificationRestService extends OnmsRestService {
     @Operation(
             summary = "Count all notifications",
             description = "Return the total number of notification rows as a plain-text integer. Query parameters "
-                    + "are ignored, so this is not a count of a filtered set.",
+                    + "are ignored.",
             operationId = "getNotificationCountV1"
     )
     @ApiResponses(value = {
@@ -265,9 +265,9 @@ public class NotificationRestService extends OnmsRestService {
                     says otherwise.
                     Filters are `OnmsNotification` property names, with `node.*`, `event.*`, `ipInterface.*`,
                     `snmpInterface.*` and `usersNotified.*` reachable through their aliases. Outstanding
-                    notifications are the ones with `answeredBy=null`, which the filter syntax expresses as
-                    `answeredBy=null`. `limit` (default 10), `offset`, `orderBy`, `order`, `match` and `comparator`
-                    shape the result. A filter name that is not a property of the entity fails with 500.""",
+                    notifications are the ones matching `answeredBy=null`. `limit` (default 10), `offset`,
+                    `orderBy`, `order`, `match` and `comparator` shape the result. A filter name that is not a
+                    property of the entity fails with 500.""",
             operationId = "getNotificationsV1"
     )
     @ApiResponses(value = {
@@ -388,8 +388,8 @@ public class NotificationRestService extends OnmsRestService {
             summary = "Acknowledge or unacknowledge matching notifications",
             description = """
                     Set or clear the acknowledgement on every notification matching the filters in the form body.
-                    Fields other than `ack` are read as notification filters, so scope the request with `notifyId`,
-                    `nodeId` or another `OnmsNotification` property.
+                    Fields other than `ack` are read as filters on `OnmsNotification` property names such as
+                    `notifyId` and `nodeId`.
                     `ack` is optional here and defaults to `false`, and only the exact string `true`
                     acknowledges. The default limit of 10 applies, so a large match set is processed one page at a
                     time. A body that matches nothing still returns 204.""",
@@ -434,12 +434,11 @@ public class NotificationRestService extends OnmsRestService {
     @Operation(
             summary = "Trigger a destination path",
             description = """
-                    Run every notification command of every target on a destination path, as a delivery test. The
-                    request takes no body and requires `ROLE_ADMIN`.
+                    Run every notification command of every target on a destination path. The request takes no
+                    body and requires `ROLE_ADMIN`.
                     A path name with no targets, including one that does not exist in `destinationPaths.xml`,
                     returns 204 without doing anything. Otherwise the commands are executed synchronously and the
-                    response is 202 once they have all been attempted, so it does not report per-target delivery
-                    success.
+                    response is 202 once they have all been attempted.
                     Only the path's own targets are used; escalation levels are not walked.""",
             operationId = "triggerDestinationPathV1"
     )

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationRestService.java
@@ -135,7 +135,7 @@ public class NotificationRestService extends OnmsRestService {
                       ]
                     }"""))),
             @ApiResponse(responseCode = "404", description = "No notification with that id, or the path segment is not an integer.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Notification 99999999 was not found.")))
     })
@@ -202,11 +202,11 @@ public class NotificationRestService extends OnmsRestService {
                       "user": "admin",
                       "totalCount": 2613,
                       "totalUnacknowledgedCount": 2293,
-                      "userUnacknowledgedCount": 4578,
+                      "userUnacknowledgedCount": 0,
                       "teamUnacknowledgedCount": 1,
                       "userUnacknowledgedNotifications": {
                         "totalCount": null,
-                        "count": 10,
+                        "count": null,
                         "offset": 0,
                         "notification": []
                       }
@@ -309,7 +309,7 @@ public class NotificationRestService extends OnmsRestService {
                         } ]
                     }"""))),
             @ApiResponse(responseCode = "500", description = "A query parameter is not a property of the notification entity.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Unknown entity: null; nested exception is org.hibernate.HibernateException: Unknown entity: null")))
     })
@@ -350,11 +350,11 @@ public class NotificationRestService extends OnmsRestService {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "The notification was updated."),
             @ApiResponse(responseCode = "400", description = "`ack` was absent.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Must supply the 'ack' parameter, set to either 'true' or 'false'"))),
             @ApiResponse(responseCode = "404", description = "No notification with that id.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Notification 99999999 was not found."))),
             @ApiResponse(responseCode = "415", description = "The body was not `application/x-www-form-urlencoded`.")
@@ -403,7 +403,7 @@ public class NotificationRestService extends OnmsRestService {
             @ApiResponse(responseCode = "204", description = "The request was processed, whether or not anything matched."),
             @ApiResponse(responseCode = "415", description = "The body was not `application/x-www-form-urlencoded`."),
             @ApiResponse(responseCode = "500", description = "A form parameter is not a property of the notification entity.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Unknown entity: null; nested exception is org.hibernate.HibernateException: Unknown entity: null")))
     })

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationRestService.java
@@ -40,6 +40,14 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.criteria.Alias.JoinType;
 import org.opennms.core.criteria.CriteriaBuilder;
@@ -54,6 +62,7 @@ import org.opennms.netmgt.notifd.api.NotificationTester;
 import org.opennms.netmgt.provision.service.MonitorHolder;
 import org.opennms.web.api.Authentication;
 import org.opennms.web.rest.support.MultivaluedMapImpl;
+import org.opennms.web.rest.v1.model.AckOnlyForm;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -82,7 +91,57 @@ public class NotificationRestService extends OnmsRestService {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     @Path("{notifId}")
     @Transactional
-    public OnmsNotification getNotification(@PathParam("notifId") Integer notifId) {
+    @Operation(
+            summary = "Get a notification",
+            description = """
+                    Return one notification by id, including the per-user delivery records in `destinations`.
+                    `ackUser` and `ackTime` carry the `answeredBy` and `respondTime` columns, so they are null
+                    while the notification is outstanding.
+                    Timestamps are epoch milliseconds in JSON and ISO-8601 strings in XML, whatever the schema
+                    says.""",
+            operationId = "getNotificationV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The notification.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsNotification.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "id": 2615,
+                      "uei": "uei.opennms.org/nodes/nodeUp",
+                      "nodeId": 2,
+                      "nodeLabel": "loopback-001",
+                      "subject": "Notice #2615: Node loopback-001 has been cleared.",
+                      "textMessage": "The node loopback-001 which was previously down is now up.",
+                      "numericMessage": "111-2615",
+                      "severity": "NORMAL",
+                      "serviceType": null,
+                      "ackUser": null,
+                      "ackTime": null,
+                      "ackId": 2615,
+                      "pageTime": 1787074522047,
+                      "queueId": "default",
+                      "eventId": 9650,
+                      "type": "NOTIFICATION",
+                      "destinations": [
+                        {
+                          "id": 4801,
+                          "userId": "admin",
+                          "contactInfo": "",
+                          "notifyTime": 1787074527360,
+                          "media": "browser",
+                          "autoNotify": "C"
+                        }
+                      ]
+                    }"""))),
+            @ApiResponse(responseCode = "404", description = "No notification with that id, or the path segment is not an integer.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Notification 99999999 was not found.")))
+    })
+    public OnmsNotification getNotification(
+            @Parameter(description = "Notification id.", example = "2615", required = true)
+            @PathParam("notifId") Integer notifId) {
         if (notifId == null) {
             throw getException(Status.BAD_REQUEST, "Notification ID is required");
         }
@@ -102,6 +161,18 @@ public class NotificationRestService extends OnmsRestService {
     @Produces(MediaType.TEXT_PLAIN)
     @Path("count")
     @Transactional
+    @Operation(
+            summary = "Count all notifications",
+            description = "Return the total number of notification rows as a plain-text integer. Query parameters "
+                    + "are ignored, so this is not a count of a filtered set.",
+            operationId = "getNotificationCountV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The notification count.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "2613")))
+    })
     public String getCount() {
         return Integer.toString(m_notifDao.countAll());
     }
@@ -109,6 +180,39 @@ public class NotificationRestService extends OnmsRestService {
     @GET
     @Path("summary")
     @Produces({MediaType.APPLICATION_JSON})
+    @Operation(
+            summary = "Get a notification summary for the caller",
+            description = """
+                    Return outstanding notification counts for the authenticated user, plus up to the ten newest
+                    notifications addressed to them.
+                    This operation produces JSON only. A request that asks for XML does not get a 406: the
+                    `{notifId}` route matches the literal `summary` instead, and the integer conversion fails with
+                    404.
+                    `userUnacknowledgedCount` and `teamUnacknowledgedCount` are counted over a join against the
+                    per-user delivery rows, so a notification delivered to a user by several media is counted once
+                    per delivery and these figures can exceed `totalCount`.""",
+            operationId = "getNotificationSummaryV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The summary.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = NotificationSummary.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "user": "admin",
+                      "totalCount": 2613,
+                      "totalUnacknowledgedCount": 2293,
+                      "userUnacknowledgedCount": 4578,
+                      "teamUnacknowledgedCount": 1,
+                      "userUnacknowledgedNotifications": {
+                        "totalCount": null,
+                        "count": 10,
+                        "offset": 0,
+                        "notification": []
+                      }
+                    }"""))),
+            @ApiResponse(responseCode = "404", description = "The request asked for a media type other than JSON, so the `{notifId}` route was matched instead.")
+    })
     public NotificationSummary getInfo(@Context final SecurityContext securityContext) {
         final String user = securityContext.getUserPrincipal().getName();
         final NotificationSummary info = new NotificationSummary();
@@ -154,6 +258,61 @@ public class NotificationRestService extends OnmsRestService {
     @Path("")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     @Transactional
+    @Operation(
+            summary = "Search notifications",
+            description = """
+                    Return notifications matching the query parameters, highest `notifyId` first unless `orderBy`
+                    says otherwise.
+                    Filters are `OnmsNotification` property names, with `node.*`, `event.*`, `ipInterface.*`,
+                    `snmpInterface.*` and `usersNotified.*` reachable through their aliases. Outstanding
+                    notifications are the ones with `answeredBy=null`, which the filter syntax expresses as
+                    `answeredBy=null`. `limit` (default 10), `offset`, `orderBy`, `order`, `match` and `comparator`
+                    shape the result. A filter name that is not a property of the entity fails with 500.""",
+            operationId = "getNotificationsV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The matching notifications.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsNotificationCollection.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 2613,
+                      "count": 1,
+                      "offset": 0,
+                      "notification": [ {
+                          "id": 2615,
+                          "uei": "uei.opennms.org/nodes/nodeUp",
+                          "nodeId": 2,
+                          "nodeLabel": "loopback-001",
+                          "subject": "Notice #2615: Node loopback-001 has been cleared.",
+                          "textMessage": "The node loopback-001 which was previously down is now up.",
+                          "numericMessage": "111-2615",
+                          "severity": "NORMAL",
+                          "serviceType": null,
+                          "ackUser": null,
+                          "ackTime": null,
+                          "ackId": 2615,
+                          "pageTime": 1787074522047,
+                          "queueId": "default",
+                          "eventId": 9650,
+                          "type": "NOTIFICATION",
+                          "destinations": [
+                            {
+                              "id": 4801,
+                              "userId": "admin",
+                              "contactInfo": "",
+                              "notifyTime": 1787074527360,
+                              "media": "browser",
+                              "autoNotify": "C"
+                            }
+                          ]
+                        } ]
+                    }"""))),
+            @ApiResponse(responseCode = "500", description = "A query parameter is not a property of the notification entity.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Unknown entity: null; nested exception is org.hibernate.HibernateException: Unknown entity: null")))
+    })
     public OnmsNotificationCollection getNotifications(@Context final UriInfo uriInfo) {
         final CriteriaBuilder builder = getCriteriaBuilder(uriInfo.getQueryParameters());
         builder.orderBy("notifyId").desc();
@@ -175,7 +334,34 @@ public class NotificationRestService extends OnmsRestService {
     @Path("{notifId}")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Transactional
-    public Response updateNotification(@Context final SecurityContext securityContext, @PathParam("notifId") final Integer notifId, @FormParam("ack") final Boolean ack) {
+    @Operation(
+            summary = "Acknowledge or unacknowledge one notification",
+            description = """
+                    Set or clear `answeredBy` and `respondTime` on one notification. The answering user is taken
+                    from the authenticated principal and cannot be overridden.
+                    `ack` has to be present. Any value other than `true` parses as `false` and clears the
+                    acknowledgement.""",
+            operationId = "updateNotificationV1"
+    )
+    @RequestBody(required = true, description = "The acknowledge flag.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(implementation = AckOnlyForm.class),
+                    examples = @ExampleObject(value = "ack=true")))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The notification was updated."),
+            @ApiResponse(responseCode = "400", description = "`ack` was absent.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Must supply the 'ack' parameter, set to either 'true' or 'false'"))),
+            @ApiResponse(responseCode = "404", description = "No notification with that id.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Notification 99999999 was not found."))),
+            @ApiResponse(responseCode = "415", description = "The body was not `application/x-www-form-urlencoded`.")
+    })
+    public Response updateNotification(@Context final SecurityContext securityContext,
+            @Parameter(description = "Notification id.", example = "2615", required = true)
+            @PathParam("notifId") final Integer notifId, @FormParam("ack") final Boolean ack) {
         writeLock();
         
         try {
@@ -198,6 +384,29 @@ public class NotificationRestService extends OnmsRestService {
     @PUT
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Transactional
+    @Operation(
+            summary = "Acknowledge or unacknowledge matching notifications",
+            description = """
+                    Set or clear the acknowledgement on every notification matching the filters in the form body.
+                    Fields other than `ack` are read as notification filters, so scope the request with `notifyId`,
+                    `nodeId` or another `OnmsNotification` property.
+                    `ack` is optional here and defaults to `false`, and only the exact string `true`
+                    acknowledges. The default limit of 10 applies, so a large match set is processed one page at a
+                    time. A body that matches nothing still returns 204.""",
+            operationId = "updateNotificationsV1"
+    )
+    @RequestBody(required = true, description = "The acknowledge flag, plus the filters selecting the notifications.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(implementation = AckOnlyForm.class),
+                    examples = @ExampleObject(value = "ack=true&notifyId=2615")))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The request was processed, whether or not anything matched."),
+            @ApiResponse(responseCode = "415", description = "The body was not `application/x-www-form-urlencoded`."),
+            @ApiResponse(responseCode = "500", description = "A form parameter is not a property of the notification entity.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Unknown entity: null; nested exception is org.hibernate.HibernateException: Unknown entity: null")))
+    })
     public Response updateNotifications(@Context final SecurityContext securityContext, final MultivaluedMapImpl params) {
         writeLock();
         
@@ -222,7 +431,29 @@ public class NotificationRestService extends OnmsRestService {
     @POST
     @Path("destination-paths/{destinationPathName}/trigger")
     @Transactional
-    public Response triggerDestinationPath(@Context final SecurityContext securityContext, @PathParam("destinationPathName") final String destinationPathName) {
+    @Operation(
+            summary = "Trigger a destination path",
+            description = """
+                    Run every notification command of every target on a destination path, as a delivery test. The
+                    request takes no body and requires `ROLE_ADMIN`.
+                    A path name with no targets, including one that does not exist in `destinationPaths.xml`,
+                    returns 204 without doing anything. Otherwise the commands are executed synchronously and the
+                    response is 202 once they have all been attempted, so it does not report per-target delivery
+                    success.
+                    Only the path's own targets are used; escalation levels are not walked.""",
+            operationId = "triggerDestinationPathV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "202", description = "The path had targets and its commands were run."),
+            @ApiResponse(responseCode = "204", description = "The path has no targets, or does not exist."),
+            @ApiResponse(responseCode = "403", description = "The caller does not hold `ROLE_ADMIN`. The body is "
+                    + "the handler's message when the request reaches the resource, and the container's error page "
+                    + "when a security filter rejects it first.")
+    })
+    public Response triggerDestinationPath(@Context final SecurityContext securityContext,
+            @Parameter(description = "Destination path name as it appears in `destinationPaths.xml`.",
+                    example = "Email-Admin", required = true)
+            @PathParam("destinationPathName") final String destinationPathName) {
         if (!securityContext.isUserInRole(Authentication.ROLE_ADMIN)) {
             throw getException(Status.FORBIDDEN, "User {} does not have access to trigger notifications.", securityContext.getUserPrincipal().getName());
         }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OnmsIpInterfaceResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OnmsIpInterfaceResource.java
@@ -108,10 +108,7 @@ public class OnmsIpInterfaceResource extends OnmsRestService {
 
                     `isManaged` is a one-character code: `M` is managed, and only `M` counts as managed. `U`, `F`
                     and `N` are the unmanaged, forced-unmanaged and not-polled variants; `D` marks a deleted row.
-                    `snmpPrimary` is `P` for the primary SNMP interface, `S` for secondary and `N` for none.
-
-                    The node lookup is not guarded, so an unknown `nodeCriteria` fails with HTTP 500 rather than
-                    400 or 404.""",
+                    `snmpPrimary` is `P` for the primary SNMP interface, `S` for secondary and `N` for none.""",
             operationId = "listNodeIpInterfaces",
             parameters = {
                     @Parameter(in = ParameterIn.QUERY, name = "limit",
@@ -136,7 +133,7 @@ public class OnmsIpInterfaceResource extends OnmsRestService {
                             schema = @Schema(type = "string", defaultValue = "all", allowableValues = {"all", "any"}),
                             example = "any"),
                     @Parameter(in = ParameterIn.QUERY, name = "ipAddress",
-                            description = "Restrict to this address. Example of the generic property-restriction form; pair it with `comparator=iplike` for a range.",
+                            description = "Restrict to this address. One of the generic property restrictions; with `comparator=iplike` it matches a range.",
                             schema = @Schema(type = "string"), example = "192.0.2.10"),
                     @Parameter(in = ParameterIn.QUERY, name = "snmpPrimary",
                             description = "Restrict by SNMP primary role.",
@@ -180,7 +177,7 @@ public class OnmsIpInterfaceResource extends OnmsRestService {
                       </ipInterface>
                     </ipInterfaces>"""))
                     }),
-            @ApiResponse(responseCode = "500", description = "No node matches `nodeCriteria`. The node is dereferenced without a null check, so this is a null-pointer failure rather than a 400.",
+            @ApiResponse(responseCode = "500", description = "No node matches `nodeCriteria`. This path reports a missing node as a null-pointer failure, not as 400 or 404.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Cannot invoke \"org.opennms.netmgt.model.OnmsNode.getId()\" because \"node\" is null")))
@@ -224,9 +221,7 @@ public class OnmsIpInterfaceResource extends OnmsRestService {
             description = """
                     Returns a single IP interface, addressed by its literal address. The address is parsed before
                     the lookup, so an unparseable address behaves the same as an address the node does not have.
-
-                    Unlike the list endpoint, this one does look at interfaces flagged deleted, since it reads the
-                    node's own interface set rather than running a query.""",
+                    Unlike the list endpoint, interfaces flagged deleted are returned here.""",
             operationId = "getNodeIpInterface"
     )
     @ApiResponses(value = {
@@ -293,8 +288,7 @@ public class OnmsIpInterfaceResource extends OnmsRestService {
     @Operation(
             summary = "Add an IP interface to a node",
             description = """
-                    Attaches a new IP interface to the node and publishes `nodeGainedInterface`, which is what
-                    makes pollerd and collectd pick it up.
+                    Attaches a new IP interface to the node and publishes `nodeGainedInterface`.
 
                     XML only. A JSON or form-encoded body is rejected with 415.
 
@@ -375,15 +369,14 @@ public class OnmsIpInterfaceResource extends OnmsRestService {
             summary = "Update one IP interface of a node",
             description = """
                     Applies form-encoded fields to an existing IP interface. Keys are bean property names on
-                    `OnmsIpInterface`, which do not always match the names in the XML representation, so check the
-                    property name rather than copying the attribute name out of a GET response.
+                    `OnmsIpInterface`, which do not always match the names in the XML representation.
 
                     `nodeId` is skipped so the interface cannot be moved between nodes, and `id`, `dbId`,
                     `authorizedGroups`, `foreignSource`, `foreignId` and `type` are protected and dropped with a
                     log warning. Keys that resolve to nothing writable are ignored, so a request naming only such
                     keys comes back 304.
 
-                    No event is published, so changing `isManaged` here does not by itself tell pollerd.""",
+                    No event is published.""",
             operationId = "updateNodeIpInterface"
     )
     @RequestBody(
@@ -471,13 +464,13 @@ public class OnmsIpInterfaceResource extends OnmsRestService {
             description = """
                     Publishes `deleteInterface` and returns immediately. The deletion is carried out
                     asynchronously by provisiond, so the interface is normally still readable for a moment after
-                    the 202 and the caller has to poll to see the effect.
+                    the 202.
 
-                    Only the node is checked. Whether the node actually has that interface is not, so a request
-                    naming an address the node does not have is accepted and simply has no effect.
+                    Only the node is checked, not whether it has that interface, so a request naming an address
+                    the node does not have is accepted and has no effect.
 
-                    Removing a node's last IP interface has been observed to take the node with it: provisiond
-                    deletes a node left with no interfaces, so a following request for the node returns 404.""",
+                    Removing a node's last IP interface has been observed to delete the node as well: a following
+                    request for the node returns 404.""",
             operationId = "deleteNodeIpInterface"
     )
     @ApiResponses(value = {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OnmsIpInterfaceResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OnmsIpInterfaceResource.java
@@ -104,11 +104,15 @@ public class OnmsIpInterfaceResource extends OnmsRestService {
                     Every query parameter that is not one of the paging parameters below is read as a property
                     restriction on `OnmsIpInterface`. Joins are pre-registered for `monitoredServices.serviceType`
                     as `serviceType` and for `node`. A value of `null` or `notnull` becomes an is-null /
-                    is-not-null test. Unknown property names are logged and ignored rather than rejected.
+                    is-not-null test. Unknown property names are not ignored: the filter still binds them and the query fails with 500 `Unknown entity: null`.
 
                     `isManaged` is a one-character code: `M` is managed, and only `M` counts as managed. `U`, `F`
                     and `N` are the unmanaged, forced-unmanaged and not-polled variants; `D` marks a deleted row.
-                    `snmpPrimary` is `P` for the primary SNMP interface, `S` for secondary and `N` for none.""",
+                    `snmpPrimary` is `P` for the primary SNMP interface, `S` for secondary and `N` for none.
+
+                    An interface bound to an SNMP interface additionally carries a nested `snmpInterface`
+                    object, as shown on `GET .../ipinterfaces/{ipAddress}`; the example below is an unbound
+                    interface.""",
             operationId = "listNodeIpInterfaces",
             parameters = {
                     @Parameter(in = ParameterIn.QUERY, name = "limit",

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OnmsIpInterfaceResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OnmsIpInterfaceResource.java
@@ -37,6 +37,15 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.opennms.core.criteria.Alias.JoinType;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.core.utils.InetAddressUtils;
@@ -86,7 +95,99 @@ public class OnmsIpInterfaceResource extends OnmsRestService {
      */
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-    public OnmsIpInterfaceList getIpInterfaces(@Context final UriInfo uriInfo, @PathParam("nodeCriteria") final String nodeCriteria) {
+    @Operation(
+            summary = "List a node's IP interfaces",
+            description = """
+                    Returns the IP interfaces of one node. Interfaces flagged deleted (`isManaged` of `D`) are
+                    excluded and cannot be included.
+
+                    Every query parameter that is not one of the paging parameters below is read as a property
+                    restriction on `OnmsIpInterface`. Joins are pre-registered for `monitoredServices.serviceType`
+                    as `serviceType` and for `node`. A value of `null` or `notnull` becomes an is-null /
+                    is-not-null test. Unknown property names are logged and ignored rather than rejected.
+
+                    `isManaged` is a one-character code: `M` is managed, and only `M` counts as managed. `U`, `F`
+                    and `N` are the unmanaged, forced-unmanaged and not-polled variants; `D` marks a deleted row.
+                    `snmpPrimary` is `P` for the primary SNMP interface, `S` for secondary and `N` for none.
+
+                    The node lookup is not guarded, so an unknown `nodeCriteria` fails with HTTP 500 rather than
+                    400 or 404.""",
+            operationId = "listNodeIpInterfaces",
+            parameters = {
+                    @Parameter(in = ParameterIn.QUERY, name = "limit",
+                            description = "Maximum rows to return. 0 disables the limit.",
+                            schema = @Schema(type = "integer", defaultValue = "10"), example = "25"),
+                    @Parameter(in = ParameterIn.QUERY, name = "offset",
+                            description = "Zero-based index of the first row to return.",
+                            schema = @Schema(type = "integer"), example = "0"),
+                    @Parameter(in = ParameterIn.QUERY, name = "orderBy",
+                            description = "Property to sort on.",
+                            schema = @Schema(type = "string"), example = "ipAddress"),
+                    @Parameter(in = ParameterIn.QUERY, name = "order",
+                            description = "Sort direction for `orderBy`. Anything other than `desc` is read as ascending.",
+                            schema = @Schema(type = "string", allowableValues = {"asc", "desc"}), example = "asc"),
+                    @Parameter(in = ParameterIn.QUERY, name = "comparator",
+                            description = "Comparison applied to every property restriction in the query.",
+                            schema = @Schema(type = "string", defaultValue = "eq",
+                                    allowableValues = {"eq", "ne", "gt", "lt", "ge", "le", "like", "ilike", "contains", "iplike"}),
+                            example = "iplike"),
+                    @Parameter(in = ParameterIn.QUERY, name = "match",
+                            description = "Whether the property restrictions are combined with AND or OR.",
+                            schema = @Schema(type = "string", defaultValue = "all", allowableValues = {"all", "any"}),
+                            example = "any"),
+                    @Parameter(in = ParameterIn.QUERY, name = "ipAddress",
+                            description = "Restrict to this address. Example of the generic property-restriction form; pair it with `comparator=iplike` for a range.",
+                            schema = @Schema(type = "string"), example = "192.0.2.10"),
+                    @Parameter(in = ParameterIn.QUERY, name = "snmpPrimary",
+                            description = "Restrict by SNMP primary role.",
+                            schema = @Schema(type = "string", allowableValues = {"P", "S", "N"}), example = "P")
+            }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The node's IP interfaces.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsIpInterfaceList.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 1,
+                      "count": 1,
+                      "offset": 0,
+                      "ipInterface": [
+                        {
+                          "ipAddress": "192.0.2.10",
+                          "ifIndex": 8,
+                          "lastIngressFlow": null,
+                          "lastEgressFlow": null,
+                          "isManaged": "M",
+                          "snmpPrimary": "P",
+                          "monitoredServiceCount": 2,
+                          "isDown": false,
+                          "id": "23601",
+                          "hostName": "core-sw-01",
+                          "nodeId": 258
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsIpInterfaceList.class),
+                                    examples = @ExampleObject(value = """
+                    <ipInterfaces count="1" offset="0" totalCount="1">
+                      <ipInterface isDown="false" ifIndex="8" id="23601" isManaged="M" monitoredServiceCount="2" snmpPrimary="P">
+                        <ipAddress>192.0.2.10</ipAddress>
+                        <hostName>core-sw-01</hostName>
+                        <nodeId>258</nodeId>
+                      </ipInterface>
+                    </ipInterfaces>"""))
+                    }),
+            @ApiResponse(responseCode = "500", description = "No node matches `nodeCriteria`. The node is dereferenced without a null check, so this is a null-pointer failure rather than a 400.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot invoke \"org.opennms.netmgt.model.OnmsNode.getId()\" because \"node\" is null")))
+    })
+    public OnmsIpInterfaceList getIpInterfaces(@Context final UriInfo uriInfo,
+                                               @Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                               @PathParam("nodeCriteria") final String nodeCriteria) {
         LOG.debug("getIpInterfaces: reading interfaces for node {}", nodeCriteria);
 
         final OnmsNode node = m_nodeDao.get(nodeCriteria);
@@ -118,7 +219,57 @@ public class OnmsIpInterfaceResource extends OnmsRestService {
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     @Path("{ipAddress}")
-    public OnmsIpInterface getIpInterface(@PathParam("nodeCriteria") final String nodeCriteria, @PathParam("ipAddress") final String ipAddress) {
+    @Operation(
+            summary = "Get one IP interface of a node",
+            description = """
+                    Returns a single IP interface, addressed by its literal address. The address is parsed before
+                    the lookup, so an unparseable address behaves the same as an address the node does not have.
+
+                    Unlike the list endpoint, this one does look at interfaces flagged deleted, since it reads the
+                    node's own interface set rather than running a query.""",
+            operationId = "getNodeIpInterface"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The IP interface. `snmpInterface` is present when the address is bound to a known ifIndex.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsIpInterface.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "ipAddress": "192.0.2.10",
+                      "ifIndex": 8,
+                      "lastIngressFlow": null,
+                      "lastEgressFlow": null,
+                      "isManaged": "M",
+                      "snmpPrimary": "P",
+                      "monitoredServiceCount": 2,
+                      "isDown": false,
+                      "id": "23601",
+                      "hostName": "core-sw-01",
+                      "nodeId": 258
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsIpInterface.class),
+                                    examples = @ExampleObject(value = """
+                    <ipInterface isDown="false" ifIndex="8" id="23601" isManaged="M" monitoredServiceCount="2" snmpPrimary="P">
+                      <ipAddress>192.0.2.10</ipAddress>
+                      <hostName>core-sw-01</hostName>
+                      <nodeId>258</nodeId>
+                    </ipInterface>"""))
+                    }),
+            @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Node 999999 was not found."))),
+            @ApiResponse(responseCode = "404", description = "The node has no interface with that address.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "IP Interface 192.0.2.99 was not found on node 258.")))
+    })
+    public OnmsIpInterface getIpInterface(@Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                          @PathParam("nodeCriteria") final String nodeCriteria,
+                                          @Parameter(description = "Literal IPv4 or IPv6 address of the interface.", example = "192.0.2.10")
+                                          @PathParam("ipAddress") final String ipAddress) {
         final OnmsNode node = m_nodeDao.get(nodeCriteria);
         if (node == null) {
             throw getException(Status.BAD_REQUEST, "Node {} was not found.", nodeCriteria);
@@ -139,7 +290,47 @@ public class OnmsIpInterfaceResource extends OnmsRestService {
      */
     @POST
     @Consumes(MediaType.APPLICATION_XML)
-    public Response addIpInterface(@Context final UriInfo uriInfo, @PathParam("nodeCriteria") final String nodeCriteria, final OnmsIpInterface ipInterface) {
+    @Operation(
+            summary = "Add an IP interface to a node",
+            description = """
+                    Attaches a new IP interface to the node and publishes `nodeGainedInterface`, which is what
+                    makes pollerd and collectd pick it up.
+
+                    XML only. A JSON or form-encoded body is rejected with 415.
+
+                    `isManaged` and `snmpPrimary` are XML *attributes* on `ipInterface`, while `ipAddress` and
+                    `hostName` are *elements*; a value sent as the wrong kind of node is dropped silently.""",
+            operationId = "addNodeIpInterface"
+    )
+    @RequestBody(
+            required = true,
+            description = "The interface to add. `ipAddress` is required.",
+            content = @Content(mediaType = MediaType.APPLICATION_XML,
+                    schema = @Schema(implementation = OnmsIpInterface.class),
+                    examples = @ExampleObject(value = """
+                    <ipInterface isManaged="M" snmpPrimary="P">
+                      <ipAddress>192.0.2.10</ipAddress>
+                      <hostName>core-sw-01</hostName>
+                    </ipInterface>"""))
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Created. `Location` points at the new interface."),
+            @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`, or the body carries no usable `ipAddress`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "unknownNode", value = "Node 999999 was not found."),
+                                    @ExampleObject(name = "noAddress", value = "IP Interface's ipAddress cannot be null")
+                            })),
+            @ApiResponse(responseCode = "415", description = "The body was not XML."),
+            @ApiResponse(responseCode = "500", description = "Publishing `nodeGainedInterface` failed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot send event uei.opennms.org/nodes/nodeGainedInterface : connection refused")))
+    })
+    public Response addIpInterface(@Context final UriInfo uriInfo,
+                                   @Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                   @PathParam("nodeCriteria") final String nodeCriteria, final OnmsIpInterface ipInterface) {
         writeLock();
         
         try {
@@ -180,7 +371,49 @@ public class OnmsIpInterfaceResource extends OnmsRestService {
     @PUT
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("{ipAddress}")
-    public Response updateIpInterface(@PathParam("nodeCriteria") final String nodeCriteria, @PathParam("ipAddress") final String ipAddress, final MultivaluedMapImpl params) {
+    @Operation(
+            summary = "Update one IP interface of a node",
+            description = """
+                    Applies form-encoded fields to an existing IP interface. Keys are bean property names on
+                    `OnmsIpInterface`, which do not always match the names in the XML representation, so check the
+                    property name rather than copying the attribute name out of a GET response.
+
+                    `nodeId` is skipped so the interface cannot be moved between nodes, and `id`, `dbId`,
+                    `authorizedGroups`, `foreignSource`, `foreignId` and `type` are protected and dropped with a
+                    log warning. Keys that resolve to nothing writable are ignored, so a request naming only such
+                    keys comes back 304.
+
+                    No event is published, so changing `isManaged` here does not by itself tell pollerd.""",
+            operationId = "updateNodeIpInterface"
+    )
+    @RequestBody(
+            required = true,
+            description = "Form-encoded interface properties to set.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "string"),
+                    examples = {
+                            @ExampleObject(name = "unmanage", summary = "Mark the interface unmanaged",
+                                    value = "isManaged=U"),
+                            @ExampleObject(name = "hostname", summary = "Set the reverse name",
+                                    value = "hostName=core-sw-01.example.org")
+                    })
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "At least one field was written. No body."),
+            @ApiResponse(responseCode = "304", description = "No key in the body resolved to a writable, unprotected property."),
+            @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Node 999999 was not found."))),
+            @ApiResponse(responseCode = "409", description = "The node has no interface with that address. This path reports the missing interface as a conflict, not a 404.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Can't find interface with IP address 192.0.2.99 for node 258.")))
+    })
+    public Response updateIpInterface(@Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                      @PathParam("nodeCriteria") final String nodeCriteria,
+                                      @Parameter(description = "Literal IPv4 or IPv6 address of the interface.", example = "192.0.2.10")
+                                      @PathParam("ipAddress") final String ipAddress, final MultivaluedMapImpl params) {
         writeLock();
         
         try {
@@ -233,7 +466,35 @@ public class OnmsIpInterfaceResource extends OnmsRestService {
      */
     @DELETE
     @Path("{ipAddress}")
-    public Response deleteIpInterface(@PathParam("nodeCriteria") final String nodeCriteria, @PathParam("ipAddress") final String ipAddress) {
+    @Operation(
+            summary = "Delete one IP interface of a node",
+            description = """
+                    Publishes `deleteInterface` and returns immediately. The deletion is carried out
+                    asynchronously by provisiond, so the interface is normally still readable for a moment after
+                    the 202 and the caller has to poll to see the effect.
+
+                    Only the node is checked. Whether the node actually has that interface is not, so a request
+                    naming an address the node does not have is accepted and simply has no effect.
+
+                    Removing a node's last IP interface has been observed to take the node with it: provisiond
+                    deletes a node left with no interfaces, so a following request for the node returns 404.""",
+            operationId = "deleteNodeIpInterface"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "202", description = "The delete request was published. No body. Completion is not confirmed."),
+            @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Node 999999 was not found."))),
+            @ApiResponse(responseCode = "500", description = "Publishing `deleteInterface` failed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot send event uei.opennms.org/internal/capsd/deleteInterface : connection refused")))
+    })
+    public Response deleteIpInterface(@Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                      @PathParam("nodeCriteria") final String nodeCriteria,
+                                      @Parameter(description = "Literal IPv4 or IPv6 address of the interface.", example = "192.0.2.10")
+                                      @PathParam("ipAddress") final String ipAddress) {
         writeLock();
         
         try {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OnmsMonitoredServiceResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OnmsMonitoredServiceResource.java
@@ -277,17 +277,15 @@ public class OnmsMonitoredServiceResource extends OnmsRestService {
             description = """
                     Attaches a monitored service to the interface and publishes `nodeGainedService`.
 
-                    The service type is looked up by `serviceType.name` and created if it does not exist, so this
-                    endpoint can introduce a new service name into the system. A service type created this way
-                    stays in the `service` table after the monitored service is deleted.
+                    The service type is looked up by `serviceType.name` and created if it does not exist. A
+                    service type created this way stays in the `service` table after the monitored service is
+                    deleted.
 
                     Both XML and JSON bodies are accepted; a form-encoded body is rejected with 415. In XML
                     `status` is an attribute on `service` and `serviceType` is a nested element; in JSON both are
-                    plain fields. `serviceType` is required in practice: a body without it fails with 500, because
-                    the check meant to reject it dereferences the missing type.
+                    plain fields. `serviceType` is required: a body without it fails with 500, not 400.
 
-                    The `status` sent in the body is stored, but pollerd may change it immediately afterwards, so
-                    read the service back rather than assuming the posted value stuck.""",
+                    The `status` sent in the body is stored, and pollerd can change it immediately afterwards.""",
             operationId = "addInterfaceService"
     )
     @RequestBody(
@@ -487,8 +485,7 @@ public class OnmsMonitoredServiceResource extends OnmsRestService {
             summary = "Delete one monitored service",
             description = """
                     Publishes `deleteService` and returns immediately. The deletion is carried out asynchronously,
-                    so the service is normally still readable for a moment after the 202 and the caller has to
-                    poll to see the effect.
+                    so the service is normally still readable for a moment after the 202.
 
                     The service type row itself is left in place, so a service name introduced by a POST here
                     stays defined after its last monitored service is gone.""",

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OnmsMonitoredServiceResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OnmsMonitoredServiceResource.java
@@ -35,6 +35,14 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.opennms.netmgt.dao.api.IpInterfaceDao;
 import org.opennms.netmgt.dao.api.MonitoredServiceDao;
 import org.opennms.netmgt.dao.api.NodeDao;
@@ -104,7 +112,67 @@ public class OnmsMonitoredServiceResource extends OnmsRestService {
      */
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-    public OnmsMonitoredServiceList getServices(@PathParam("nodeCriteria") String nodeCriteria, @PathParam("ipAddress") String ipAddress) {
+    @Operation(
+            summary = "List the monitored services on one IP interface",
+            description = """
+                    Returns every monitored service on the interface. The whole set is returned; this endpoint
+                    takes no paging or filter parameters, so `offset` is always 0 and `count` equals `totalCount`.
+
+                    `status` is the stored one-character poller state and `statusLong` its label: `A` Managed,
+                    `N` Not Monitored, `U` Unmanaged, `D` Deleted, `F` Forced Unmanaged, `R` Rescan to Resume,
+                    `S` Rescan to Suspend, `X` Remotely Monitored.""",
+            operationId = "listInterfaceServices"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The interface's monitored services.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsMonitoredServiceList.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 1,
+                      "count": 1,
+                      "offset": 0,
+                      "service": [
+                        {
+                          "source": null,
+                          "qualifier": null,
+                          "status": "A",
+                          "down": false,
+                          "notify": null,
+                          "lastGood": null,
+                          "lastFail": null,
+                          "serviceType": { "id": 1, "name": "ICMP" },
+                          "statusLong": "Managed",
+                          "ipInterfaceId": 23601,
+                          "id": 23616
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsMonitoredServiceList.class),
+                                    examples = @ExampleObject(value = """
+                    <services count="1" offset="0" totalCount="1">
+                      <service down="false" status="A" statusLong="Managed" id="23616">
+                        <ipInterfaceId>23601</ipInterfaceId>
+                        <serviceType id="1">
+                          <name>ICMP</name>
+                        </serviceType>
+                      </service>
+                    </services>"""))
+                    }),
+            @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`, or the node has no interface with that address.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "unknownNode", value = "Node 999999 was not found."),
+                                    @ExampleObject(name = "unknownInterface", value = "IP Interface 192.0.2.99 was not found on node 258.")
+                            }))
+    })
+    public OnmsMonitoredServiceList getServices(@Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                                @PathParam("nodeCriteria") String nodeCriteria,
+                                                @Parameter(description = "Literal IPv4 or IPv6 address of the interface.", example = "192.0.2.10")
+                                                @PathParam("ipAddress") String ipAddress) {
         OnmsNode node = m_nodeDao.get(nodeCriteria);
         if (node == null) {
             throw getException(Status.BAD_REQUEST, "Node {} was not found.", nodeCriteria);
@@ -127,7 +195,58 @@ public class OnmsMonitoredServiceResource extends OnmsRestService {
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     @Path("{service}")
-    public OnmsMonitoredService getService(@PathParam("nodeCriteria") String nodeCriteria, @PathParam("ipAddress") String ipAddress, @PathParam("service") String service) {
+    @Operation(
+            summary = "Get one monitored service by service name",
+            description = """
+                    Returns the monitored service with the given service name on the interface. The path segment
+                    is the service *name*, such as `ICMP` or `HTTP`, not the numeric service id used by
+                    `/ifservices/{id}`. Matching is exact and case-sensitive.""",
+            operationId = "getInterfaceService"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The monitored service.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsMonitoredService.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "source": null,
+                      "qualifier": null,
+                      "status": "A",
+                      "down": false,
+                      "notify": null,
+                      "lastGood": null,
+                      "lastFail": null,
+                      "serviceType": { "id": 1, "name": "ICMP" },
+                      "statusLong": "Managed",
+                      "ipInterfaceId": 23601,
+                      "id": 23616
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsMonitoredService.class),
+                                    examples = @ExampleObject(value = """
+                    <service down="false" status="A" statusLong="Managed" id="23616">
+                      <ipInterfaceId>23601</ipInterfaceId>
+                      <serviceType id="1">
+                        <name>ICMP</name>
+                      </serviceType>
+                    </service>"""))
+                    }),
+            @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`, or the node has no interface with that address.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "IP Interface 192.0.2.99 was not found on node 258."))),
+            @ApiResponse(responseCode = "404", description = "The interface carries no service with that name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Monitored Service NOSUCH was not found on IP Interface 192.0.2.10 and node 258.")))
+    })
+    public OnmsMonitoredService getService(@Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                           @PathParam("nodeCriteria") String nodeCriteria,
+                                           @Parameter(description = "Literal IPv4 or IPv6 address of the interface.", example = "192.0.2.10")
+                                           @PathParam("ipAddress") String ipAddress,
+                                           @Parameter(description = "Service name, as it appears in `serviceType.name`.", example = "ICMP")
+                                           @PathParam("service") String service) {
         final OnmsNode node = m_nodeDao.get(nodeCriteria);
         if (node == null) {
             throw getException(Status.BAD_REQUEST, "Node {} was not found.", nodeCriteria);
@@ -153,7 +272,65 @@ public class OnmsMonitoredServiceResource extends OnmsRestService {
      */
     @POST
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-    public Response addService(@Context final UriInfo uriInfo, @PathParam("nodeCriteria") final String nodeCriteria, @PathParam("ipAddress") final String ipAddress, final OnmsMonitoredService service) {
+    @Operation(
+            summary = "Add a monitored service to an IP interface",
+            description = """
+                    Attaches a monitored service to the interface and publishes `nodeGainedService`.
+
+                    The service type is looked up by `serviceType.name` and created if it does not exist, so this
+                    endpoint can introduce a new service name into the system. A service type created this way
+                    stays in the `service` table after the monitored service is deleted.
+
+                    Both XML and JSON bodies are accepted; a form-encoded body is rejected with 415. In XML
+                    `status` is an attribute on `service` and `serviceType` is a nested element; in JSON both are
+                    plain fields. `serviceType` is required in practice: a body without it fails with 500, because
+                    the check meant to reject it dereferences the missing type.
+
+                    The `status` sent in the body is stored, but pollerd may change it immediately afterwards, so
+                    read the service back rather than assuming the posted value stuck.""",
+            operationId = "addInterfaceService"
+    )
+    @RequestBody(
+            required = true,
+            description = "The service to add. `serviceType.name` is required.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = OnmsMonitoredService.class),
+                            examples = @ExampleObject(value = """
+                    <service status="A">
+                      <serviceType>
+                        <name>ICMP</name>
+                      </serviceType>
+                    </service>""")),
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsMonitoredService.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "status": "A",
+                      "serviceType": { "name": "ICMP" }
+                    }"""))
+            }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Created. `Location` points at the service, keyed by name."),
+            @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`, or the node has no interface with that address.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "unknownNode", value = "Node 999999 was not found."),
+                                    @ExampleObject(name = "unknownInterface", value = "IP Interface 192.0.2.99 was not found on node 258.")
+                            })),
+            @ApiResponse(responseCode = "415", description = "The body was form-encoded. Send XML or JSON."),
+            @ApiResponse(responseCode = "500", description = "The body carried no `serviceType`, or publishing `nodeGainedService` failed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot invoke \"org.opennms.netmgt.model.OnmsServiceType.getName()\" because the return value of \"org.opennms.netmgt.model.OnmsMonitoredService.getServiceType()\" is null")))
+    })
+    public Response addService(@Context final UriInfo uriInfo,
+                               @Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                               @PathParam("nodeCriteria") final String nodeCriteria,
+                               @Parameter(description = "Literal IPv4 or IPv6 address of the interface.", example = "192.0.2.10")
+                               @PathParam("ipAddress") final String ipAddress, final OnmsMonitoredService service) {
         writeLock();
         
         try {
@@ -206,7 +383,49 @@ public class OnmsMonitoredServiceResource extends OnmsRestService {
     @PUT
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("{service}")
-    public Response updateService(@PathParam("nodeCriteria") String nodeCriteria, @PathParam("ipAddress") String ipAddress, @PathParam("service") String serviceName, MultivaluedMapImpl params) {
+    @Operation(
+            summary = "Update one monitored service",
+            description = """
+                    Applies form-encoded fields to one monitored service. Keys are bean property names on
+                    `OnmsMonitoredService`; `id`, `dbId`, `nodeId`, `authorizedGroups`, `foreignSource`,
+                    `foreignId` and `type` are protected and dropped with a log warning, and unresolvable keys are
+                    ignored, so a request naming only such keys comes back 304.
+
+                    `status` is handled specially. `S`, and a move from `A` to `F`, store `F` and publish
+                    `suspendPollingService`. `R`, and a move from `F` to `A`, store `A` and publish
+                    `resumePollingService`. So `R` and `S` are request codes that are never themselves stored.""",
+            operationId = "updateInterfaceService"
+    )
+    @RequestBody(
+            required = true,
+            description = "Form-encoded service properties to set.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "string"),
+                    examples = {
+                            @ExampleObject(name = "suspend", summary = "Stop polling the service",
+                                    value = "status=F"),
+                            @ExampleObject(name = "resume", summary = "Resume polling the service",
+                                    value = "status=A")
+                    })
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "At least one field was written. No body."),
+            @ApiResponse(responseCode = "304", description = "No key in the body resolved to a writable, unprotected property."),
+            @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`, the node has no interface with that address, or the interface carries no service with that name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Monitored Service NOSUCH was not found on IP Interface 192.0.2.10 and node 258."))),
+            @ApiResponse(responseCode = "500", description = "Publishing the suspend or resume event failed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot send event uei.opennms.org/internal/poller/suspendPollingService : connection refused")))
+    })
+    public Response updateService(@Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                  @PathParam("nodeCriteria") String nodeCriteria,
+                                  @Parameter(description = "Literal IPv4 or IPv6 address of the interface.", example = "192.0.2.10")
+                                  @PathParam("ipAddress") String ipAddress,
+                                  @Parameter(description = "Service name, as it appears in `serviceType.name`.", example = "ICMP")
+                                  @PathParam("service") String serviceName, MultivaluedMapImpl params) {
         writeLock();
         try {
             OnmsNode node = m_nodeDao.get(nodeCriteria);
@@ -264,7 +483,38 @@ public class OnmsMonitoredServiceResource extends OnmsRestService {
      */
     @DELETE
     @Path("{service}")
-    public Response deleteService(@PathParam("nodeCriteria") final String nodeCriteria, @PathParam("ipAddress") final String ipAddress, @PathParam("service") final String serviceName) {
+    @Operation(
+            summary = "Delete one monitored service",
+            description = """
+                    Publishes `deleteService` and returns immediately. The deletion is carried out asynchronously,
+                    so the service is normally still readable for a moment after the 202 and the caller has to
+                    poll to see the effect.
+
+                    The service type row itself is left in place, so a service name introduced by a POST here
+                    stays defined after its last monitored service is gone.""",
+            operationId = "deleteInterfaceService"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "202", description = "The delete request was published. No body. Completion is not confirmed."),
+            @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`, or the node has no interface with that address.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "IP Interface 192.0.2.99 was not found on node 258."))),
+            @ApiResponse(responseCode = "409", description = "The interface carries no service with that name. This path reports the missing service as a conflict, not a 404.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Monitored Service NOSUCH was not found on IP Interface 192.0.2.10 and node 258."))),
+            @ApiResponse(responseCode = "500", description = "Publishing `deleteService` failed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot send event uei.opennms.org/nodes/deleteService : connection refused")))
+    })
+    public Response deleteService(@Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                  @PathParam("nodeCriteria") final String nodeCriteria,
+                                  @Parameter(description = "Literal IPv4 or IPv6 address of the interface.", example = "192.0.2.10")
+                                  @PathParam("ipAddress") final String ipAddress,
+                                  @Parameter(description = "Service name, as it appears in `serviceType.name`.", example = "ICMP")
+                                  @PathParam("service") final String serviceName) {
         writeLock();
         
         try {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OnmsSnmpInterfaceResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OnmsSnmpInterfaceResource.java
@@ -114,11 +114,7 @@ public class OnmsSnmpInterfaceResource extends OnmsRestService {
                     `collectFlag` and `pollFlag` in the representation are the bean properties `collect` and
                     `poll`; the boolean `collect` and `poll` in the same body are derived read-only views of them.
                     A collection flag ends in `C` to collect and `N` not to, with an optional `U` or `P` prefix
-                    recording whether a user or a provisioning policy set it. That distinction matters when
-                    writing: see the update operation.
-
-                    The node lookup is not guarded, so an unknown `nodeCriteria` fails with HTTP 500 rather than
-                    400 or 404.""",
+                    recording whether a user or a provisioning policy set it.""",
             operationId = "listNodeSnmpInterfaces",
             parameters = {
                     @Parameter(in = ParameterIn.QUERY, name = "limit",
@@ -143,7 +139,7 @@ public class OnmsSnmpInterfaceResource extends OnmsRestService {
                             schema = @Schema(type = "string", defaultValue = "all", allowableValues = {"all", "any"}),
                             example = "any"),
                     @Parameter(in = ParameterIn.QUERY, name = "ifName",
-                            description = "Restrict by interface name. Example of the generic property-restriction form.",
+                            description = "Restrict by interface name. One of the generic property restrictions.",
                             schema = @Schema(type = "string"), example = "Gi0/8"),
                     @Parameter(in = ParameterIn.QUERY, name = "collect",
                             description = "Restrict by collection flag. Values end in `C` to collect and `N` not to, with an optional `U` or `P` prefix recording whether a user or a provisioning policy set it: `C`, `N`, `UC`, `UN`, `PC`, `PN`. `D` marks a deleted row.",
@@ -207,7 +203,7 @@ public class OnmsSnmpInterfaceResource extends OnmsRestService {
                       </snmpInterface>
                     </snmpInterfaces>"""))
                     }),
-            @ApiResponse(responseCode = "500", description = "No node matches `nodeCriteria`. The node is dereferenced without a null check, so this is a null-pointer failure rather than a 400.",
+            @ApiResponse(responseCode = "500", description = "No node matches `nodeCriteria`. This path reports a missing node as a null-pointer failure, not as 400 or 404.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Cannot invoke \"org.opennms.netmgt.model.OnmsNode.getId()\" because \"node\" is null")))
@@ -245,8 +241,8 @@ public class OnmsSnmpInterfaceResource extends OnmsRestService {
     @Operation(
             summary = "Get one SNMP interface of a node",
             description = """
-                    Returns the SNMP interface with the given ifIndex. The lookup is over the node's own interface
-                    set, so unlike the list endpoint it also sees interfaces whose collection flag is `D`.
+                    Returns the SNMP interface with the given ifIndex. Unlike the list endpoint, interfaces whose
+                    collection flag is `D` are returned here.
 
                     `ifIndex` must be an integer. A non-numeric value matches no method and comes back as an empty
                     404 rather than a message.""",
@@ -333,8 +329,7 @@ public class OnmsSnmpInterfaceResource extends OnmsRestService {
     @Operation(
             summary = "Add an SNMP interface to a node",
             description = """
-                    Attaches a new SNMP interface to the node. No event is published, so collectd is not told
-                    about it here.
+                    Attaches a new SNMP interface to the node. No event is published.
 
                     XML only. A JSON or form-encoded body is rejected with 415.
 
@@ -344,9 +339,8 @@ public class OnmsSnmpInterfaceResource extends OnmsRestService {
                     interface is stored with the database default of `N`.
 
                     If the node has a primary IP interface (`snmpPrimary` of `P`), that interface is pointed at
-                    the new SNMP interface, which is how an IP interface acquires the `ifIndex` and nested
-                    `snmpInterface` seen in its own representation. The pairing follows the primary flag, not a
-                    matching ifIndex.""",
+                    the new SNMP interface, which gives it the `ifIndex` and nested `snmpInterface` seen in its
+                    own representation. The pairing follows the primary flag, not a matching ifIndex.""",
             operationId = "addNodeSnmpInterface"
     )
     @RequestBody(
@@ -467,16 +461,15 @@ public class OnmsSnmpInterfaceResource extends OnmsRestService {
             description = """
                     Applies form-encoded fields to an existing SNMP interface. Keys are bean property names on
                     `OnmsSnmpInterface`, not the names used in the representation. The collection and poll flags
-                    are the properties `collect` and `poll`, so send `collect=C`, not `collectFlag=C`: a key of
-                    `collectFlag` resolves to nothing and the request comes back 304.
+                    are the properties `collect` and `poll`: `collect=C` is written, while `collectFlag=C`
+                    resolves to nothing and the request comes back 304.
 
                     `nodeId`, `ipInterface` and `ipInterfaces` are skipped, and `id`, `dbId`, `authorizedGroups`,
                     `foreignSource`, `foreignId` and `type` are protected and dropped with a log warning.
 
                     If the body contains a `collect` key, `reinitializePrimarySnmpInterface` is published for the
-                    node so collectd re-reads the interface. That happens whether or not the value actually
-                    changed anything, and is skipped with a log warning when the node has no primary interface to
-                    name in the event.""",
+                    node, whether or not the value changed anything. It is skipped with a log warning when the
+                    node has no primary interface to name in the event.""",
             operationId = "updateNodeSnmpInterface"
     )
     @RequestBody(

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OnmsSnmpInterfaceResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OnmsSnmpInterfaceResource.java
@@ -109,7 +109,7 @@ public class OnmsSnmpInterfaceResource extends OnmsRestService {
 
                     Every query parameter that is not one of the paging parameters below is read as a property
                     restriction on `OnmsSnmpInterface`. A value of `null` or `notnull` becomes an is-null /
-                    is-not-null test. Unknown property names are logged and ignored rather than rejected.
+                    is-not-null test. Unknown property names are not ignored: the filter still binds them and the query fails with 500 `Unknown entity: null`.
 
                     `collectFlag` and `pollFlag` in the representation are the bean properties `collect` and
                     `poll`; the boolean `collect` and `poll` in the same body are derived read-only views of them.
@@ -486,7 +486,7 @@ public class OnmsSnmpInterfaceResource extends OnmsRestService {
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "At least one field was written. No body."),
-            @ApiResponse(responseCode = "304", description = "No key in the body resolved to a writable, unprotected property. A `collect` key still triggers the reinitialize event in this case."),
+            @ApiResponse(responseCode = "304", description = "No key in the body resolved to a writable, unprotected property. `collect` itself is writable, so a body containing it always answers 204 instead."),
             @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`, `ifIndex` is negative, or the node has no SNMP interface with that ifIndex.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OnmsSnmpInterfaceResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OnmsSnmpInterfaceResource.java
@@ -36,6 +36,15 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.dao.api.SnmpInterfaceDao;
@@ -92,7 +101,120 @@ public class OnmsSnmpInterfaceResource extends OnmsRestService {
      */
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-    public OnmsSnmpInterfaceList getSnmpInterfaces(@Context final UriInfo uriInfo, @PathParam("nodeCriteria") final String nodeCriteria) {
+    @Operation(
+            summary = "List a node's SNMP interfaces",
+            description = """
+                    Returns the SNMP interfaces of one node, one per ifIndex. Interfaces whose collection flag is
+                    `D` are excluded and cannot be included.
+
+                    Every query parameter that is not one of the paging parameters below is read as a property
+                    restriction on `OnmsSnmpInterface`. A value of `null` or `notnull` becomes an is-null /
+                    is-not-null test. Unknown property names are logged and ignored rather than rejected.
+
+                    `collectFlag` and `pollFlag` in the representation are the bean properties `collect` and
+                    `poll`; the boolean `collect` and `poll` in the same body are derived read-only views of them.
+                    A collection flag ends in `C` to collect and `N` not to, with an optional `U` or `P` prefix
+                    recording whether a user or a provisioning policy set it. That distinction matters when
+                    writing: see the update operation.
+
+                    The node lookup is not guarded, so an unknown `nodeCriteria` fails with HTTP 500 rather than
+                    400 or 404.""",
+            operationId = "listNodeSnmpInterfaces",
+            parameters = {
+                    @Parameter(in = ParameterIn.QUERY, name = "limit",
+                            description = "Maximum rows to return. 0 disables the limit.",
+                            schema = @Schema(type = "integer", defaultValue = "10"), example = "25"),
+                    @Parameter(in = ParameterIn.QUERY, name = "offset",
+                            description = "Zero-based index of the first row to return.",
+                            schema = @Schema(type = "integer"), example = "0"),
+                    @Parameter(in = ParameterIn.QUERY, name = "orderBy",
+                            description = "Property to sort on.",
+                            schema = @Schema(type = "string"), example = "ifIndex"),
+                    @Parameter(in = ParameterIn.QUERY, name = "order",
+                            description = "Sort direction for `orderBy`. Anything other than `desc` is read as ascending.",
+                            schema = @Schema(type = "string", allowableValues = {"asc", "desc"}), example = "asc"),
+                    @Parameter(in = ParameterIn.QUERY, name = "comparator",
+                            description = "Comparison applied to every property restriction in the query.",
+                            schema = @Schema(type = "string", defaultValue = "eq",
+                                    allowableValues = {"eq", "ne", "gt", "lt", "ge", "le", "like", "ilike", "contains", "iplike"}),
+                            example = "ilike"),
+                    @Parameter(in = ParameterIn.QUERY, name = "match",
+                            description = "Whether the property restrictions are combined with AND or OR.",
+                            schema = @Schema(type = "string", defaultValue = "all", allowableValues = {"all", "any"}),
+                            example = "any"),
+                    @Parameter(in = ParameterIn.QUERY, name = "ifName",
+                            description = "Restrict by interface name. Example of the generic property-restriction form.",
+                            schema = @Schema(type = "string"), example = "Gi0/8"),
+                    @Parameter(in = ParameterIn.QUERY, name = "collect",
+                            description = "Restrict by collection flag. Values end in `C` to collect and `N` not to, with an optional `U` or `P` prefix recording whether a user or a provisioning policy set it: `C`, `N`, `UC`, `UN`, `PC`, `PN`. `D` marks a deleted row.",
+                            schema = @Schema(type = "string", allowableValues = {"C", "N", "UC", "UN", "PC", "PN", "D"}),
+                            example = "C")
+            }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The node's SNMP interfaces.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsSnmpInterfaceList.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 1,
+                      "count": 1,
+                      "offset": 0,
+                      "snmpInterface": [
+                        {
+                          "id": 23602,
+                          "hasIngressFlows": false,
+                          "hasEgressFlows": false,
+                          "ifIndex": 8,
+                          "hasFlows": false,
+                          "lastIngressFlow": null,
+                          "lastEgressFlow": null,
+                          "lastCapsdPoll": null,
+                          "ifAlias": "uplink to core",
+                          "collectionPolicySpecified": false,
+                          "ifDescr": "GigabitEthernet0/8",
+                          "ifName": "Gi0/8",
+                          "physAddr": "02005e108108",
+                          "ifType": 6,
+                          "ifSpeed": 1000000000,
+                          "ifAdminStatus": 1,
+                          "ifOperStatus": 1,
+                          "lastSnmpPoll": null,
+                          "collectionUserSpecified": false,
+                          "collectFlag": "C",
+                          "pollFlag": "N",
+                          "collect": true,
+                          "poll": false,
+                          "nodeId": 258
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsSnmpInterfaceList.class),
+                                    examples = @ExampleObject(value = """
+                    <snmpInterfaces count="1" offset="0" totalCount="1">
+                      <snmpInterface collectFlag="C" collect="true" id="23602" ifIndex="8" pollFlag="N" poll="false">
+                        <ifAdminStatus>1</ifAdminStatus>
+                        <ifAlias>uplink to core</ifAlias>
+                        <ifDescr>GigabitEthernet0/8</ifDescr>
+                        <ifName>Gi0/8</ifName>
+                        <ifOperStatus>1</ifOperStatus>
+                        <ifSpeed>1000000000</ifSpeed>
+                        <ifType>6</ifType>
+                        <nodeId>258</nodeId>
+                        <physAddr>02005e108108</physAddr>
+                      </snmpInterface>
+                    </snmpInterfaces>"""))
+                    }),
+            @ApiResponse(responseCode = "500", description = "No node matches `nodeCriteria`. The node is dereferenced without a null check, so this is a null-pointer failure rather than a 400.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot invoke \"org.opennms.netmgt.model.OnmsNode.getId()\" because \"node\" is null")))
+    })
+    public OnmsSnmpInterfaceList getSnmpInterfaces(@Context final UriInfo uriInfo,
+                                                   @Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                                   @PathParam("nodeCriteria") final String nodeCriteria) {
         final OnmsNode node = m_nodeDao.get(nodeCriteria);
         
         final MultivaluedMap<String,String> params = uriInfo.getQueryParameters();
@@ -120,7 +242,74 @@ public class OnmsSnmpInterfaceResource extends OnmsRestService {
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     @Path("{ifIndex}")
-    public OnmsSnmpInterface getSnmpInterface(@PathParam("nodeCriteria") final String nodeCriteria, @PathParam("ifIndex") final int ifIndex) {
+    @Operation(
+            summary = "Get one SNMP interface of a node",
+            description = """
+                    Returns the SNMP interface with the given ifIndex. The lookup is over the node's own interface
+                    set, so unlike the list endpoint it also sees interfaces whose collection flag is `D`.
+
+                    `ifIndex` must be an integer. A non-numeric value matches no method and comes back as an empty
+                    404 rather than a message.""",
+            operationId = "getNodeSnmpInterface"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The SNMP interface.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsSnmpInterface.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "id": 23602,
+                      "hasIngressFlows": false,
+                      "hasEgressFlows": false,
+                      "ifIndex": 8,
+                      "hasFlows": false,
+                      "lastCapsdPoll": null,
+                      "ifAlias": "uplink to core",
+                      "collectionPolicySpecified": false,
+                      "ifDescr": "GigabitEthernet0/8",
+                      "ifName": "Gi0/8",
+                      "physAddr": "02005e108108",
+                      "ifType": 6,
+                      "ifSpeed": 1000000000,
+                      "ifAdminStatus": 1,
+                      "ifOperStatus": 1,
+                      "lastSnmpPoll": null,
+                      "collectionUserSpecified": false,
+                      "collectFlag": "C",
+                      "pollFlag": "N",
+                      "collect": true,
+                      "poll": false,
+                      "nodeId": 258
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsSnmpInterface.class),
+                                    examples = @ExampleObject(value = """
+                    <snmpInterface collectFlag="C" collect="true" id="23602" ifIndex="8" pollFlag="N" poll="false">
+                      <ifAdminStatus>1</ifAdminStatus>
+                      <ifAlias>uplink to core</ifAlias>
+                      <ifDescr>GigabitEthernet0/8</ifDescr>
+                      <ifName>Gi0/8</ifName>
+                      <ifOperStatus>1</ifOperStatus>
+                      <ifSpeed>1000000000</ifSpeed>
+                      <ifType>6</ifType>
+                      <nodeId>258</nodeId>
+                      <physAddr>02005e108108</physAddr>
+                    </snmpInterface>"""))
+                    }),
+            @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Node 999999 was not found."))),
+            @ApiResponse(responseCode = "404", description = "The node has no SNMP interface with that ifIndex, or `ifIndex` was not an integer.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "SNMP Interface 99 was not found on node 258.")))
+    })
+    public OnmsSnmpInterface getSnmpInterface(@Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                              @PathParam("nodeCriteria") final String nodeCriteria,
+                                              @Parameter(description = "SNMP ifIndex of the interface, unique within the node.", example = "8")
+                                              @PathParam("ifIndex") final int ifIndex) {
         final OnmsNode node = m_nodeDao.get(nodeCriteria);
         if (node == null) {
             throw getException(Status.BAD_REQUEST, "Node {} was not found.", nodeCriteria);
@@ -141,7 +330,56 @@ public class OnmsSnmpInterfaceResource extends OnmsRestService {
      */
     @POST
     @Consumes(MediaType.APPLICATION_XML)
-    public Response addSnmpInterface(@Context final UriInfo uriInfo, @PathParam("nodeCriteria") final String nodeCriteria, final OnmsSnmpInterface snmpInterface) {
+    @Operation(
+            summary = "Add an SNMP interface to a node",
+            description = """
+                    Attaches a new SNMP interface to the node. No event is published, so collectd is not told
+                    about it here.
+
+                    XML only. A JSON or form-encoded body is rejected with 415.
+
+                    `ifIndex`, `collectFlag` and `pollFlag` are XML *attributes* on `snmpInterface`, while
+                    `ifAlias`, `ifDescr`, `ifName`, `ifType`, `ifSpeed`, `ifAdminStatus`, `ifOperStatus` and
+                    `physAddr` are *elements*. Sending `collectFlag` as an element is dropped silently and the
+                    interface is stored with the database default of `N`.
+
+                    If the node has a primary IP interface (`snmpPrimary` of `P`), that interface is pointed at
+                    the new SNMP interface, which is how an IP interface acquires the `ifIndex` and nested
+                    `snmpInterface` seen in its own representation. The pairing follows the primary flag, not a
+                    matching ifIndex.""",
+            operationId = "addNodeSnmpInterface"
+    )
+    @RequestBody(
+            required = true,
+            description = "The SNMP interface to add. `ifIndex` identifies it within the node.",
+            content = @Content(mediaType = MediaType.APPLICATION_XML,
+                    schema = @Schema(implementation = OnmsSnmpInterface.class),
+                    examples = @ExampleObject(value = """
+                    <snmpInterface ifIndex="8" collectFlag="C" pollFlag="N">
+                      <ifAdminStatus>1</ifAdminStatus>
+                      <ifAlias>uplink to core</ifAlias>
+                      <ifDescr>GigabitEthernet0/8</ifDescr>
+                      <ifName>Gi0/8</ifName>
+                      <ifOperStatus>1</ifOperStatus>
+                      <ifSpeed>1000000000</ifSpeed>
+                      <ifType>6</ifType>
+                      <physAddr>02005e108108</physAddr>
+                    </snmpInterface>"""))
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Created. `Location` points at the new interface, keyed by ifIndex."),
+            @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`, or the body was empty.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "unknownNode", value = "Node 999999 was not found."),
+                                    @ExampleObject(name = "noBody", value = "SNMP interface object cannot be null")
+                            })),
+            @ApiResponse(responseCode = "415", description = "The body was not XML.")
+    })
+    public Response addSnmpInterface(@Context final UriInfo uriInfo,
+                                     @Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                     @PathParam("nodeCriteria") final String nodeCriteria, final OnmsSnmpInterface snmpInterface) {
         writeLock();
         
         try {
@@ -173,7 +411,27 @@ public class OnmsSnmpInterfaceResource extends OnmsRestService {
      */
     @DELETE
     @Path("{ifIndex}")
-    public Response deleteSnmpInterface(@PathParam("nodeCriteria") final String nodeCriteria, @PathParam("ifIndex") final int ifIndex) {
+    @Operation(
+            summary = "Delete one SNMP interface of a node",
+            description = """
+                    Removes the SNMP interface from the node and saves the node. The delete is synchronous, so the
+                    interface is gone by the time the 204 comes back, and no event is published.""",
+            operationId = "deleteNodeSnmpInterface"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Deleted. No body."),
+            @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`, or the node has no SNMP interface with that ifIndex.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "unknownNode", value = "Node 999999 was not found."),
+                                    @ExampleObject(name = "unknownIfIndex", value = "Can't find SNMP interface with ifIndex 9 for node 258")
+                            }))
+    })
+    public Response deleteSnmpInterface(@Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                        @PathParam("nodeCriteria") final String nodeCriteria,
+                                        @Parameter(description = "SNMP ifIndex of the interface to delete.", example = "8")
+                                        @PathParam("ifIndex") final int ifIndex) {
         writeLock();
         
         try {
@@ -204,7 +462,54 @@ public class OnmsSnmpInterfaceResource extends OnmsRestService {
     @PUT
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("{ifIndex}")
-    public Response updateSnmpInterface(@PathParam("nodeCriteria") final String nodeCriteria, @PathParam("ifIndex") final int ifIndex, final MultivaluedMapImpl params) {
+    @Operation(
+            summary = "Update one SNMP interface of a node",
+            description = """
+                    Applies form-encoded fields to an existing SNMP interface. Keys are bean property names on
+                    `OnmsSnmpInterface`, not the names used in the representation. The collection and poll flags
+                    are the properties `collect` and `poll`, so send `collect=C`, not `collectFlag=C`: a key of
+                    `collectFlag` resolves to nothing and the request comes back 304.
+
+                    `nodeId`, `ipInterface` and `ipInterfaces` are skipped, and `id`, `dbId`, `authorizedGroups`,
+                    `foreignSource`, `foreignId` and `type` are protected and dropped with a log warning.
+
+                    If the body contains a `collect` key, `reinitializePrimarySnmpInterface` is published for the
+                    node so collectd re-reads the interface. That happens whether or not the value actually
+                    changed anything, and is skipped with a log warning when the node has no primary interface to
+                    name in the event.""",
+            operationId = "updateNodeSnmpInterface"
+    )
+    @RequestBody(
+            required = true,
+            description = "Form-encoded SNMP interface properties to set.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "string"),
+                    examples = {
+                            @ExampleObject(name = "enableCollection", summary = "Turn data collection on for the interface",
+                                    value = "collect=C"),
+                            @ExampleObject(name = "labels", summary = "Set the interface description fields",
+                                    value = "ifAlias=uplink+to+core&ifName=Gi0%2F8")
+                    })
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "At least one field was written. No body."),
+            @ApiResponse(responseCode = "304", description = "No key in the body resolved to a writable, unprotected property. A `collect` key still triggers the reinitialize event in this case."),
+            @ApiResponse(responseCode = "400", description = "No node matches `nodeCriteria`, `ifIndex` is negative, or the node has no SNMP interface with that ifIndex.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "unknownIfIndex", value = "Can't find SNMP interface with ifIndex 77 for node 258"),
+                                    @ExampleObject(name = "negativeIfIndex", value = "Invalid ifIndex specified for SNMP interface on node 258: -1")
+                            })),
+            @ApiResponse(responseCode = "500", description = "Publishing `reinitializePrimarySnmpInterface` failed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Exception occurred sending event uei.opennms.org/nodes/reinitializePrimarySnmpInterface : connection refused")))
+    })
+    public Response updateSnmpInterface(@Parameter(description = "Node identifier: either the database node id or `foreignSource:foreignId`. Both forms are accepted.", example = "Router-Requisition:node1")
+                                        @PathParam("nodeCriteria") final String nodeCriteria,
+                                        @Parameter(description = "SNMP ifIndex of the interface to update.", example = "8")
+                                        @PathParam("ifIndex") final int ifIndex, final MultivaluedMapImpl params) {
         writeLock();
         
         try {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OutageRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OutageRestService.java
@@ -100,10 +100,9 @@ public class OutageRestService extends OnmsRestService {
             description = """
                     Return one outage by id.
                     The literal path segment `summaries` is handled by this same method and returns per-node outage
-                    summaries, honouring a `limit` query parameter that defaults to 10, so `GET /outages/summaries`
-                    is a second, differently shaped response from this operation.
-                    Timestamps are epoch milliseconds in JSON and ISO-8601 strings in XML, whatever the schema
-                    says.""",
+                    summaries, honouring a `limit` query parameter that defaults to 10.
+                    The derived schema shows `date-time`; the wire carries epoch milliseconds in JSON and ISO-8601
+                    strings in XML.""",
             operationId = "getOutageV1"
     )
     @ApiResponses(value = {
@@ -170,10 +169,9 @@ public class OutageRestService extends OnmsRestService {
     @Operation(
             summary = "Count all outages",
             description = """
-                    Return the total number of outage rows as a plain-text integer. Query parameters are ignored,
-                    so this is not a count of a filtered set.
-                    Unlike `GET /outages`, this count includes perspective (remote-poller) outages, so it can be
-                    larger than the `totalCount` that the search operation reports for an unfiltered query.""",
+                    Return the total number of outage rows as a plain-text integer. Query parameters are ignored.
+                    This count includes the perspective (remote-poller) outages that `GET /outages` excludes, so it
+                    can be larger than the `totalCount` that operation reports for an unfiltered query.""",
             operationId = "getOutageCountV1"
     )
     @ApiResponses(value = {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OutageRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OutageRestService.java
@@ -37,6 +37,13 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.criteria.Alias.JoinType;
 import org.opennms.core.criteria.CriteriaBuilder;
@@ -88,7 +95,55 @@ public class OutageRestService extends OnmsRestService {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Path("{outageId}")
     @Transactional
-    public Response getOutage(@Context final UriInfo uriInfo, @PathParam("outageId") final String outageId) {
+    @Operation(
+            summary = "Get an outage",
+            description = """
+                    Return one outage by id.
+                    The literal path segment `summaries` is handled by this same method and returns per-node outage
+                    summaries, honouring a `limit` query parameter that defaults to 10, so `GET /outages/summaries`
+                    is a second, differently shaped response from this operation.
+                    Timestamps are epoch milliseconds in JSON and ISO-8601 strings in XML, whatever the schema
+                    says.""",
+            operationId = "getOutageV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The outage, or the node outage summaries for the `summaries` path segment.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsOutage.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "id": 255,
+                      "nodeId": 197,
+                      "nodeLabel": "loopback-202",
+                      "foreignSource": "loopback-lab",
+                      "foreignId": "lb-202",
+                      "locationName": "Default",
+                      "ipAddress": "127.0.0.202",
+                      "serviceId": 2,
+                      "ifLostService": 1786382635109,
+                      "ifRegainedService": 1786382665199,
+                      "serviceLostEvent": null,
+                      "monitoredService": {
+                        "id": 1221,
+                        "status": "A",
+                        "statusLong": "Managed",
+                        "down": false,
+                        "ipInterfaceId": 582,
+                        "lastGood": 1787727479371,
+                        "lastFail": 1787685424740,
+                        "serviceType": { "id": 2, "name": "HTTP-8080" }
+                      }
+                    }"""))),
+            @ApiResponse(responseCode = "404", description = "No outage with that id."),
+            @ApiResponse(responseCode = "500", description = "The path segment is neither `summaries` nor an integer.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"abc\"")))
+    })
+    public Response getOutage(@Context final UriInfo uriInfo,
+            @Parameter(description = "Outage id, or the literal `summaries` for per-node outage summaries.",
+                    example = "255", required = true)
+            @PathParam("outageId") final String outageId) {
         if ("summaries".equals(outageId)) {
             final MultivaluedMap<String,String> parms = uriInfo.getQueryParameters(true);
             int limit = 10;
@@ -112,6 +167,21 @@ public class OutageRestService extends OnmsRestService {
     @Produces(MediaType.TEXT_PLAIN)
     @Path("count")
     @Transactional
+    @Operation(
+            summary = "Count all outages",
+            description = """
+                    Return the total number of outage rows as a plain-text integer. Query parameters are ignored,
+                    so this is not a count of a filtered set.
+                    Unlike `GET /outages`, this count includes perspective (remote-poller) outages, so it can be
+                    larger than the `totalCount` that the search operation reports for an unfiltered query.""",
+            operationId = "getOutageCountV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The outage count.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "4077")))
+    })
     public String getCount() {
         return Integer.toString(m_outageDao.countAll());
     }
@@ -124,6 +194,57 @@ public class OutageRestService extends OnmsRestService {
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
+    @Operation(
+            summary = "Search outages",
+            description = """
+                    Return outages matching the query parameters. Perspective (remote-poller) outages are excluded
+                    by a fixed `perspective is null` restriction that a query parameter cannot lift.
+                    Filters are `OnmsOutage` property names, with `monitoredService.*`, `ipInterface.*`, `node.*`,
+                    `snmpInterface.*`, `serviceType.*`, `serviceLostEvent.*` and `serviceRegainedEvent.*` reachable
+                    through their aliases. Current outages are the ones with `ifRegainedService=null`. `limit`
+                    (default 10), `offset`, `orderBy`, `order`, `match` and `comparator` shape the result, and no
+                    ordering is applied unless `orderBy` asks for one. A filter name that is not a property of the
+                    entity fails with 500.""",
+            operationId = "getOutagesV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The matching outages.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsOutageCollection.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 4067,
+                      "count": 1,
+                      "offset": 0,
+                      "outage": [ {
+                          "id": 255,
+                          "nodeId": 197,
+                          "nodeLabel": "loopback-202",
+                          "foreignSource": "loopback-lab",
+                          "foreignId": "lb-202",
+                          "locationName": "Default",
+                          "ipAddress": "127.0.0.202",
+                          "serviceId": 2,
+                          "ifLostService": 1786382635109,
+                          "ifRegainedService": 1786382665199,
+                          "serviceLostEvent": null,
+                          "monitoredService": {
+                            "id": 1221,
+                            "status": "A",
+                            "statusLong": "Managed",
+                            "down": false,
+                            "ipInterfaceId": 582,
+                            "lastGood": 1787727479371,
+                            "lastFail": 1787685424740,
+                            "serviceType": { "id": 2, "name": "HTTP-8080" }
+                          }
+                        } ]
+                    }"""))),
+            @ApiResponse(responseCode = "500", description = "A query parameter is not a property of the outage entity.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Unknown entity: null; nested exception is org.hibernate.HibernateException: Unknown entity: null")))
+    })
     public OnmsOutageCollection getOutages(@Context final UriInfo uriInfo) {
         final CriteriaBuilder builder = new CriteriaBuilder(OnmsOutage.class);
         builder.alias("monitoredService", "monitoredService", JoinType.LEFT_JOIN);
@@ -159,10 +280,69 @@ public class OutageRestService extends OnmsRestService {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
     @Path("forNode/{nodeId}")
+    @Operation(
+            summary = "List a node's outages",
+            description = """
+                    Return outages for one node, newest id first. Perspective outages are excluded.
+                    With both `start` and `end` present the window is `ifLostService` strictly between them; with
+                    either missing, `dateRange` is subtracted from now to give the lower bound and there is no
+                    upper bound. Outages that are still open (`ifRegainedService` null) are always included,
+                    whichever form is used.
+                    Remaining query parameters are applied as outage filters as on `GET /outages`, including the
+                    default `limit` of 10. `totalCount` is not set on this operation and comes back null.
+                    An unknown node id is not an error: the result is an empty list.""",
+            operationId = "getOutagesForNodeV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The node's outages.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsOutageCollection.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "totalCount": null,
+                      "count": null,
+                      "offset": 0,
+                      "outage": [ {
+                          "id": 255,
+                          "nodeId": 197,
+                          "nodeLabel": "loopback-202",
+                          "foreignSource": "loopback-lab",
+                          "foreignId": "lb-202",
+                          "locationName": "Default",
+                          "ipAddress": "127.0.0.202",
+                          "serviceId": 2,
+                          "ifLostService": 1786382635109,
+                          "ifRegainedService": 1786382665199,
+                          "serviceLostEvent": null,
+                          "monitoredService": {
+                            "id": 1221,
+                            "status": "A",
+                            "statusLong": "Managed",
+                            "down": false,
+                            "ipInterfaceId": 582,
+                            "lastGood": 1787727479371,
+                            "lastFail": 1787685424740,
+                            "serviceType": { "id": 2, "name": "HTTP-8080" }
+                          }
+                        } ]
+                    }"""))),
+            @ApiResponse(responseCode = "404", description = "The path segment is not an integer."),
+            @ApiResponse(responseCode = "500", description = "A query parameter is not a property of the outage entity.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Unknown entity: null; nested exception is org.hibernate.HibernateException: Unknown entity: null")))
+    })
     public OnmsOutageCollection forNodeId(@Context final UriInfo uriInfo,
+            @Parameter(description = "Node id.", example = "2", required = true)
             @PathParam("nodeId") final int nodeId,
+            @Parameter(description = "Lookback window in milliseconds, counted back from now. Ignored when both "
+                    + "`start` and `end` are given.", example = "604800000")
             @DefaultValue("604800000") @QueryParam("dateRange") final long dateRange,
+            @Parameter(description = "Window start as epoch milliseconds. Only honoured together with `end`.",
+                    example = "1780000000000")
             @QueryParam("start") final Long startTs,
+            @Parameter(description = "Window end as epoch milliseconds. Only honoured together with `start`.",
+                    example = "1790000000000")
             @QueryParam("end") final Long endTs) {
 
         final CriteriaBuilder builder = new CriteriaBuilder(OnmsOutage.class);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OutageRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OutageRestService.java
@@ -287,7 +287,8 @@ public class OutageRestService extends OnmsRestService {
                     upper bound. Outages that are still open (`ifRegainedService` null) are always included,
                     whichever form is used.
                     Remaining query parameters are applied as outage filters as on `GET /outages`, including the
-                    default `limit` of 10. `totalCount` is not set on this operation and comes back null.
+                    default `limit` of 10. `totalCount` is never set separately here, so it falls back to `count`
+                    and reflects the page size rather than the number of matches.
                     An unknown node id is not an error: the result is an empty list.""",
             operationId = "getOutagesForNodeV1"
     )
@@ -297,8 +298,8 @@ public class OutageRestService extends OnmsRestService {
                             schema = @Schema(implementation = OnmsOutageCollection.class),
                             examples = @ExampleObject(value = """
                     {
-                      "totalCount": null,
-                      "count": null,
+                      "totalCount": 1,
+                      "count": 1,
                       "offset": 0,
                       "outage": [ {
                           "id": 255,

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/RequisitionNamesRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/RequisitionNamesRestService.java
@@ -32,6 +32,11 @@ import javax.ws.rs.core.MediaType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.config.api.JaxbListWrapper;
 import org.opennms.web.svclayer.api.RequisitionAccessService;
@@ -66,6 +71,7 @@ public class RequisitionNamesRestService extends OnmsRestService {
          * @return the names
          */
         @XmlElement(name="foreign-source")
+        @Schema(description = "Foreign source name of each requisition, pending and deployed.", example = "[\"selfmonitor\"]")
         public List<String> getNames() {
             return getObjects();
         }
@@ -89,6 +95,32 @@ public class RequisitionNamesRestService extends OnmsRestService {
      */
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get the foreign source name of every requisition",
+            description = """
+                    Returns the names only, taken from the same union of pending and deployed requisitions that
+                    `GET /requisitions` returns. `totalCount`, `count` and `offset` are inherited from the list
+                    wrapper; `totalCount` and `count` come back as `null` when the list is empty.""",
+            operationId = "getRequisitionNames")
+    @ApiResponse(responseCode = "200", description = "Requisition names, sorted as the requisition list is sorted.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = RequisitionCollection.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "totalCount": 2,
+                                      "count": 2,
+                                      "offset": 0,
+                                      "foreign-source": [ "selfmonitor", "datacenter-east" ]
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = RequisitionCollection.class),
+                            examples = @ExampleObject(value = """
+                                    <foreign-sources count="2" offset="0" totalCount="2">
+                                      <foreign-source>selfmonitor</foreign-source>
+                                      <foreign-source>datacenter-east</foreign-source>
+                                    </foreign-sources>"""))
+            })
     public RequisitionCollection getRequisitionNames() throws ParseException {
         RequisitionCollection names = new RequisitionCollection();
         m_accessService.getRequisitions().forEach(r -> names.add(r.getForeignSource()));

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/RequisitionRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/RequisitionRestService.java
@@ -127,21 +127,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Tag(name = "Requisitions", description = """
         Requisitions API.
 
-        A requisition is the declarative model of a group of nodes: the nodes, their IP interfaces, the
-        monitored services on those interfaces, and the surveillance categories and asset fields on the
-        nodes. Editing a requisition changes nothing in the monitored inventory. The nodes are only created,
-        updated and deleted when the requisition is imported.
+        A requisition declares a group of nodes, their IP interfaces, the monitored services on those
+        interfaces, and the surveillance categories and asset fields on the nodes. Editing a requisition
+        changes no monitored inventory: nodes are created, updated and deleted when the requisition is
+        imported.
 
-        Requisitions live in two repositories. Writes land in *pending*
-        (`etc/imports/pending/{foreignSource}.xml`); `PUT /requisitions/{foreignSource}/import` hands the
-        pending document to provisiond, which reconciles the database against it and moves the document to
-        *deployed* (`etc/imports/{foreignSource}.xml`). `GET /requisitions` and
-        `GET /requisitions/{foreignSource}` read the pending document when there is one and fall back to the
-        deployed document, so a read after an edit shows the edit whether or not it has been imported.
-        `/requisitions/count` counts pending documents and drops back to zero once an import completes;
-        `/requisitions/deployed/count` counts deployed documents.
-
-        The URL tree mirrors the document, and every level can be read, replaced and deleted on its own:
+        Writes land in `etc/imports/pending/{foreignSource}.xml`.
+        `PUT /requisitions/{foreignSource}/import` hands that document to provisiond, which reconciles the
+        database against it and moves it to `etc/imports/{foreignSource}.xml`. Reads resolve pending first
+        and fall back to deployed, so a read after an edit shows the edit whether or not it was imported.
+        `POST /requisitions` replaces the whole document; the nested paths replace one level:
 
             /requisitions/{foreignSource}
             /requisitions/{foreignSource}/nodes/{foreignId}
@@ -150,12 +145,9 @@ import org.springframework.transaction.annotation.Transactional;
             /requisitions/{foreignSource}/nodes/{foreignId}/interfaces/{ipAddress}
             /requisitions/{foreignSource}/nodes/{foreignId}/interfaces/{ipAddress}/services/{service}
 
-        Editing one node or one interface is the cheaper path for a large requisition, since a `POST` to
-        `/requisitions` replaces the whole document.
-
-        Two wire-format points. Dates (`date-stamp`, `last-import`, `last-imported`) are epoch milliseconds
-        in JSON and ISO-8601 timestamps in XML, whatever the derived schema says. The `PUT` handlers consume
-        `application/x-www-form-urlencoded` only, not JSON or XML.""")
+        Dates (`date-stamp`, `last-import`, `last-imported`) are epoch milliseconds in JSON and ISO-8601
+        timestamps in XML; the derived schema shows `date-time`. The `PUT` handlers consume
+        `application/x-www-form-urlencoded` only.""")
 public class RequisitionRestService extends OnmsRestService {
 
     private static final Logger LOG = LoggerFactory.getLogger(RequisitionRestService.class);
@@ -268,9 +260,7 @@ public class RequisitionRestService extends OnmsRestService {
                     import time of its deployed requisition.
 
                     A foreign source with no deployed requisition fails with 500 rather than 404, including one
-                    whose nodes still exist after the requisition was deleted. Check
-                    `GET /requisitions/deployed/count` or the list from `GET /requisitions/deployed/stats`
-                    before calling this for a name you are not sure of.""",
+                    whose nodes still exist after the requisition was deleted.""",
             operationId = "getDeployedRequisitionStatsForForeignSource")
     @ApiResponse(responseCode = "200", description = "Statistics for the foreign source.",
             content = {
@@ -341,7 +331,7 @@ public class RequisitionRestService extends OnmsRestService {
             summary = "List the deployed requisitions",
             description = """
                     Every document in the deployed repository, in full. A requisition that has been written but
-                    not imported yet does not appear here; use `GET /requisitions` for the pending-and-deployed
+                    not imported yet does not appear here; `GET /requisitions` returns the pending-and-deployed
                     view. `totalCount` and `count` come back as `null` when the list is empty.""",
             operationId = "getDeployedRequisitions")
     @ApiResponse(responseCode = "200", description = "Deployed requisitions.",
@@ -422,7 +412,7 @@ public class RequisitionRestService extends OnmsRestService {
             description = """
                     One document per foreign source, resolved pending-first, so a requisition edited but not yet
                     imported appears here in its edited form. `totalCount` and `count` come back as `null` when
-                    the list is empty. For the names alone, `GET /requisitionNames` is the cheaper call.""",
+                    the list is empty. `GET /requisitionNames` returns the names alone.""",
             operationId = "getRequisitions")
     @ApiResponse(responseCode = "200", description = "All requisitions, pending documents preferred over deployed.",
             content = {
@@ -500,7 +490,7 @@ public class RequisitionRestService extends OnmsRestService {
             description = """
                     Plain-text decimal count of the documents in the pending repository, that is, of
                     requisitions with edits that have not been imported. A requisition drops out of this count
-                    once its import completes, so a healthy steady state is `0`.""",
+                    once its import completes.""",
             operationId = "getPendingRequisitionCount")
     @ApiResponse(responseCode = "200", description = "The count.",
             content = @Content(mediaType = MediaType.TEXT_PLAIN,
@@ -677,9 +667,8 @@ public class RequisitionRestService extends OnmsRestService {
     @Operation(
             summary = "Get one node of a requisition",
             description = """
-                    Looked up by foreign ID, which is the node's identity within the requisition and is what
-                    ties the requisitioned node to the provisioned one. The node label is not an identifier
-                    here.""",
+                    Looked up by foreign ID, the node's identity within the requisition. The node label is not
+                    an identifier here.""",
             operationId = "getRequisitionNode")
     @ApiResponse(responseCode = "200", description = "The node.",
             content = {
@@ -1038,9 +1027,9 @@ public class RequisitionRestService extends OnmsRestService {
     @Operation(
             summary = "List the asset fields set on a requisitioned node",
             description = """
-                    Only the fields the requisition sets, not the node's full asset record. `name` must be one
-                    of the field names `GET /foreignSourcesConfig/assets` returns; an unrecognized name is
-                    accepted into the requisition but has no effect at import.""",
+                    Only the fields the requisition sets, not the node's full asset record.
+                    `GET /foreignSourcesConfig/assets` lists the recognized `name` values; an unrecognized name
+                    is accepted into the requisition and has no effect at import.""",
             operationId = "getRequisitionNodeAssets")
     @ApiResponse(responseCode = "200", description = "The asset fields.",
             content = {
@@ -1126,16 +1115,16 @@ public class RequisitionRestService extends OnmsRestService {
             description = """
                     Writes the document to the pending repository under the `foreign-source` carried in the
                     body, not in the URL. The previous pending document is replaced outright rather than merged,
-                    so anything absent from the body is dropped. To edit part of a large requisition, post to the
-                    node, interface, service, category or asset sub-resource instead.
+                    so anything absent from the body is dropped. The node, interface, service, category and asset
+                    sub-resources replace one level instead.
 
                     Nothing is provisioned until `PUT /requisitions/{foreignSource}/import` runs.
 
                     The body is validated before it is written: `foreign-source` must be present and must not
                     contain any of `: / \\ ? & * ' "`, every node needs a `foreign-id`, foreign IDs must be
-                    unique within the document, and each interface needs an `ip-addr`. Note that `foreign-source`
-                    has a default of `imported-`, so a body that omits it is accepted and stored under that name
-                    rather than rejected. `date-stamp` and `last-import` in the body are ignored.""",
+                    unique within the document, and each interface needs an `ip-addr`. `foreign-source` has a
+                    default of `imported-`, so a body that omits it is accepted and stored under that name.
+                    `date-stamp` and `last-import` in the body are ignored.""",
             operationId = "addOrReplaceRequisition")
     @RequestBody(required = true, description = "The complete requisition document.",
             content = {
@@ -1210,8 +1199,7 @@ public class RequisitionRestService extends OnmsRestService {
             summary = "Add or replace one node in a requisition",
             description = """
                     Keyed on the `foreign-id` in the body: an existing node with that foreign ID is replaced
-                    outright, otherwise the node is appended. The rest of the requisition is left alone, which is
-                    what makes this the practical way to edit a large requisition.
+                    outright, otherwise the node is appended. The rest of the requisition is left alone.
 
                     If the requisition does not exist it is created with this node as its only member. Nothing is
                     provisioned until an import runs.""",
@@ -1290,7 +1278,7 @@ public class RequisitionRestService extends OnmsRestService {
                     Validation rejects a second interface marked `P` on the same node, two services with the
                     same `service-name` on this interface, and an `ip-addr` that does not parse.""",
             operationId = "addOrReplaceRequisitionInterface")
-    @RequestBody(required = true, description = "The interface, with the monitored services it should carry.",
+    @RequestBody(required = true, description = "The interface and its monitored services.",
             content = {
                     @Content(mediaType = MediaType.APPLICATION_JSON,
                             schema = @Schema(implementation = RequisitionInterface.class),
@@ -1443,9 +1431,8 @@ public class RequisitionRestService extends OnmsRestService {
     @Operation(
             summary = "Add or replace one asset field on a requisitioned node",
             description = """
-                    Keyed on `name`, which should be one of the field names
-                    `GET /foreignSourcesConfig/assets` returns. An unrecognized name is stored without complaint
-                    and then has no effect at import.""",
+                    Keyed on `name`. `GET /foreignSourcesConfig/assets` lists the recognized names; an
+                    unrecognized name is stored and has no effect at import.""",
             operationId = "addOrReplaceRequisitionNodeAsset")
     @RequestBody(required = true, description = "The asset field and its value.",
             content = {
@@ -1496,17 +1483,14 @@ public class RequisitionRestService extends OnmsRestService {
                     from the pending repository to the deployed one, `last-import` is stamped, and
                     `/requisitions/count` drops back to zero.
 
-                    **This is asynchronous.** The 202 means the event was accepted, not that any node exists yet.
-                    A large requisition can take minutes, and the request can succeed while the import then
-                    fails. Poll `GET /requisitions/deployed/stats/{foreignSource}`, or the node list, rather than
-                    treating the 202 as completion. Firing several imports for the same foreign source in quick
-                    succession queues them all; they are not coalesced.
+                    The import is asynchronous. The 202 means the event was accepted, not that any node exists
+                    yet, and the request can succeed while the import then fails. Several imports fired for the
+                    same foreign source in quick succession are all queued; they are not coalesced.
 
                     If there is no pending document, the already-deployed document is re-imported.
 
                     Deleting a requisition does not undo an import: `DELETE /requisitions/deployed/{foreignSource}`
-                    removes the document and leaves the provisioned nodes in place. To remove the nodes, empty
-                    the requisition and import it, or delete the nodes through the nodes API.""",
+                    removes the document and leaves the provisioned nodes in place.""",
             operationId = "importRequisition")
     @ApiResponse(responseCode = "202", description = "The import event was sent. No body. The import itself has not necessarily started, let alone finished.",
             headers = @Header(name = "Location", description = "URI of the requisition that is being imported.",
@@ -1549,8 +1533,7 @@ public class RequisitionRestService extends OnmsRestService {
                     same property. `id`, `dbId`, `nodeId` and `authorizedGroups` are protected and skipped with a
                     log line; any other key that does not name a writable property is ignored.
 
-                    The response is 202 whether or not a key matched. Read the resource back to confirm the
-                    change.""",
+                    The response is 202 whether or not a key matched.""",
             operationId = "updateRequisition")
     @RequestBody(required = true, description = "Form-encoded field names and values.",
             content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
@@ -1586,9 +1569,8 @@ public class RequisitionRestService extends OnmsRestService {
                     that name no writable property are ignored, and `id`, `dbId`, `nodeId` and `authorizedGroups`
                     are protected and skipped.
 
-                    Interfaces, categories and assets are collections and are not settable this way; use their
-                    sub-resources. The response is 202 whether or not a key matched, so read the node back to
-                    confirm.""",
+                    Interfaces, categories and assets are collections and are not settable this way. The
+                    response is 202 whether or not a key matched.""",
             operationId = "updateRequisitionNode")
     @RequestBody(required = true, description = "Form-encoded field names and values.",
             content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
@@ -1679,12 +1661,11 @@ public class RequisitionRestService extends OnmsRestService {
             summary = "Delete the deployed requisition",
             description = """
                     Removes the deployed document. The **nodes stay provisioned**: they keep their foreign source
-                    and foreign ID and continue to be polled, they simply no longer have a requisition behind
+                    and foreign ID and continue to be polled, they no longer have a requisition behind
                     them. `GET /requisitions/deployed/stats` still lists the foreign source, with `last-imported`
                     null, and `GET /requisitions/deployed/stats/{foreignSource}` starts failing with a 500 for
                     that name.
 
-                    To retire a group of nodes, empty the requisition and import it, then delete the requisition.
                     A foreign source with no deployed document is not reported as an error, the response is still
                     202.""",
             operationId = "deleteDeployedRequisition")
@@ -1810,9 +1791,7 @@ public class RequisitionRestService extends OnmsRestService {
             summary = "Remove one asset field from a requisitioned node",
             description = """
                     Removes the field from the pending requisition, which stops the requisition from setting it.
-                    Whether the value already written to the node's asset record is cleared at the next import
-                    depends on the import behaviour rather than on this call. An asset name that is not on the
-                    node is not reported as an error.""",
+                    An asset name that is not on the node is not reported as an error.""",
             operationId = "deleteRequisitionNodeAsset")
     @ApiResponse(responseCode = "202", description = "Delete attempted. No body. Returned whether or not the asset field was present.")
     public Response deleteAssetParameter(@Context final UriInfo uriInfo, @Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource, @Parameter(required = true, description = "Foreign ID of the node within the requisition.", example = "node-1") @PathParam("foreignId") final String foreignId, @Parameter(required = true, description = "Asset field name.", example = "city") @PathParam("parameter") final String parameter) {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/RequisitionRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/RequisitionRestService.java
@@ -43,6 +43,9 @@ import javax.xml.bind.ValidationException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -121,7 +124,38 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component("requisitionRestService")
 @Path("requisitions")
-@Tag(name = "Requisitions", description = "Requisitions API")
+@Tag(name = "Requisitions", description = """
+        Requisitions API.
+
+        A requisition is the declarative model of a group of nodes: the nodes, their IP interfaces, the
+        monitored services on those interfaces, and the surveillance categories and asset fields on the
+        nodes. Editing a requisition changes nothing in the monitored inventory. The nodes are only created,
+        updated and deleted when the requisition is imported.
+
+        Requisitions live in two repositories. Writes land in *pending*
+        (`etc/imports/pending/{foreignSource}.xml`); `PUT /requisitions/{foreignSource}/import` hands the
+        pending document to provisiond, which reconciles the database against it and moves the document to
+        *deployed* (`etc/imports/{foreignSource}.xml`). `GET /requisitions` and
+        `GET /requisitions/{foreignSource}` read the pending document when there is one and fall back to the
+        deployed document, so a read after an edit shows the edit whether or not it has been imported.
+        `/requisitions/count` counts pending documents and drops back to zero once an import completes;
+        `/requisitions/deployed/count` counts deployed documents.
+
+        The URL tree mirrors the document, and every level can be read, replaced and deleted on its own:
+
+            /requisitions/{foreignSource}
+            /requisitions/{foreignSource}/nodes/{foreignId}
+            /requisitions/{foreignSource}/nodes/{foreignId}/categories/{category}
+            /requisitions/{foreignSource}/nodes/{foreignId}/assets/{parameter}
+            /requisitions/{foreignSource}/nodes/{foreignId}/interfaces/{ipAddress}
+            /requisitions/{foreignSource}/nodes/{foreignId}/interfaces/{ipAddress}/services/{service}
+
+        Editing one node or one interface is the cheaper path for a large requisition, since a `POST` to
+        `/requisitions` replaces the whole document.
+
+        Two wire-format points. Dates (`date-stamp`, `last-import`, `last-imported`) are epoch milliseconds
+        in JSON and ISO-8601 timestamps in XML, whatever the derived schema says. The `PUT` handlers consume
+        `application/x-www-form-urlencoded` only, not JSON or XML.""")
 public class RequisitionRestService extends OnmsRestService {
 
     private static final Logger LOG = LoggerFactory.getLogger(RequisitionRestService.class);
@@ -147,7 +181,14 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("deployed/count")
     @Produces(MediaType.TEXT_PLAIN)
-    @Operation(summary = "Get the number of deployed requisitions", description = "Get the number of deployed requisitions (returns plaintext rather than XML or JSON).", responses = {@ApiResponse(responseCode = "200", description = "Get the number of deployed requisitions (returns plaintext rather than XML or JSON).")})
+    @Operation(
+            summary = "Count the deployed requisitions",
+            description = "Plain-text decimal count of the documents in the deployed repository, that is, of requisitions that have been imported at least once.",
+            operationId = "getDeployedRequisitionCount")
+    @ApiResponse(responseCode = "200", description = "The count.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                    schema = @Schema(type = "string", example = "1"),
+                    examples = @ExampleObject(value = "1")))
     public String getDeployedCount() {
         return Integer.toString(m_accessService.getDeployedCount());
     }
@@ -160,6 +201,54 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("deployed/stats")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Summarize what is provisioned, per foreign source",
+            description = """
+                    One entry per foreign source that has nodes in the database, listing the foreign IDs of
+                    those nodes and the last import time of the matching deployed requisition. The entries come
+                    from the node table rather than from the requisition repository, so a foreign source whose
+                    requisition has been deleted while its nodes remain still appears, with `last-imported`
+                    null.""",
+            operationId = "getDeployedRequisitionStats")
+    @ApiResponse(responseCode = "200", description = "Per-foreign-source statistics.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DeployedStats.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "totalCount": 2,
+                                      "count": 2,
+                                      "offset": 0,
+                                      "foreign-source": [
+                                        {
+                                          "totalCount": 3,
+                                          "count": 3,
+                                          "offset": 0,
+                                          "name": "datacenter-east",
+                                          "last-imported": 1787727435518,
+                                          "foreign-id": [ "node-1", "node-2", "node-3" ]
+                                        },
+                                        {
+                                          "totalCount": 1,
+                                          "count": 1,
+                                          "offset": 0,
+                                          "name": "selfmonitor",
+                                          "last-imported": null,
+                                          "foreign-id": [ "1" ]
+                                        }
+                                      ]
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = DeployedStats.class),
+                            examples = @ExampleObject(value = """
+                                    <deployed-stats xmlns="http://xmlns.opennms.org/xsd/config/model-import" count="1" offset="0" totalCount="1">
+                                      <foreign-source name="datacenter-east" count="3" offset="0" totalCount="3" last-imported="2026-08-26T02:57:15.518-04:00">
+                                        <foreign-id>node-1</foreign-id>
+                                        <foreign-id>node-2</foreign-id>
+                                        <foreign-id>node-3</foreign-id>
+                                      </foreign-source>
+                                    </deployed-stats>"""))
+            })
     public DeployedStats getDeployedStats() {
         return m_accessService.getDeployedStats();
     }
@@ -172,7 +261,44 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("deployed/stats/{foreignSource}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    public DeployedRequisitionStats getDeployedStats(@PathParam("foreignSource") final String foreignSource) {
+    @Operation(
+            summary = "Summarize what is provisioned for one foreign source",
+            description = """
+                    The foreign IDs of the nodes currently in the database for this foreign source, and the last
+                    import time of its deployed requisition.
+
+                    A foreign source with no deployed requisition fails with 500 rather than 404, including one
+                    whose nodes still exist after the requisition was deleted. Check
+                    `GET /requisitions/deployed/count` or the list from `GET /requisitions/deployed/stats`
+                    before calling this for a name you are not sure of.""",
+            operationId = "getDeployedRequisitionStatsForForeignSource")
+    @ApiResponse(responseCode = "200", description = "Statistics for the foreign source.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DeployedRequisitionStats.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "totalCount": 3,
+                                      "count": 3,
+                                      "offset": 0,
+                                      "name": "datacenter-east",
+                                      "last-imported": 1787727435518,
+                                      "foreign-id": [ "node-1", "node-2", "node-3" ]
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = DeployedRequisitionStats.class),
+                            examples = @ExampleObject(value = """
+                                    <foreign-source xmlns="http://xmlns.opennms.org/xsd/config/model-import" name="datacenter-east" count="3" offset="0" totalCount="3" last-imported="2026-08-26T02:57:15.518-04:00">
+                                      <foreign-id>node-1</foreign-id>
+                                      <foreign-id>node-2</foreign-id>
+                                      <foreign-id>node-3</foreign-id>
+                                    </foreign-source>"""))
+            })
+    @ApiResponse(responseCode = "500", description = "No deployed requisition exists for this foreign source.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                    schema = @Schema(type = "string"),
+                    examples = @ExampleObject(value = "Cannot invoke \"org.opennms.netmgt.provision.persist.requisition.Requisition.getLastImportAsDate()\" because \"fs\" is null")))
+    public DeployedRequisitionStats getDeployedStats(@Parameter(required = true, description = "Foreign source name of a deployed requisition.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource) {
         return m_accessService.getDeployedStats(foreignSource);
     }
 
@@ -184,6 +310,20 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("repositoryStrategy")
     @Produces(MediaType.TEXT_PLAIN)
+    @Operation(
+            summary = "Get the foreign source repository strategy in effect",
+            description = """
+                    Plain-text name of the repository implementation backing requisitions and foreign source
+                    definitions, taken from `org.opennms.provisiond.repositoryImplementation`. The enumeration is
+                    `file`, `fastFile`, `caching`, `fastCaching`, `queueing`, `fastQueueing`, `fused` and
+                    `fastFused`. `file` stores the documents as XML under `etc/imports` and
+                    `etc/foreign-sources`; the queueing variants wrap the file store with an asynchronous writer,
+                    which means a write can be acknowledged before it is on disk.""",
+            operationId = "getForeignSourceRepositoryStrategy")
+    @ApiResponse(responseCode = "200", description = "The configured strategy.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                    schema = @Schema(type = "string", example = "file"),
+                    examples = @ExampleObject(value = "file")))
     public String getForeignSourceRepositoryStrategy() {
         return m_foreignSourceRepositoryFactory.getRepositoryStrategy().toString();
     }
@@ -197,7 +337,74 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("deployed")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    @Operation(summary = "Get a list of all deployed (active) requisitions.", responses = {@ApiResponse(responseCode = "200", description = "Get a list of all deployed (active) requisitions.")})
+    @Operation(
+            summary = "List the deployed requisitions",
+            description = """
+                    Every document in the deployed repository, in full. A requisition that has been written but
+                    not imported yet does not appear here; use `GET /requisitions` for the pending-and-deployed
+                    view. `totalCount` and `count` come back as `null` when the list is empty.""",
+            operationId = "getDeployedRequisitions")
+    @ApiResponse(responseCode = "200", description = "Deployed requisitions.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = RequisitionCollection.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "totalCount": 1,
+                                      "count": 1,
+                                      "offset": 0,
+                                      "model-import": [
+                                        {
+                                          "node": [
+                                            {
+                                              "interface": [
+                                                {
+                                                  "monitored-service": [ { "category": [], "meta-data": [], "service-name": "ICMP" } ],
+                                                  "category": [],
+                                                  "meta-data": [],
+                                                  "descr": "eth0",
+                                                  "ip-addr": "198.51.100.11",
+                                                  "managed": null,
+                                                  "status": 1,
+                                                  "snmp-primary": "P"
+                                                }
+                                              ],
+                                              "category": [ { "name": "Production" } ],
+                                              "asset": [ { "name": "city", "value": "Apex" } ],
+                                              "meta-data": [],
+                                              "location": null,
+                                              "building": "HQ",
+                                              "city": null,
+                                              "foreign-id": "node-1",
+                                              "node-label": "router-1",
+                                              "parent-foreign-source": null,
+                                              "parent-foreign-id": null,
+                                              "parent-node-label": null
+                                            }
+                                          ],
+                                          "date-stamp": 1787727326179,
+                                          "foreign-source": "datacenter-east",
+                                          "last-import": 1787727435518
+                                        }
+                                      ]
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = RequisitionCollection.class),
+                            examples = @ExampleObject(value = """
+                                    <requisitions xmlns="http://xmlns.opennms.org/xsd/config/model-import" count="1" offset="0" totalCount="1">
+                                      <model-import date-stamp="2026-08-26T02:55:26.179-04:00"
+                                                    last-import="2026-08-26T02:57:15.518-04:00"
+                                                    foreign-source="datacenter-east">
+                                        <node building="HQ" foreign-id="node-1" node-label="router-1">
+                                          <interface descr="eth0" ip-addr="198.51.100.11" status="1" snmp-primary="P">
+                                            <monitored-service service-name="ICMP"/>
+                                          </interface>
+                                          <category name="Production"/>
+                                          <asset name="city" value="Apex"/>
+                                        </node>
+                                      </model-import>
+                                    </requisitions>"""))
+            })
     public RequisitionCollection getDeployedRequisitions() throws ParseException {
         return m_accessService.getDeployedRequisitions();
     }
@@ -210,9 +417,72 @@ public class RequisitionRestService extends OnmsRestService {
      */
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    @Operation(summary = "Get all active requisitions.", responses = {@ApiResponse(responseCode = "200", description = "Get all active requisitions.")
-
-    })
+    @Operation(
+            summary = "List every requisition",
+            description = """
+                    One document per foreign source, resolved pending-first, so a requisition edited but not yet
+                    imported appears here in its edited form. `totalCount` and `count` come back as `null` when
+                    the list is empty. For the names alone, `GET /requisitionNames` is the cheaper call.""",
+            operationId = "getRequisitions")
+    @ApiResponse(responseCode = "200", description = "All requisitions, pending documents preferred over deployed.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = RequisitionCollection.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "totalCount": 1,
+                                      "count": 1,
+                                      "offset": 0,
+                                      "model-import": [
+                                        {
+                                          "node": [
+                                            {
+                                              "interface": [
+                                                {
+                                                  "monitored-service": [ { "category": [], "meta-data": [], "service-name": "ICMP" } ],
+                                                  "category": [],
+                                                  "meta-data": [],
+                                                  "descr": "eth0",
+                                                  "ip-addr": "198.51.100.11",
+                                                  "managed": null,
+                                                  "status": 1,
+                                                  "snmp-primary": "P"
+                                                }
+                                              ],
+                                              "category": [ { "name": "Production" } ],
+                                              "asset": [ { "name": "city", "value": "Apex" } ],
+                                              "meta-data": [],
+                                              "location": null,
+                                              "building": "HQ",
+                                              "city": null,
+                                              "foreign-id": "node-1",
+                                              "node-label": "router-1",
+                                              "parent-foreign-source": null,
+                                              "parent-foreign-id": null,
+                                              "parent-node-label": null
+                                            }
+                                          ],
+                                          "date-stamp": 1787727326179,
+                                          "foreign-source": "datacenter-east",
+                                          "last-import": null
+                                        }
+                                      ]
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = RequisitionCollection.class),
+                            examples = @ExampleObject(value = """
+                                    <requisitions xmlns="http://xmlns.opennms.org/xsd/config/model-import" count="1" offset="0" totalCount="1">
+                                      <model-import date-stamp="2026-08-26T02:55:26.179-04:00" foreign-source="datacenter-east">
+                                        <node building="HQ" foreign-id="node-1" node-label="router-1">
+                                          <interface descr="eth0" ip-addr="198.51.100.11" status="1" snmp-primary="P">
+                                            <monitored-service service-name="ICMP"/>
+                                          </interface>
+                                          <category name="Production"/>
+                                          <asset name="city" value="Apex"/>
+                                        </node>
+                                      </model-import>
+                                    </requisitions>"""))
+            })
     public RequisitionCollection getRequisitions() throws ParseException {
         return m_accessService.getRequisitions();
     }
@@ -225,7 +495,17 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("count")
     @Produces(MediaType.TEXT_PLAIN)
-    @Operation(summary = "Get the number of undeployed requisitions", responses = {@ApiResponse(responseCode = "200", description = "Get the number of undeployed requisitions (returns plaintext rather than XML or JSON).")})
+    @Operation(
+            summary = "Count the pending requisitions",
+            description = """
+                    Plain-text decimal count of the documents in the pending repository, that is, of
+                    requisitions with edits that have not been imported. A requisition drops out of this count
+                    once its import completes, so a healthy steady state is `0`.""",
+            operationId = "getPendingRequisitionCount")
+    @ApiResponse(responseCode = "200", description = "The count.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                    schema = @Schema(type = "string", example = "1"),
+                    examples = @ExampleObject(value = "1")))
     public String getPendingCount() {
         return Integer.toString(m_accessService.getPendingCount());
     }
@@ -239,9 +519,69 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    @Operation(summary = "Get the active requisition for the given foreign source name.", responses = {@ApiResponse(responseCode = "200",
-            description = "Get the active requisition for the given foreign source name."), @ApiResponse(responseCode = "404")})
-    public Requisition getRequisition(@PathParam("foreignSource") final String foreignSource) {
+    @Operation(
+            summary = "Get one requisition",
+            description = """
+                    The pending document if there is one, otherwise the deployed document. `date-stamp` is when
+                    the document was last written; `last-import` is when it was last imported and is null until
+                    the first import.""",
+            operationId = "getRequisition")
+    @ApiResponse(responseCode = "200", description = "The requisition.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = Requisition.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "node": [ {
+                                      "interface": [
+                                        {
+                                          "monitored-service": [ { "category": [], "meta-data": [], "service-name": "ICMP" } ],
+                                          "category": [],
+                                          "meta-data": [],
+                                          "descr": "eth0",
+                                          "ip-addr": "198.51.100.11",
+                                          "managed": null,
+                                          "status": 1,
+                                          "snmp-primary": "P"
+                                        }
+                                      ],
+                                      "category": [ { "name": "Production" } ],
+                                      "asset": [ { "name": "city", "value": "Apex" } ],
+                                      "meta-data": [],
+                                      "location": null,
+                                      "building": "HQ",
+                                      "city": null,
+                                      "foreign-id": "node-1",
+                                      "node-label": "router-1",
+                                      "parent-foreign-source": null,
+                                      "parent-foreign-id": null,
+                                      "parent-node-label": null
+                                    } ],
+                                      "date-stamp": 1787727326179,
+                                      "foreign-source": "datacenter-east",
+                                      "last-import": 1787727435518
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = Requisition.class),
+                            examples = @ExampleObject(value = """
+                                    <model-import xmlns="http://xmlns.opennms.org/xsd/config/model-import"
+                                                  date-stamp="2026-08-26T02:55:26.179-04:00"
+                                                  last-import="2026-08-26T02:57:15.518-04:00"
+                                                  foreign-source="datacenter-east">
+                                      <node building="HQ" foreign-id="node-1" node-label="router-1">
+                                        <interface descr="eth0" ip-addr="198.51.100.11" status="1" snmp-primary="P">
+                                          <monitored-service service-name="ICMP"/>
+                                        </interface>
+                                        <category name="Production"/>
+                                        <asset name="city" value="Apex"/>
+                                      </node>
+                                    </model-import>"""))
+            })
+    @ApiResponse(responseCode = "404", description = "No requisition of that name in either repository.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                    schema = @Schema(type = "string"),
+                    examples = @ExampleObject(value = "Foreign source 'datacenter-west' not found.")))
+    public Requisition getRequisition(@Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource) {
         final Requisition requisition = m_accessService.getRequisition(foreignSource);
         if (requisition == null) {
             throw getException(Status.NOT_FOUND, "Foreign source '{}' not found.", foreignSource);
@@ -259,10 +599,63 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}/nodes")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    @Operation(summary = "Get the list of nodes being requisitioned for the given foreign source name.", responses = {@ApiResponse(responseCode = "200", description = "Get the list of nodes being requisitioned for the given foreign source name."
-
-    ), @ApiResponse(responseCode = "404")})
-    public RequisitionNodeCollection getNodes(@PathParam("foreignSource") final String foreignSource) throws ParseException {
+    @Operation(
+            summary = "List the nodes of a requisition",
+            description = "The `node` elements of the resolved requisition, without the requisition envelope.",
+            operationId = "getRequisitionNodes")
+    @ApiResponse(responseCode = "200", description = "The nodes.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = RequisitionNodeCollection.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "totalCount": 1,
+                                      "count": 1,
+                                      "offset": 0,
+                                      "node": [ {
+                                      "interface": [
+                                        {
+                                          "monitored-service": [ { "category": [], "meta-data": [], "service-name": "ICMP" } ],
+                                          "category": [],
+                                          "meta-data": [],
+                                          "descr": "eth0",
+                                          "ip-addr": "198.51.100.11",
+                                          "managed": null,
+                                          "status": 1,
+                                          "snmp-primary": "P"
+                                        }
+                                      ],
+                                      "category": [ { "name": "Production" } ],
+                                      "asset": [ { "name": "city", "value": "Apex" } ],
+                                      "meta-data": [],
+                                      "location": null,
+                                      "building": "HQ",
+                                      "city": null,
+                                      "foreign-id": "node-1",
+                                      "node-label": "router-1",
+                                      "parent-foreign-source": null,
+                                      "parent-foreign-id": null,
+                                      "parent-node-label": null
+                                    } ]
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = RequisitionNodeCollection.class),
+                            examples = @ExampleObject(value = """
+                                    <nodes xmlns="http://xmlns.opennms.org/xsd/config/model-import" count="1" offset="0" totalCount="1">
+                                      <node building="HQ" foreign-id="node-1" node-label="router-1">
+                                        <interface descr="eth0" ip-addr="198.51.100.11" status="1" snmp-primary="P">
+                                          <monitored-service service-name="ICMP"/>
+                                        </interface>
+                                        <category name="Production"/>
+                                        <asset name="city" value="Apex"/>
+                                      </node>
+                                    </nodes>"""))
+            })
+    @ApiResponse(responseCode = "404", description = "No requisition of that name in either repository.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                    schema = @Schema(type = "string"),
+                    examples = @ExampleObject(value = "Foreign source 'datacenter-west' not found.")))
+    public RequisitionNodeCollection getNodes(@Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource) throws ParseException {
         final RequisitionNodeCollection results = m_accessService.getNodes(foreignSource);
         if (results == null) {
             throw getException(Status.NOT_FOUND, "Foreign source '{}' not found.", foreignSource);
@@ -281,8 +674,59 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}/nodes/{foreignId}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    @Operation(summary = "Get the node with the given foreign ID for the given foreign source name.", responses = {@ApiResponse(responseCode = "200", description = "Get the node with the given foreign ID for the given foreign source name."), @ApiResponse(responseCode = "404")})
-    public RequisitionNode getNode(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId) throws ParseException {
+    @Operation(
+            summary = "Get one node of a requisition",
+            description = """
+                    Looked up by foreign ID, which is the node's identity within the requisition and is what
+                    ties the requisitioned node to the provisioned one. The node label is not an identifier
+                    here.""",
+            operationId = "getRequisitionNode")
+    @ApiResponse(responseCode = "200", description = "The node.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = RequisitionNode.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "interface": [
+                                        {
+                                          "monitored-service": [ { "category": [], "meta-data": [], "service-name": "ICMP" } ],
+                                          "category": [],
+                                          "meta-data": [],
+                                          "descr": "eth0",
+                                          "ip-addr": "198.51.100.11",
+                                          "managed": null,
+                                          "status": 1,
+                                          "snmp-primary": "P"
+                                        }
+                                      ],
+                                      "category": [ { "name": "Production" } ],
+                                      "asset": [ { "name": "city", "value": "Apex" } ],
+                                      "meta-data": [],
+                                      "location": null,
+                                      "building": "HQ",
+                                      "city": null,
+                                      "foreign-id": "node-1",
+                                      "node-label": "router-1",
+                                      "parent-foreign-source": null,
+                                      "parent-foreign-id": null,
+                                      "parent-node-label": null
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = RequisitionNode.class),
+                            examples = @ExampleObject(value = """
+                                    <node xmlns="http://xmlns.opennms.org/xsd/config/model-import" building="HQ" foreign-id="node-1" node-label="router-1">
+                                      <interface descr="eth0" ip-addr="198.51.100.11" status="1" snmp-primary="P">
+                                        <monitored-service service-name="ICMP"/>
+                                      </interface>
+                                      <category name="Production"/>
+                                      <asset name="city" value="Apex"/>
+                                    </node>"""))
+            })
+    @ApiResponse(responseCode = "404", description = "No such foreign ID in that requisition, or no such requisition.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                    schema = @Schema(type = "string"),
+                    examples = @ExampleObject(value = "Node with Foreign ID 'node-9' and Foreign source 'datacenter-east' not found.")))
+    public RequisitionNode getNode(@Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource, @Parameter(required = true, description = "Foreign ID of the node within the requisition.", example = "node-1") @PathParam("foreignId") final String foreignId) throws ParseException {
         final RequisitionNode node = m_accessService.getNode(foreignSource, foreignId);
         if (node == null) {
             throw getException(Status.NOT_FOUND, "Node with Foreign ID '{}' and Foreign source '{}' not found.", foreignId, foreignSource);
@@ -301,10 +745,44 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}/nodes/{foreignId}/interfaces")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    @Operation(summary = "Get the interfaces for the node with the given foreign ID and foreign source name.", responses = {@ApiResponse(responseCode = "200", description = "Get the interfaces for the node with the given foreign ID and foreign source name."), @ApiResponse(responseCode = "404")
-
-    })
-    public RequisitionInterfaceCollection getInterfacesForNode(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId) throws ParseException {
+    @Operation(
+            summary = "List the IP interfaces of a requisitioned node",
+            description = "The `interface` elements of the node. Order is the stored order, which is not necessarily the order they were added in.",
+            operationId = "getRequisitionInterfaces")
+    @ApiResponse(responseCode = "200", description = "The interfaces.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = RequisitionInterfaceCollection.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "totalCount": 1,
+                                      "count": 1,
+                                      "offset": 0,
+                                      "interface": [ {
+                                      "monitored-service": [ { "category": [], "meta-data": [], "service-name": "ICMP" } ],
+                                      "category": [],
+                                      "meta-data": [],
+                                      "descr": "eth0",
+                                      "ip-addr": "198.51.100.11",
+                                      "managed": null,
+                                      "status": 1,
+                                      "snmp-primary": "P"
+                                    } ]
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = RequisitionInterfaceCollection.class),
+                            examples = @ExampleObject(value = """
+                                    <interfaces xmlns="http://xmlns.opennms.org/xsd/config/model-import" count="1" offset="0" totalCount="1">
+                                      <interface descr="eth0" ip-addr="198.51.100.11" status="1" snmp-primary="P">
+                                        <monitored-service service-name="ICMP"/>
+                                      </interface>
+                                    </interfaces>"""))
+            })
+    @ApiResponse(responseCode = "404", description = "No such node in that requisition.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                    schema = @Schema(type = "string"),
+                    examples = @ExampleObject(value = "Node with Foreign ID 'node-9' and Foreign source 'datacenter-east' not found.")))
+    public RequisitionInterfaceCollection getInterfacesForNode(@Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource, @Parameter(required = true, description = "Foreign ID of the node within the requisition.", example = "node-1") @PathParam("foreignId") final String foreignId) throws ParseException {
         final RequisitionInterfaceCollection ifaces = m_accessService.getInterfacesForNode(foreignSource, foreignId);
         if (ifaces == null) {
             throw getException(Status.NOT_FOUND, "Node with Foreign ID '{}' and Foreign source '{}' not found.", foreignId, foreignSource);
@@ -324,8 +802,40 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}/nodes/{foreignId}/interfaces/{ipAddress}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    @Operation(summary = "Get the interface with the given IP for the node with the specified foreign ID and foreign source name.", responses = {@ApiResponse(responseCode = "200", description = "Get the interface with the given IP for the node with the specified foreign ID and foreign source name."), @ApiResponse(responseCode = "404")})
-    public RequisitionInterface getInterfaceForNode(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId, @PathParam("ipAddress") final String ipAddress) throws ParseException {
+    @Operation(
+            summary = "Get one IP interface of a requisitioned node",
+            description = """
+                    `snmp-primary` is `P` for the primary SNMP interface, `S` for a secondary one and `N` for
+                    not eligible. `status` of 3 marks the interface unmanaged; any other value, including the
+                    default of 1, leaves it managed.""",
+            operationId = "getRequisitionInterface")
+    @ApiResponse(responseCode = "200", description = "The interface.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = RequisitionInterface.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "monitored-service": [ { "category": [], "meta-data": [], "service-name": "ICMP" } ],
+                                      "category": [],
+                                      "meta-data": [],
+                                      "descr": "eth0",
+                                      "ip-addr": "198.51.100.11",
+                                      "managed": null,
+                                      "status": 1,
+                                      "snmp-primary": "P"
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = RequisitionInterface.class),
+                            examples = @ExampleObject(value = """
+                                    <interface xmlns="http://xmlns.opennms.org/xsd/config/model-import" descr="eth0" ip-addr="198.51.100.11" status="1" snmp-primary="P">
+                                      <monitored-service service-name="ICMP"/>
+                                    </interface>"""))
+            })
+    @ApiResponse(responseCode = "404", description = "No such IP on that node, or no such node.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                    schema = @Schema(type = "string"),
+                    examples = @ExampleObject(value = "IP Interface 198.51.100.99 on node with Foreign ID 'node-1' and Foreign source 'datacenter-east' not found.")))
+    public RequisitionInterface getInterfaceForNode(@Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource, @Parameter(required = true, description = "Foreign ID of the node within the requisition.", example = "node-1") @PathParam("foreignId") final String foreignId, @Parameter(required = true, description = "IP address of the requisitioned interface, exactly as stored.", example = "198.51.100.11") @PathParam("ipAddress") final String ipAddress) throws ParseException {
         final RequisitionInterface iface = m_accessService.getInterfaceForNode(foreignSource, foreignId, ipAddress);
         if (iface == null) {
             throw getException(Status.NOT_FOUND, "IP Interface {} on node with Foreign ID '{}' and Foreign source '{}' not found.", ipAddress, foreignId, foreignSource);
@@ -345,10 +855,40 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}/nodes/{foreignId}/interfaces/{ipAddress}/services")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    @Operation(summary = "Get the services for the interface with the specified IP address, foreign ID, and foreign source name.", responses = {@ApiResponse(responseCode = "200", description = "Get the services for the interface with the specified IP address, foreign ID, and foreign source name."), @ApiResponse(responseCode = "404")
-
-    })
-    public RequisitionMonitoredServiceCollection getServicesForInterface(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId, @PathParam("ipAddress") final String ipAddress) throws ParseException {
+    @Operation(
+            summary = "List the monitored services on a requisitioned interface",
+            description = """
+                    Services named here are created on the interface at import whether or not a detector finds
+                    them. Detectors on the foreign source definition can add further services on top of
+                    these.""",
+            operationId = "getRequisitionServices")
+    @ApiResponse(responseCode = "200", description = "The monitored services.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = RequisitionMonitoredServiceCollection.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "totalCount": 2,
+                                      "count": 2,
+                                      "offset": 0,
+                                      "monitored-service": [
+                                        { "category": [], "meta-data": [], "service-name": "ICMP" },
+                                        { "category": [], "meta-data": [], "service-name": "SNMP" }
+                                      ]
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = RequisitionMonitoredServiceCollection.class),
+                            examples = @ExampleObject(value = """
+                                    <services xmlns="http://xmlns.opennms.org/xsd/config/model-import" count="2" offset="0" totalCount="2">
+                                      <monitored-service service-name="ICMP"/>
+                                      <monitored-service service-name="SNMP"/>
+                                    </services>"""))
+            })
+    @ApiResponse(responseCode = "404", description = "No such IP on that node, or no such node.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                    schema = @Schema(type = "string"),
+                    examples = @ExampleObject(value = "IP Interface 198.51.100.99 on node with Foreign ID 'node-1' and Foreign source 'datacenter-east' not found.")))
+    public RequisitionMonitoredServiceCollection getServicesForInterface(@Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource, @Parameter(required = true, description = "Foreign ID of the node within the requisition.", example = "node-1") @PathParam("foreignId") final String foreignId, @Parameter(required = true, description = "IP address of the requisitioned interface, exactly as stored.", example = "198.51.100.11") @PathParam("ipAddress") final String ipAddress) throws ParseException {
         final RequisitionMonitoredServiceCollection services = m_accessService.getServicesForInterface(foreignSource, foreignId, ipAddress);
         if (services == null) {
             throw getException(Status.NOT_FOUND, "IP Interface {} on node with Foreign ID '{}' and Foreign source '{}' not found.", ipAddress, foreignId, foreignSource);
@@ -369,10 +909,26 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}/nodes/{foreignId}/interfaces/{ipAddress}/services/{service}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    @Operation(summary = "Get the given service with the specified IP address, foreign ID, and foreign source name.", responses = {@ApiResponse(responseCode = "200", description = "Get the given service with the specified IP address, foreign ID, and foreign source name."), @ApiResponse(responseCode = "404")
-
-    })
-    public RequisitionMonitoredService getServiceForInterface(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId, @PathParam("ipAddress") final String ipAddress, @PathParam("service") String service) throws ParseException {
+    @Operation(
+            summary = "Get one monitored service on a requisitioned interface",
+            description = "Looked up by service name, matched exactly and case-sensitively.",
+            operationId = "getRequisitionService")
+    @ApiResponse(responseCode = "200", description = "The monitored service.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = RequisitionMonitoredService.class),
+                            examples = @ExampleObject(value = """
+                                    { "category": [], "meta-data": [], "service-name": "ICMP" }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = RequisitionMonitoredService.class),
+                            examples = @ExampleObject(value = """
+                                    <monitored-service xmlns="http://xmlns.opennms.org/xsd/config/model-import" service-name="ICMP"/>"""))
+            })
+    @ApiResponse(responseCode = "404", description = "No service of that name on the interface, or the interface or node does not exist.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                    schema = @Schema(type = "string"),
+                    examples = @ExampleObject(value = "Monitored Service HTTP on IP Interface 198.51.100.11 on node with Foreign ID 'node-1' and Foreign source 'datacenter-east' not found.")))
+    public RequisitionMonitoredService getServiceForInterface(@Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource, @Parameter(required = true, description = "Foreign ID of the node within the requisition.", example = "node-1") @PathParam("foreignId") final String foreignId, @Parameter(required = true, description = "IP address of the requisitioned interface, exactly as stored.", example = "198.51.100.11") @PathParam("ipAddress") final String ipAddress, @Parameter(required = true, description = "Monitored service name.", example = "ICMP") @PathParam("service") String service) throws ParseException {
         final RequisitionMonitoredService monitoredService = m_accessService.getServiceForInterface(foreignSource, foreignId, ipAddress, service);
         if (monitoredService == null) {
             throw getException(Status.NOT_FOUND, "Monitored Service {} on IP Interface {} on node with Foreign ID '{}' and Foreign source '{}' not found.", service, ipAddress, foreignId, foreignSource);
@@ -391,10 +947,37 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}/nodes/{foreignId}/categories")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    @Operation(summary = "Get the categories for the node with the given foreign ID and foreign source name.", responses = {@ApiResponse(responseCode = "200", description = "Get the categories for the node with the given foreign ID and foreign source name."), @ApiResponse(responseCode = "404")
-
-    })
-    public RequisitionCategoryCollection getCategories(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId) throws ParseException {
+    @Operation(
+            summary = "List the surveillance categories on a requisitioned node",
+            description = """
+                    Categories are applied to the node at import. A category named here that does not yet exist
+                    is created, so the names are not restricted to what
+                    `GET /foreignSourcesConfig/categories` returns.""",
+            operationId = "getRequisitionNodeCategories")
+    @ApiResponse(responseCode = "200", description = "The categories.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = RequisitionCategoryCollection.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "totalCount": 2,
+                                      "count": 2,
+                                      "offset": 0,
+                                      "category": [ { "name": "Production" }, { "name": "Routers" } ]
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = RequisitionCategoryCollection.class),
+                            examples = @ExampleObject(value = """
+                                    <categories xmlns="http://xmlns.opennms.org/xsd/config/model-import" count="2" offset="0" totalCount="2">
+                                      <category name="Production"/>
+                                      <category name="Routers"/>
+                                    </categories>"""))
+            })
+    @ApiResponse(responseCode = "404", description = "No such node in that requisition.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                    schema = @Schema(type = "string"),
+                    examples = @ExampleObject(value = "Node with Foreign ID 'node-9' and Foreign source 'datacenter-east' not found.")))
+    public RequisitionCategoryCollection getCategories(@Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource, @Parameter(required = true, description = "Foreign ID of the node within the requisition.", example = "node-1") @PathParam("foreignId") final String foreignId) throws ParseException {
         final RequisitionCategoryCollection categories = m_accessService.getCategories(foreignSource, foreignId);
         if (categories == null) {
             throw getException(Status.NOT_FOUND, "Node with Foreign ID '{}' and Foreign source '{}' not found.", foreignId, foreignSource);
@@ -414,10 +997,26 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}/nodes/{foreignId}/categories/{category}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    @Operation(summary = "Get the category with the given name for the node with the specified foreign ID and foreign source name.", responses = {@ApiResponse(responseCode = "200", description = "Get the category with the given name for the node with the specified foreign ID and foreign source name."), @ApiResponse(responseCode = "404")
-
-    })
-    public RequisitionCategory getCategory(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId, @PathParam("category") final String category) throws ParseException {
+    @Operation(
+            summary = "Get one surveillance category on a requisitioned node",
+            description = "Looked up by category name, matched exactly and case-sensitively.",
+            operationId = "getRequisitionNodeCategory")
+    @ApiResponse(responseCode = "200", description = "The category.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = RequisitionCategory.class),
+                            examples = @ExampleObject(value = """
+                                    { "name": "Production" }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = RequisitionCategory.class),
+                            examples = @ExampleObject(value = """
+                                    <category xmlns="http://xmlns.opennms.org/xsd/config/model-import" name="Production"/>"""))
+            })
+    @ApiResponse(responseCode = "404", description = "No category of that name on the node, or no such node.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                    schema = @Schema(type = "string"),
+                    examples = @ExampleObject(value = "Category Staging on node with Foreign ID 'node-1' and Foreign source 'datacenter-east' not found.")))
+    public RequisitionCategory getCategory(@Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource, @Parameter(required = true, description = "Foreign ID of the node within the requisition.", example = "node-1") @PathParam("foreignId") final String foreignId, @Parameter(required = true, description = "Surveillance category name.", example = "Production") @PathParam("category") final String category) throws ParseException {
         final RequisitionCategory reqCategory = m_accessService.getCategory(foreignSource, foreignId, category);
         if (reqCategory == null) {
             throw getException(Status.NOT_FOUND, "Category {} on node with Foreign ID '{}' and Foreign source '{}' not found.", category, foreignId, foreignSource);
@@ -436,10 +1035,37 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}/nodes/{foreignId}/assets")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    @Operation(summary = "Get the assets for the node with the given foreign ID and foreign source name.", responses = {@ApiResponse(responseCode = "200", description = "Get the assets for the node with the given foreign ID and foreign source name."), @ApiResponse(responseCode = "404")
-
-    })
-    public RequisitionAssetCollection getAssetParameters(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId) throws ParseException {
+    @Operation(
+            summary = "List the asset fields set on a requisitioned node",
+            description = """
+                    Only the fields the requisition sets, not the node's full asset record. `name` must be one
+                    of the field names `GET /foreignSourcesConfig/assets` returns; an unrecognized name is
+                    accepted into the requisition but has no effect at import.""",
+            operationId = "getRequisitionNodeAssets")
+    @ApiResponse(responseCode = "200", description = "The asset fields.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = RequisitionAssetCollection.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "totalCount": 2,
+                                      "count": 2,
+                                      "offset": 0,
+                                      "asset": [ { "name": "city", "value": "Apex" }, { "name": "region", "value": "east" } ]
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = RequisitionAssetCollection.class),
+                            examples = @ExampleObject(value = """
+                                    <assets xmlns="http://xmlns.opennms.org/xsd/config/model-import" count="2" offset="0" totalCount="2">
+                                      <asset name="city" value="Apex"/>
+                                      <asset name="region" value="east"/>
+                                    </assets>"""))
+            })
+    @ApiResponse(responseCode = "404", description = "No such node in that requisition.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                    schema = @Schema(type = "string"),
+                    examples = @ExampleObject(value = "Node with Foreign ID 'node-9' and Foreign source 'datacenter-east' not found.")))
+    public RequisitionAssetCollection getAssetParameters(@Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource, @Parameter(required = true, description = "Foreign ID of the node within the requisition.", example = "node-1") @PathParam("foreignId") final String foreignId) throws ParseException {
         final RequisitionAssetCollection assets = m_accessService.getAssetParameters(foreignSource, foreignId);
         if (assets == null) {
             throw getException(Status.NOT_FOUND, "Node with Foreign ID '{}' and Foreign source '{}' not found.", foreignId, foreignSource);
@@ -459,10 +1085,26 @@ public class RequisitionRestService extends OnmsRestService {
     @GET
     @Path("{foreignSource}/nodes/{foreignId}/assets/{parameter}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    @Operation(summary = "Get the value of the asset for the given assetName for the node with the given foreign ID and foreign source name.", responses = {@ApiResponse(responseCode = "200", description = "Get the value of the asset for the given assetName for the node with the given foreign ID and foreign source name."), @ApiResponse(responseCode = "404")
-
-    })
-    public RequisitionAsset getAssetParameter(@PathParam("foreignSource") final String foreignSource, @PathParam("foreignId") final String foreignId, @PathParam("parameter") final String parameter) throws ParseException {
+    @Operation(
+            summary = "Get one asset field set on a requisitioned node",
+            description = "Looked up by asset field name, matched exactly and case-sensitively.",
+            operationId = "getRequisitionNodeAsset")
+    @ApiResponse(responseCode = "200", description = "The asset field.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = RequisitionAsset.class),
+                            examples = @ExampleObject(value = """
+                                    { "name": "city", "value": "Apex" }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = RequisitionAsset.class),
+                            examples = @ExampleObject(value = """
+                                    <asset xmlns="http://xmlns.opennms.org/xsd/config/model-import" name="city" value="Apex"/>"""))
+            })
+    @ApiResponse(responseCode = "404", description = "No asset of that name on the node, or no such node.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                    schema = @Schema(type = "string"),
+                    examples = @ExampleObject(value = "Asset serialNumber on node with Foreign ID 'node-1' and Foreign source 'datacenter-east' not found.")))
+    public RequisitionAsset getAssetParameter(@Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource, @Parameter(required = true, description = "Foreign ID of the node within the requisition.", example = "node-1") @PathParam("foreignId") final String foreignId, @Parameter(required = true, description = "Asset field name.", example = "city") @PathParam("parameter") final String parameter) throws ParseException {
         final RequisitionAsset asset = m_accessService.getAssetParameter(foreignSource, foreignId, parameter);
         if (asset == null) {
             throw getException(Status.NOT_FOUND, "Asset {} on node with Foreign ID '{}' and Foreign source '{}' not found.", parameter, foreignId, foreignSource);
@@ -479,8 +1121,69 @@ public class RequisitionRestService extends OnmsRestService {
     @POST
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
-    @Operation(summary = "Adds or replaces a requisition.", responses = {@ApiResponse(headers = @Header(name = "Location"), responseCode = "202", description = "Adds or replaces a requisition.")})
-    public Response addOrReplaceRequisition(@Context final UriInfo uriInfo, @RequestBody(description = "Requisition") final Requisition requisition) {
+    @Operation(
+            summary = "Add or replace a whole requisition",
+            description = """
+                    Writes the document to the pending repository under the `foreign-source` carried in the
+                    body, not in the URL. The previous pending document is replaced outright rather than merged,
+                    so anything absent from the body is dropped. To edit part of a large requisition, post to the
+                    node, interface, service, category or asset sub-resource instead.
+
+                    Nothing is provisioned until `PUT /requisitions/{foreignSource}/import` runs.
+
+                    The body is validated before it is written: `foreign-source` must be present and must not
+                    contain any of `: / \\ ? & * ' "`, every node needs a `foreign-id`, foreign IDs must be
+                    unique within the document, and each interface needs an `ip-addr`. Note that `foreign-source`
+                    has a default of `imported-`, so a body that omits it is accepted and stored under that name
+                    rather than rejected. `date-stamp` and `last-import` in the body are ignored.""",
+            operationId = "addOrReplaceRequisition")
+    @RequestBody(required = true, description = "The complete requisition document.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = Requisition.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "foreign-source": "datacenter-east",
+                                      "node": [
+                                        {
+                                          "foreign-id": "node-1",
+                                          "node-label": "router-1",
+                                          "building": "HQ",
+                                          "interface": [
+                                            {
+                                              "ip-addr": "198.51.100.11",
+                                              "descr": "eth0",
+                                              "snmp-primary": "P",
+                                              "status": 1,
+                                              "monitored-service": [ { "service-name": "ICMP" } ]
+                                            }
+                                          ],
+                                          "category": [ { "name": "Production" } ],
+                                          "asset": [ { "name": "city", "value": "Apex" } ]
+                                        }
+                                      ]
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = Requisition.class),
+                            examples = @ExampleObject(value = """
+                                    <model-import xmlns="http://xmlns.opennms.org/xsd/config/model-import" foreign-source="datacenter-east">
+                                      <node foreign-id="node-1" node-label="router-1" building="HQ">
+                                        <interface ip-addr="198.51.100.11" descr="eth0" status="1" snmp-primary="P">
+                                          <monitored-service service-name="ICMP"/>
+                                        </interface>
+                                        <category name="Production"/>
+                                        <asset name="city" value="Apex"/>
+                                      </node>
+                                    </model-import>"""))
+            })
+    @ApiResponse(responseCode = "202", description = "Written to the pending repository. No body.",
+            headers = @Header(name = "Location", description = "URI of the stored requisition.",
+                    schema = @Schema(type = "string", example = "http://localhost:8980/opennms/rest/requisitions/datacenter-east")))
+    @ApiResponse(responseCode = "400", description = "The body failed validation. The message names the offending attribute.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                    schema = @Schema(type = "string"),
+                    examples = @ExampleObject(value = "Duplicate nodes found on foreign source datacenter-east: node-1 (2 found)")))
+    public Response addOrReplaceRequisition(@Context final UriInfo uriInfo, final Requisition requisition) {
         try {
             requisition.validate();
         } catch (final ValidationException e) {
@@ -503,8 +1206,56 @@ public class RequisitionRestService extends OnmsRestService {
     @Path("{foreignSource}/nodes")
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
-    @Operation(summary = "Adds or replaces a node in the specified requisition.", responses = {@ApiResponse(headers = @Header(name = "Location"), responseCode = "202", description = "Adds or replaces a node in the specified requisition. This operation can be very helpful when working with large requisitions.")})
-    public Response addOrReplaceNode(@Context final UriInfo uriInfo, @Parameter(required = true) @PathParam("foreignSource") String foreignSource, @RequestBody(description = "Node") RequisitionNode node) {
+    @Operation(
+            summary = "Add or replace one node in a requisition",
+            description = """
+                    Keyed on the `foreign-id` in the body: an existing node with that foreign ID is replaced
+                    outright, otherwise the node is appended. The rest of the requisition is left alone, which is
+                    what makes this the practical way to edit a large requisition.
+
+                    If the requisition does not exist it is created with this node as its only member. Nothing is
+                    provisioned until an import runs.""",
+            operationId = "addOrReplaceRequisitionNode")
+    @RequestBody(required = true, description = "The node, complete with its interfaces, categories and assets.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = RequisitionNode.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "foreign-id": "node-2",
+                                      "node-label": "router-2",
+                                      "building": "Annex",
+                                      "interface": [
+                                        {
+                                          "ip-addr": "198.51.100.12",
+                                          "descr": "eth0",
+                                          "snmp-primary": "P",
+                                          "status": 1,
+                                          "monitored-service": [ { "service-name": "ICMP" } ]
+                                        }
+                                      ],
+                                      "category": [ { "name": "Routers" } ],
+                                      "asset": [ { "name": "region", "value": "east" } ]
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = RequisitionNode.class),
+                            examples = @ExampleObject(value = """
+                                    <node xmlns="http://xmlns.opennms.org/xsd/config/model-import" foreign-id="node-2" node-label="router-2" building="Annex">
+                                      <interface ip-addr="198.51.100.12" descr="eth0" status="1" snmp-primary="P">
+                                        <monitored-service service-name="ICMP"/>
+                                      </interface>
+                                      <category name="Routers"/>
+                                      <asset name="region" value="east"/>
+                                    </node>"""))
+            })
+    @ApiResponse(responseCode = "202", description = "Written to the pending requisition. No body.",
+            headers = @Header(name = "Location", description = "URI of the stored node.",
+                    schema = @Schema(type = "string", example = "http://localhost:8980/opennms/rest/requisitions/datacenter-east/nodes/node-2")))
+    @ApiResponse(responseCode = "400", description = "The body failed validation. The message names the offending attribute.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                    schema = @Schema(type = "string"),
+                    examples = @ExampleObject(value = "Requisition node 'foreign-id' is a required attribute!")))
+    public Response addOrReplaceNode(@Context final UriInfo uriInfo, @Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") String foreignSource, RequisitionNode node) {
         try {
             node.validate();
         } catch (final ValidationException e) {
@@ -528,8 +1279,45 @@ public class RequisitionRestService extends OnmsRestService {
     @Path("{foreignSource}/nodes/{foreignId}/interfaces")
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
-    @Operation(summary = "Adds or replaces an interface for the given node in the specified requisition.", responses = {@ApiResponse(headers = @Header(name = "Location"), responseCode = "202", description = "Adds or replaces an interface for the given node in the specified requisition.")})
-    public Response addOrReplaceInterface(@Context final UriInfo uriInfo, @Parameter(required = true) @PathParam("foreignSource") String foreignSource, @Parameter(required = true) @PathParam("foreignId") String foreignId, @RequestBody(description = "Interface") RequisitionInterface iface) {
+    @Operation(
+            summary = "Add or replace one IP interface on a requisitioned node",
+            description = """
+                    Keyed on `ip-addr`: an existing interface with that address is replaced outright, otherwise
+                    the interface is appended. `snmp-primary` takes `P` (primary), `S` (secondary) or `N` (not
+                    eligible). `status` of 3 marks the interface unmanaged; any other value, including the
+                    default of 1, leaves it managed.
+
+                    Validation rejects a second interface marked `P` on the same node, two services with the
+                    same `service-name` on this interface, and an `ip-addr` that does not parse.""",
+            operationId = "addOrReplaceRequisitionInterface")
+    @RequestBody(required = true, description = "The interface, with the monitored services it should carry.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = RequisitionInterface.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "ip-addr": "198.51.100.12",
+                                      "descr": "eth1",
+                                      "snmp-primary": "S",
+                                      "status": 1,
+                                      "monitored-service": [ { "service-name": "ICMP" }, { "service-name": "SNMP" } ]
+                                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = RequisitionInterface.class),
+                            examples = @ExampleObject(value = """
+                                    <interface xmlns="http://xmlns.opennms.org/xsd/config/model-import" ip-addr="198.51.100.12" descr="eth1" status="1" snmp-primary="S">
+                                      <monitored-service service-name="ICMP"/>
+                                      <monitored-service service-name="SNMP"/>
+                                    </interface>"""))
+            })
+    @ApiResponse(responseCode = "202", description = "Written to the pending requisition. No body.",
+            headers = @Header(name = "Location", description = "URI of the stored interface.",
+                    schema = @Schema(type = "string", example = "http://localhost:8980/opennms/rest/requisitions/datacenter-east/nodes/node-1/interfaces/198.51.100.12")))
+    @ApiResponse(responseCode = "400", description = "The body failed validation. The message names the offending attribute.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                    schema = @Schema(type = "string"),
+                    examples = @ExampleObject(value = "Requisition interface 'ip-addr' is a required attribute!")))
+    public Response addOrReplaceInterface(@Context final UriInfo uriInfo, @Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") String foreignSource, @Parameter(required = true, description = "Foreign ID of the node within the requisition.", example = "node-1") @PathParam("foreignId") String foreignId, RequisitionInterface iface) {
         try {
             final RequisitionNode node = m_accessService.getNode(foreignSource, foreignId);
             iface.validate(node);
@@ -555,8 +1343,32 @@ public class RequisitionRestService extends OnmsRestService {
     @Path("{foreignSource}/nodes/{foreignId}/interfaces/{ipAddress}/services")
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
-    @Operation(summary = "Adds or replaces a service on the given interface in the specified requisition.", responses = {@ApiResponse(headers = @Header(name = "Location"), responseCode = "202", description = "Adds or replaces a service on the given interface in the specified requisition.")})
-    public Response addOrReplaceService(@Context final UriInfo uriInfo, @Parameter(required = true) @PathParam("foreignSource") String foreignSource, @Parameter(required = true) @PathParam("foreignId") String foreignId, @Parameter(required = true) @PathParam("ipAddress") String ipAddress, @RequestBody(description = "Monitored Service") RequisitionMonitoredService service) {
+    @Operation(
+            summary = "Add or replace one monitored service on a requisitioned interface",
+            description = """
+                    Keyed on `service-name`. The name is free text and is not checked against the configured
+                    poller services; `GET /foreignSourcesConfig/services/{groupName}` lists the names that have
+                    a monitor behind them.""",
+            operationId = "addOrReplaceRequisitionService")
+    @RequestBody(required = true, description = "The monitored service.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = RequisitionMonitoredService.class),
+                            examples = @ExampleObject(value = """
+                                    { "service-name": "SNMP" }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = RequisitionMonitoredService.class),
+                            examples = @ExampleObject(value = """
+                                    <monitored-service xmlns="http://xmlns.opennms.org/xsd/config/model-import" service-name="SNMP"/>"""))
+            })
+    @ApiResponse(responseCode = "202", description = "Written to the pending requisition. No body.",
+            headers = @Header(name = "Location", description = "URI of the stored service.",
+                    schema = @Schema(type = "string", example = "http://localhost:8980/opennms/rest/requisitions/datacenter-east/nodes/node-1/interfaces/198.51.100.11/services/SNMP")))
+    @ApiResponse(responseCode = "400", description = "The body failed validation. The message names the offending attribute.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                    schema = @Schema(type = "string"),
+                    examples = @ExampleObject(value = "Requisition monitored-service 'service-name' is a required attribute!")))
+    public Response addOrReplaceService(@Context final UriInfo uriInfo, @Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") String foreignSource, @Parameter(required = true, description = "Foreign ID of the node within the requisition.", example = "node-1") @PathParam("foreignId") String foreignId, @Parameter(required = true, description = "IP address of the requisitioned interface, exactly as stored.", example = "198.51.100.11") @PathParam("ipAddress") String ipAddress, RequisitionMonitoredService service) {
         try {
             service.validate();
         } catch (final ValidationException e) {
@@ -580,8 +1392,31 @@ public class RequisitionRestService extends OnmsRestService {
     @Path("{foreignSource}/nodes/{foreignId}/categories")
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
-    @Operation(summary = "Adds or replaces a category for the given node in the specified requisition.", responses = {@ApiResponse(headers = @Header(name = "Location"), responseCode = "202", description = "Adds or replaces a category for the given node in the specified requisition.")})
-    public Response addOrReplaceNodeCategory(@Context final UriInfo uriInfo, @Parameter(required = true) @PathParam("foreignSource") String foreignSource, @Parameter(required = true) @PathParam("foreignId") String foreignId, @RequestBody(description = "Category") RequisitionCategory category) {
+    @Operation(
+            summary = "Add or replace one surveillance category on a requisitioned node",
+            description = """
+                    Keyed on `name`. The category is created at import if it does not already exist, so the name
+                    need not appear in `GET /foreignSourcesConfig/categories`.""",
+            operationId = "addOrReplaceRequisitionNodeCategory")
+    @RequestBody(required = true, description = "The category.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = RequisitionCategory.class),
+                            examples = @ExampleObject(value = """
+                                    { "name": "Routers" }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = RequisitionCategory.class),
+                            examples = @ExampleObject(value = """
+                                    <category xmlns="http://xmlns.opennms.org/xsd/config/model-import" name="Routers"/>"""))
+            })
+    @ApiResponse(responseCode = "202", description = "Written to the pending requisition. No body.",
+            headers = @Header(name = "Location", description = "URI of the stored category.",
+                    schema = @Schema(type = "string", example = "http://localhost:8980/opennms/rest/requisitions/datacenter-east/nodes/node-1/categories/Routers")))
+    @ApiResponse(responseCode = "400", description = "The body failed validation. The message names the offending attribute.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                    schema = @Schema(type = "string"),
+                    examples = @ExampleObject(value = "Requisition category 'name' is a required attribute!")))
+    public Response addOrReplaceNodeCategory(@Context final UriInfo uriInfo, @Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") String foreignSource, @Parameter(required = true, description = "Foreign ID of the node within the requisition.", example = "node-1") @PathParam("foreignId") String foreignId, RequisitionCategory category) {
         try {
             category.validate();
         } catch (final ValidationException e) {
@@ -605,8 +1440,32 @@ public class RequisitionRestService extends OnmsRestService {
     @Path("{foreignSource}/nodes/{foreignId}/assets")
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
-    @Operation(summary = "Adds or replaces an asset for the given node in the specified requisition.", responses = {@ApiResponse(headers = @Header(name = "Location"), responseCode = "202", description = "Adds or replaces an asset for the given node in the specified requisition.")})
-    public Response addOrReplaceNodeAssetParameter(@Context final UriInfo uriInfo, @Parameter(required = true) @PathParam("foreignSource") String foreignSource, @Parameter(required = true) @PathParam("foreignId") String foreignId, @RequestBody(description = "Asset") RequisitionAsset asset) {
+    @Operation(
+            summary = "Add or replace one asset field on a requisitioned node",
+            description = """
+                    Keyed on `name`, which should be one of the field names
+                    `GET /foreignSourcesConfig/assets` returns. An unrecognized name is stored without complaint
+                    and then has no effect at import.""",
+            operationId = "addOrReplaceRequisitionNodeAsset")
+    @RequestBody(required = true, description = "The asset field and its value.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = RequisitionAsset.class),
+                            examples = @ExampleObject(value = """
+                                    { "name": "region", "value": "east" }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = RequisitionAsset.class),
+                            examples = @ExampleObject(value = """
+                                    <asset xmlns="http://xmlns.opennms.org/xsd/config/model-import" name="region" value="east"/>"""))
+            })
+    @ApiResponse(responseCode = "202", description = "Written to the pending requisition. No body.",
+            headers = @Header(name = "Location", description = "URI of the stored asset field.",
+                    schema = @Schema(type = "string", example = "http://localhost:8980/opennms/rest/requisitions/datacenter-east/nodes/node-1/assets/region")))
+    @ApiResponse(responseCode = "400", description = "The body failed validation. The message names the offending attribute.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                    schema = @Schema(type = "string"),
+                    examples = @ExampleObject(value = "Requisition asset 'name' is a required attribute!")))
+    public Response addOrReplaceNodeAssetParameter(@Context final UriInfo uriInfo, @Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") String foreignSource, @Parameter(required = true, description = "Foreign ID of the node within the requisition.", example = "node-1") @PathParam("foreignId") String foreignId, RequisitionAsset asset) {
         try {
             asset.validate();
         } catch (final ValidationException e) {
@@ -627,8 +1486,45 @@ public class RequisitionRestService extends OnmsRestService {
     @PUT
     @Path("{foreignSource}/import")
     @Transactional
-    @Operation(summary = "Performs an import or synchronize on the specified requisition.", responses = {@ApiResponse(headers = @Header(name = "Location"), responseCode = "202", description = "Performs an import or synchronize on the specified requisition. This turns the \"active\" requisition into a \"deployed\" requisition.")})
-    public Response importRequisition(@Context final UriInfo uriInfo, @Parameter(required = true) @PathParam("foreignSource") final String foreignSource, @Parameter(description = "If it is newly added or removed. Existing nodes are not scanned until the next rescan interval. This request type is useful when applying changes to a subset of nodes in a requisition.") @QueryParam("rescanExisting") final String rescanExisting) {
+    @Operation(
+            summary = "Import (synchronize) a requisition",
+            description = """
+                    Snapshots the requisition, sends provisiond a `reloadImport` event pointing at the snapshot,
+                    and returns. Provisiond then reconciles the database against the document: nodes in the
+                    requisition but not in the database are created, nodes in both are updated, and **nodes in
+                    the database but no longer in the requisition are deleted**. On success the document moves
+                    from the pending repository to the deployed one, `last-import` is stamped, and
+                    `/requisitions/count` drops back to zero.
+
+                    **This is asynchronous.** The 202 means the event was accepted, not that any node exists yet.
+                    A large requisition can take minutes, and the request can succeed while the import then
+                    fails. Poll `GET /requisitions/deployed/stats/{foreignSource}`, or the node list, rather than
+                    treating the 202 as completion. Firing several imports for the same foreign source in quick
+                    succession queues them all; they are not coalesced.
+
+                    If there is no pending document, the already-deployed document is re-imported.
+
+                    Deleting a requisition does not undo an import: `DELETE /requisitions/deployed/{foreignSource}`
+                    removes the document and leaves the provisioned nodes in place. To remove the nodes, empty
+                    the requisition and import it, or delete the nodes through the nodes API.""",
+            operationId = "importRequisition")
+    @ApiResponse(responseCode = "202", description = "The import event was sent. No body. The import itself has not necessarily started, let alone finished.",
+            headers = @Header(name = "Location", description = "URI of the requisition that is being imported.",
+                    schema = @Schema(type = "string", example = "http://localhost:8980/opennms/rest/requisitions/datacenter-east")))
+    public Response importRequisition(@Context final UriInfo uriInfo, @Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource,
+            @Parameter(description = """
+                    How to treat nodes that already exist. `true` runs a full rescan of every node in the
+                    requisition; `false` applies the database changes and scans only nodes that were added, so
+                    existing nodes are left until their next scheduled scan; `dbonly` applies the database
+                    changes and scans nothing.
+
+                    The value is forwarded to provisiond verbatim without being validated here, so a
+                    misspelling is accepted with a 202 and then behaves like `false` downstream. Omitting the
+                    parameter leaves the event parameter unset, in which case provisiond falls back to
+                    `org.opennms.provisiond.scheduleRescanForUpdatedNodes`, whose own default is `true`.""",
+                    example = "false",
+                    schema = @Schema(type = "string", allowableValues = {"true", "false", "dbonly"}))
+            @QueryParam("rescanExisting") final String rescanExisting) {
         LOG.info("PUT {}: Importing requisition for foreign source {}", uriInfo.getPath(), foreignSource);
         m_accessService.importRequisition(foreignSource, rescanExisting);
         return Response.accepted().header("Location", uriInfo.getBaseUriBuilder().path(this.getClass()).path(this.getClass(), "getRequisition").build(foreignSource)).build();
@@ -645,8 +1541,25 @@ public class RequisitionRestService extends OnmsRestService {
     @Path("{foreignSource}")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Transactional
-    @Operation(summary = "Update the specified requisition.", responses = {@ApiResponse(headers = @Header(name = "Location"), responseCode = "202", description = "Update the specified requisition.")})
-    public Response updateRequisition(@Context final UriInfo uriInfo, @Parameter(required = true) @PathParam("foreignSource") final String foreignSource, @RequestBody(description = "Requisition key/value pairs") final MultivaluedMapImpl params) {
+    @Operation(
+            summary = "Update scalar fields of a requisition",
+            description = """
+                    Form-encoded key/value pairs applied to the requisition envelope, not to its nodes. Keys are
+                    normalized to bean property names, so both `foreign-source` and `foreignSource` reach the
+                    same property. `id`, `dbId`, `nodeId` and `authorizedGroups` are protected and skipped with a
+                    log line; any other key that does not name a writable property is ignored.
+
+                    The response is 202 whether or not a key matched. Read the resource back to confirm the
+                    change.""",
+            operationId = "updateRequisition")
+    @RequestBody(required = true, description = "Form-encoded field names and values.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(implementation = MultivaluedMapImpl.class),
+                    examples = @ExampleObject(value = "foreign-source=datacenter-east")))
+    @ApiResponse(responseCode = "202", description = "The pending requisition was written. No body. Returned even when no key matched a writable property.",
+            headers = @Header(name = "Location", description = "URI of the updated requisition.",
+                    schema = @Schema(type = "string", example = "http://localhost:8980/opennms/rest/requisitions/datacenter-east")))
+    public Response updateRequisition(@Context final UriInfo uriInfo, @Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource, final MultivaluedMapImpl params) {
         LOG.info("PUT {}: Updated {} with params '{}'", uriInfo.getPath(), foreignSource, params.isEmpty() ? "None" : params.toString());
         m_accessService.updateRequisition(foreignSource, params);
         return Response.accepted().header("Location", getRedirectUri(uriInfo)).build();
@@ -664,8 +1577,27 @@ public class RequisitionRestService extends OnmsRestService {
     @Path("{foreignSource}/nodes/{foreignId}")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Transactional
-    @Operation(summary = "Update the specified node for the given requisition.", responses = {@ApiResponse(headers = @Header(name = "Location"), responseCode = "202", description = "Update the specified node for the given requisition.")})
-    public Response updateNode(@Context final UriInfo uriInfo, @Parameter(required = true) @PathParam("foreignSource") final String foreignSource, @Parameter(required = true) @PathParam("foreignId") final String foreignId, @RequestBody(description = "Node key/value pairs") final MultivaluedMapImpl params) {
+    @Operation(
+            summary = "Update scalar fields of a requisitioned node",
+            description = """
+                    Form-encoded key/value pairs applied to the node's own fields: `node-label`, `building`,
+                    `city`, `location`, `parent-foreign-source`, `parent-foreign-id`, `parent-node-label`. Keys
+                    are normalized to bean property names, so `node-label` and `nodeLabel` are equivalent. Keys
+                    that name no writable property are ignored, and `id`, `dbId`, `nodeId` and `authorizedGroups`
+                    are protected and skipped.
+
+                    Interfaces, categories and assets are collections and are not settable this way; use their
+                    sub-resources. The response is 202 whether or not a key matched, so read the node back to
+                    confirm.""",
+            operationId = "updateRequisitionNode")
+    @RequestBody(required = true, description = "Form-encoded field names and values.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(implementation = MultivaluedMapImpl.class),
+                    examples = @ExampleObject(value = "node-label=router-1a&building=Annex")))
+    @ApiResponse(responseCode = "202", description = "The pending requisition was written. No body. Returned even when no key matched a writable property.",
+            headers = @Header(name = "Location", description = "URI of the updated node.",
+                    schema = @Schema(type = "string", example = "http://localhost:8980/opennms/rest/requisitions/datacenter-east/nodes/node-1")))
+    public Response updateNode(@Context final UriInfo uriInfo, @Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource, @Parameter(required = true, description = "Foreign ID of the node within the requisition.", example = "node-1") @PathParam("foreignId") final String foreignId, final MultivaluedMapImpl params) {
         LOG.info("PUT {}: Updated node {}/{} with params '{}'", uriInfo.getPath(), foreignSource, foreignId, params.isEmpty() ? "None" : params.toString());
         m_accessService.updateNode(foreignSource, foreignId, params);
         return Response.accepted().header("Location", getRedirectUri(uriInfo)).build();
@@ -684,8 +1616,25 @@ public class RequisitionRestService extends OnmsRestService {
     @Path("{foreignSource}/nodes/{foreignId}/interfaces/{ipAddress}")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Transactional
-    @Operation(summary = "Update the specified IP address for the given node and requisition.", responses = {@ApiResponse(headers = @Header(name = "Location"), responseCode = "202", description = "Update the specified IP address for the given node and requisition.")})
-    public Response updateInterface(@Context final UriInfo uriInfo, @Parameter(required = true) @PathParam("foreignSource") final String foreignSource, @Parameter(required = true) @PathParam("foreignId") final String foreignId, @Parameter(required = true) @PathParam("ipAddress") final String ipAddress, @RequestBody(description = "Interface key/value pairs") final MultivaluedMapImpl params) {
+    @Operation(
+            summary = "Update scalar fields of a requisitioned IP interface",
+            description = """
+                    Form-encoded key/value pairs applied to the interface's own fields: `descr`, `status`,
+                    `snmp-primary`, `managed`, and `ip-addr` itself. Keys are normalized to bean property names,
+                    so `snmp-primary` and `snmpPrimary` are equivalent. `snmp-primary` takes `P`, `S` or `N`.
+                    Monitored services are a collection and are not settable this way. The primary-interface and
+                    duplicate-service checks that `POST` runs are not applied here.
+
+                    The response is 202 whether or not a key matched.""",
+            operationId = "updateRequisitionInterface")
+    @RequestBody(required = true, description = "Form-encoded field names and values.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(implementation = MultivaluedMapImpl.class),
+                    examples = @ExampleObject(value = "descr=eth1&snmp-primary=N")))
+    @ApiResponse(responseCode = "202", description = "The pending requisition was written. No body. Returned even when no key matched a writable property.",
+            headers = @Header(name = "Location", description = "URI of the updated interface.",
+                    schema = @Schema(type = "string", example = "http://localhost:8980/opennms/rest/requisitions/datacenter-east/nodes/node-1/interfaces/198.51.100.11")))
+    public Response updateInterface(@Context final UriInfo uriInfo, @Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource, @Parameter(required = true, description = "Foreign ID of the node within the requisition.", example = "node-1") @PathParam("foreignId") final String foreignId, @Parameter(required = true, description = "IP address of the requisitioned interface, exactly as stored.", example = "198.51.100.11") @PathParam("ipAddress") final String ipAddress, final MultivaluedMapImpl params) {
         LOG.info("PUT {}: Updated node {}/{} address {} with params '{}'", uriInfo.getPath(), foreignSource, foreignId, ipAddress, params.isEmpty() ? "None" : params.toString());
         m_accessService.updateInterface(foreignSource, foreignId, ipAddress, params);
         return Response.accepted().header("Location", getRedirectUri(uriInfo)).build();
@@ -700,8 +1649,18 @@ public class RequisitionRestService extends OnmsRestService {
     @DELETE
     @Path("{foreignSource}")
     @Transactional
-    @Operation(summary = "Delete the pending requisition for the named foreign source.", responses = @ApiResponse(responseCode = "202", description = "Delete the pending requisition for the named foreign source."))
-    public Response deletePendingRequisition(@Context final UriInfo uriInfo, @Parameter(required = true) @PathParam("foreignSource") final String foreignSource) {
+    @Operation(
+            summary = "Delete the pending requisition",
+            description = """
+                    Removes the pending document, discarding edits that have not been imported. The deployed
+                    document and the provisioned nodes are untouched, so a read of the requisition afterwards
+                    still returns the last imported version.
+
+                    A foreign source with no pending document is not reported as an error, the response is still
+                    202.""",
+            operationId = "deletePendingRequisition")
+    @ApiResponse(responseCode = "202", description = "Delete attempted. No body. Returned whether or not a pending document existed.")
+    public Response deletePendingRequisition(@Context final UriInfo uriInfo, @Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource) {
         LOG.info("DELETE {}: Deleted the pending requisition for {}", uriInfo.getPath(), foreignSource);
         m_accessService.deletePendingRequisition(foreignSource);
         return Response.accepted().build();
@@ -716,8 +1675,21 @@ public class RequisitionRestService extends OnmsRestService {
     @DELETE
     @Path("deployed/{foreignSource}")
     @Transactional
-    @Operation(summary = "Delete the active requisition for the named foreign source.", responses = @ApiResponse(responseCode = "202", description = "Delete the active requisition for the named foreign source."))
-    public Response deleteDeployedRequisition(@Context final UriInfo uriInfo, @Parameter(required = true) @PathParam("foreignSource") final String foreignSource) {
+    @Operation(
+            summary = "Delete the deployed requisition",
+            description = """
+                    Removes the deployed document. The **nodes stay provisioned**: they keep their foreign source
+                    and foreign ID and continue to be polled, they simply no longer have a requisition behind
+                    them. `GET /requisitions/deployed/stats` still lists the foreign source, with `last-imported`
+                    null, and `GET /requisitions/deployed/stats/{foreignSource}` starts failing with a 500 for
+                    that name.
+
+                    To retire a group of nodes, empty the requisition and import it, then delete the requisition.
+                    A foreign source with no deployed document is not reported as an error, the response is still
+                    202.""",
+            operationId = "deleteDeployedRequisition")
+    @ApiResponse(responseCode = "202", description = "Delete attempted. No body. Returned whether or not a deployed document existed.")
+    public Response deleteDeployedRequisition(@Context final UriInfo uriInfo, @Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource) {
         LOG.info("DELETE {}: Deleted the deployed requisition for {}", uriInfo.getPath(), foreignSource);
         m_accessService.deleteDeployedRequisition(foreignSource);
         return Response.accepted().build();
@@ -733,8 +1705,15 @@ public class RequisitionRestService extends OnmsRestService {
     @DELETE
     @Path("{foreignSource}/nodes/{foreignId}")
     @Transactional
-    @Operation(summary = "Delete the node with the given foreign ID from the given requisition.", responses = @ApiResponse(responseCode = "202", description = "Delete the node with the given foreign ID from the given requisition."))
-    public Response deleteNode(@Context final UriInfo uriInfo, @Parameter(required = true) @PathParam("foreignSource") final String foreignSource, @Parameter(required = true) @PathParam("foreignId") final String foreignId) {
+    @Operation(
+            summary = "Remove one node from a requisition",
+            description = """
+                    Removes the node from the pending requisition. The provisioned node is deleted at the next
+                    import, not by this call. A foreign ID that is not in the requisition is not reported as an
+                    error.""",
+            operationId = "deleteRequisitionNode")
+    @ApiResponse(responseCode = "202", description = "Delete attempted. No body. Returned whether or not the node was present.")
+    public Response deleteNode(@Context final UriInfo uriInfo, @Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource, @Parameter(required = true, description = "Foreign ID of the node within the requisition.", example = "node-1") @PathParam("foreignId") final String foreignId) {
         LOG.info("DELETE {}: Deleted node {} from {}", uriInfo.getPath(), foreignId, foreignSource);
         m_accessService.deleteNode(foreignSource, foreignId);
         return Response.accepted().build();
@@ -751,8 +1730,15 @@ public class RequisitionRestService extends OnmsRestService {
     @DELETE
     @Path("{foreignSource}/nodes/{foreignId}/interfaces/{ipAddress}")
     @Transactional
-    @Operation(summary = "Delete the IP address from the requisitioned node with the given foreign ID.", description = "Delete the IP address from the requisitioned node with the given foreign ID.", responses = @ApiResponse(responseCode = "202"))
-    public Response deleteInterface(@Context final UriInfo uriInfo, @Parameter(required = true) @PathParam("foreignSource") final String foreignSource, @Parameter(required = true) @PathParam("foreignId") final String foreignId, @Parameter(required = true) @PathParam("ipAddress") String ipAddress) {
+    @Operation(
+            summary = "Remove one IP interface from a requisitioned node",
+            description = """
+                    Removes the interface, and with it its monitored services, from the pending requisition. The
+                    provisioned interface is deleted at the next import. An address that is not on the node is
+                    not reported as an error.""",
+            operationId = "deleteRequisitionInterface")
+    @ApiResponse(responseCode = "202", description = "Delete attempted. No body. Returned whether or not the interface was present.")
+    public Response deleteInterface(@Context final UriInfo uriInfo, @Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource, @Parameter(required = true, description = "Foreign ID of the node within the requisition.", example = "node-1") @PathParam("foreignId") final String foreignId, @Parameter(required = true, description = "IP address of the requisitioned interface, exactly as stored.", example = "198.51.100.11") @PathParam("ipAddress") String ipAddress) {
         LOG.info("DELETE {}: Deleted the IP address {} from node {}/{}", uriInfo.getPath(), ipAddress, foreignSource, foreignId);
         m_accessService.deleteInterface(foreignSource, foreignId, ipAddress);
         return Response.accepted().build();
@@ -770,8 +1756,15 @@ public class RequisitionRestService extends OnmsRestService {
     @DELETE
     @Path("{foreignSource}/nodes/{foreignId}/interfaces/{ipAddress}/services/{service}")
     @Transactional
-    @Operation(summary = "Delete the service from the requisitioned interface with the given IP address and foreign ID.", responses = @ApiResponse(responseCode = "202", description = "Delete the service from the requisitioned interface with the given IP address and foreign ID."))
-    public Response deleteInterfaceService(@Context final UriInfo uriInfo, @Parameter(required = true) @PathParam("foreignSource") final String foreignSource, @Parameter(required = true) @PathParam("foreignId") final String foreignId, @Parameter(required = true) @PathParam("ipAddress") final String ipAddress, @Parameter(required = true) @PathParam("service") final String service) {
+    @Operation(
+            summary = "Remove one monitored service from a requisitioned interface",
+            description = """
+                    Removes the service from the pending requisition. The provisioned service is deleted at the
+                    next import; a detector on the foreign source definition can add it back on the scan that
+                    follows. A service name that is not on the interface is not reported as an error.""",
+            operationId = "deleteRequisitionService")
+    @ApiResponse(responseCode = "202", description = "Delete attempted. No body. Returned whether or not the service was present.")
+    public Response deleteInterfaceService(@Context final UriInfo uriInfo, @Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource, @Parameter(required = true, description = "Foreign ID of the node within the requisition.", example = "node-1") @PathParam("foreignId") final String foreignId, @Parameter(required = true, description = "IP address of the requisitioned interface, exactly as stored.", example = "198.51.100.11") @PathParam("ipAddress") final String ipAddress, @Parameter(required = true, description = "Monitored service name.", example = "SNMP") @PathParam("service") final String service) {
         LOG.info("DELETE {}: Deleted the service {} from node {}/{} interface {}", uriInfo.getPath(), service, foreignSource, foreignId, ipAddress);
         m_accessService.deleteInterfaceService(foreignSource, foreignId, ipAddress, service);
         return Response.accepted().build();
@@ -788,8 +1781,15 @@ public class RequisitionRestService extends OnmsRestService {
     @DELETE
     @Path("{foreignSource}/nodes/{foreignId}/categories/{category}")
     @Transactional
-    @Operation(summary = "Delete the category from the node with the given foreign ID.", responses = @ApiResponse(responseCode = "202", description = "Delete the category from the node with the given foreign ID."))
-    public Response deleteCategory(@Context final UriInfo uriInfo, @Parameter(required = true) @PathParam("foreignSource") final String foreignSource, @Parameter(required = true) @PathParam("foreignId") final String foreignId, @Parameter(required = true) @PathParam("category") final String category) {
+    @Operation(
+            summary = "Remove one surveillance category from a requisitioned node",
+            description = """
+                    Removes the category from the pending requisition; the node leaves the category at the next
+                    import. The category itself is not deleted. A category name that is not on the node is not
+                    reported as an error.""",
+            operationId = "deleteRequisitionNodeCategory")
+    @ApiResponse(responseCode = "202", description = "Delete attempted. No body. Returned whether or not the category was present.")
+    public Response deleteCategory(@Context final UriInfo uriInfo, @Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource, @Parameter(required = true, description = "Foreign ID of the node within the requisition.", example = "node-1") @PathParam("foreignId") final String foreignId, @Parameter(required = true, description = "Surveillance category name.", example = "Production") @PathParam("category") final String category) {
         LOG.info("DELETE {}: Deleted category {} from node {}/{}", uriInfo.getPath(), category, foreignSource, foreignId);
         m_accessService.deleteCategory(foreignSource, foreignId, category);
         return Response.accepted().build();
@@ -806,8 +1806,16 @@ public class RequisitionRestService extends OnmsRestService {
     @DELETE
     @Path("{foreignSource}/nodes/{foreignId}/assets/{parameter}")
     @Transactional
-    @Operation(summary = "Delete the field from the node’s assets with the given foreign ID and asset name.", responses = @ApiResponse(responseCode = "202", description = "Delete the field from the node’s assets with the given foreign ID and asset name."))
-    public Response deleteAssetParameter(@Context final UriInfo uriInfo, @Parameter(required = true) @PathParam("foreignSource") final String foreignSource, @Parameter(required = true) @PathParam("foreignId") final String foreignId, @Parameter(required = true) @PathParam("parameter") final String parameter) {
+    @Operation(
+            summary = "Remove one asset field from a requisitioned node",
+            description = """
+                    Removes the field from the pending requisition, which stops the requisition from setting it.
+                    Whether the value already written to the node's asset record is cleared at the next import
+                    depends on the import behaviour rather than on this call. An asset name that is not on the
+                    node is not reported as an error.""",
+            operationId = "deleteRequisitionNodeAsset")
+    @ApiResponse(responseCode = "202", description = "Delete attempted. No body. Returned whether or not the asset field was present.")
+    public Response deleteAssetParameter(@Context final UriInfo uriInfo, @Parameter(required = true, description = "Foreign source name of the requisition.", example = "datacenter-east") @PathParam("foreignSource") final String foreignSource, @Parameter(required = true, description = "Foreign ID of the node within the requisition.", example = "node-1") @PathParam("foreignId") final String foreignId, @Parameter(required = true, description = "Asset field name.", example = "city") @PathParam("parameter") final String parameter) {
         LOG.info("DELETE {}: Deleted asset value {} from {}/{}", uriInfo.getPath(), parameter, foreignSource, foreignId);
         m_accessService.deleteAssetParameter(foreignSource, foreignId, parameter);
         return Response.accepted().build();

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/RequisitionRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/RequisitionRestService.java
@@ -147,7 +147,7 @@ import org.springframework.transaction.annotation.Transactional;
 
         Dates (`date-stamp`, `last-import`, `last-imported`) are epoch milliseconds in JSON and ISO-8601
         timestamps in XML; the derived schema shows `date-time`. The `PUT` handlers consume
-        `application/x-www-form-urlencoded` only.""")
+        `application/x-www-form-urlencoded` only, except `PUT .../import`, which reads no body.""")
 public class RequisitionRestService extends OnmsRestService {
 
     private static final Logger LOG = LoggerFactory.getLogger(RequisitionRestService.class);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ResourceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ResourceRestService.java
@@ -78,11 +78,11 @@ import com.google.gson.Gson;
 @Component("resourceRestService")
 @Path("resources")
 @Tag(name = "Resources", description = """
-        Resources API: the tree of things that performance data is collected against.
+        The tree of entities that performance data is collected against.
 
         ## Resource ids
 
-        A resource id is an opaque string with a fixed grammar. It is a dot-separated path of segments, each
+        A resource id is an opaque string with a fixed grammar: a dot-separated path of segments, each
         segment being a resource type followed by that type's instance name in square brackets:
 
             <type>[<instance>]{.<type>[<instance>]}
@@ -97,12 +97,10 @@ import com.google.gson.Gson;
         Ids therefore contain `[`, `]`, `:` and `@`, all of which have to be percent-encoded when the id is
         used as a path segment: `node%5Bloopback-lab%3Alb-001%5D.responseTime%5B127.0.0.1%5D`.
 
-        ## Getting from a node to a resource id
-
         `GET /resources/fornode/{nodeCriteria}` takes a database id or `foreignSource:foreignId` and returns
-        the node's resource with its children, so it is the shortest path from a node to a usable id. The ids
-        that can actually be graphed are the children carrying `rrdGraphAttributes`; the attribute keys in
-        that map are the attribute names to pass to the Measurements API.
+        the node's resource with its children. The ids that can be graphed are the children carrying
+        `rrdGraphAttributes`; the attribute keys in that map are the attribute names the Measurements API
+        takes.
 
         A resource id that does not parse is reported as 500, not 400. An id that parses but names nothing is
         a 404.""")
@@ -134,8 +132,7 @@ public class ResourceRestService extends OnmsRestService {
         plus any non-node top-level resources the running resource types define.
 
         `depth` controls how far the children are walked. The default of 1 returns each top-level resource
-        with its immediate children. A negative depth walks the whole subtree, which on a large system is a
-        very large response.
+        with its immediate children. A negative depth walks the whole subtree.
 
         This operation is not paged: `totalCount` and `count` are always equal and `offset` is always 0.""",
             operationId = "getResources"
@@ -267,8 +264,7 @@ public class ResourceRestService extends OnmsRestService {
     @Operation(
             summary = "Delete a resource and its collected data",
             description = """
-        Remove the resource and the persisted data behind it. This deletes files under the share directory,
-        so it cannot be undone from the API.
+        Remove the resource and the persisted data behind it, including files under the share directory.
 
         The response carries no body on success. An id whose grammar does not parse fails with 500 rather
         than 400.""",
@@ -304,8 +300,7 @@ public class ResourceRestService extends OnmsRestService {
     @Operation(
             summary = "Get the resource tree for a node",
             description = """
-        Return the node's own resource with, by default, its whole subtree. This is the usual way to get from
-        a node to the resource ids that can be graphed.
+        Return the node's own resource with, by default, its whole subtree.
 
         `nodeCriteria` is either the database node id (`1`) or `foreignSource:foreignId`
         (`loopback-lab:lb-001`). A criteria string that is neither numeric nor contains a colon fails with
@@ -408,8 +403,7 @@ public class ResourceRestService extends OnmsRestService {
         The node resource always comes back with its own attribute maps blanked. What happens below it
         depends on `nodeSubresources`:
 
-        - omitted: every sub-resource is listed, but stripped of its children and attribute maps, which is
-          enough to browse the tree without carrying its contents;
+        - omitted: every sub-resource is listed, but stripped of its children and attribute maps;
         - given: only sub-resources whose id ends in `.<name>` are kept, and those keep their
           `stringPropertyAttributes`.
 
@@ -566,9 +560,7 @@ public class ResourceRestService extends OnmsRestService {
     @Operation(
             summary = "Store a list of resource ids under a generated key",
             description = """
-        Store a list of resource ids in the JSON store and return the key they were filed under. The graph
-        results page uses this to hand a long list of resource ids to a later request by reference instead of
-        in a query string.
+        Store a list of resource ids in the JSON store and return the key they were filed under.
 
         The key is a UUID derived from the JSON form of the list, so the same list always produces the same
         key and re-posting it overwrites the entry with identical content. Order matters: a reordered list is

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ResourceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ResourceRestService.java
@@ -41,6 +41,15 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.commons.lang3.StringUtils;
 import org.opennms.features.distributed.kvstore.api.JsonStore;
@@ -68,7 +77,35 @@ import com.google.gson.Gson;
  */
 @Component("resourceRestService")
 @Path("resources")
-@Tag(name = "Resources", description = "Resources API")
+@Tag(name = "Resources", description = """
+        Resources API: the tree of things that performance data is collected against.
+
+        ## Resource ids
+
+        A resource id is an opaque string with a fixed grammar. It is a dot-separated path of segments, each
+        segment being a resource type followed by that type's instance name in square brackets:
+
+            <type>[<instance>]{.<type>[<instance>]}
+
+        The root segment is always `node[...]`, and the node instance is either the database id
+        (`node[1]`) or `foreignSource:foreignId` (`node[loopback-lab:lb-001]`). Which of the two forms
+        appears is decided by the node, not by how it was looked up: a node that came from a requisition is
+        always reported in the `foreignSource:foreignId` form. Child segments name the sub-resource type and
+        its instance, for example `.responseTime[127.0.0.1]`, `.interfaceSnmp[eth0-005056b6b6b6]`,
+        `.perspectiveResponseTime[127.0.0.1@Default]`.
+
+        Ids therefore contain `[`, `]`, `:` and `@`, all of which have to be percent-encoded when the id is
+        used as a path segment: `node%5Bloopback-lab%3Alb-001%5D.responseTime%5B127.0.0.1%5D`.
+
+        ## Getting from a node to a resource id
+
+        `GET /resources/fornode/{nodeCriteria}` takes a database id or `foreignSource:foreignId` and returns
+        the node's resource with its children, so it is the shortest path from a node to a usable id. The ids
+        that can actually be graphed are the children carrying `rrdGraphAttributes`; the attribute keys in
+        that map are the attribute names to pass to the Measurements API.
+
+        A resource id that does not parse is reported as 500, not 400. An id that parses but names nothing is
+        a 404.""")
 public class ResourceRestService extends OnmsRestService {
 
     private static final Logger LOG = LoggerFactory.getLogger(ResourceRestService.class);
@@ -90,7 +127,51 @@ public class ResourceRestService extends OnmsRestService {
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional(readOnly=true)
-    public ResourceDTOCollection getResources(@DefaultValue("1") @QueryParam("depth") final int depth) {
+    @Operation(
+            summary = "List top-level resources",
+            description = """
+        List the top-level resources, which in practice means one entry per node that has collected data,
+        plus any non-node top-level resources the running resource types define.
+
+        `depth` controls how far the children are walked. The default of 1 returns each top-level resource
+        with its immediate children. A negative depth walks the whole subtree, which on a large system is a
+        very large response.
+
+        This operation is not paged: `totalCount` and `count` are always equal and `offset` is always 0.""",
+            operationId = "getResources"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The top-level resources.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = ResourceDTOCollection.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 254,
+                      "count": 254,
+                      "offset": 0,
+                      "resource": [
+                        {
+                          "id": "node[loopback-lab:lb-001]",
+                          "label": "loopback-001",
+                          "name": "loopback-lab:lb-001",
+                          "link": "element/node.jsp?node=loopback-lab:lb-001",
+                          "typeLabel": "Node",
+                          "parentId": null,
+                          "stringPropertyAttributes": {},
+                          "externalValueAttributes": {},
+                          "rrdGraphAttributes": {}
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = ResourceDTOCollection.class))
+                    })
+    })
+    public ResourceDTOCollection getResources(
+            @Parameter(description = "How many levels of children to include. 1 returns the immediate children; a negative value walks the whole subtree.",
+                    example = "1")
+            @DefaultValue("1") @QueryParam("depth") final int depth) {
         List<ResourceDTO> resources = Lists.newLinkedList();
         for (OnmsResource resource : m_resourceDao.findTopLevelResources()) {
             resources.add(ResourceDTO.fromResource(resource, depth));
@@ -102,7 +183,75 @@ public class ResourceRestService extends OnmsRestService {
     @Path("{resourceId}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional(readOnly=true)
-    public ResourceDTO getResourceById(@PathParam("resourceId") final String resourceId,
+    @Operation(
+            summary = "Get one resource by id",
+            description = """
+        Return a single resource and, by default, its whole subtree. The path segment is a resource id and
+        has to be percent-encoded, since ids contain `[`, `]` and often `:`.
+
+        `rrdGraphAttributes` names the numeric attributes on the resource; each entry gives the attribute
+        name and where its RRD/JRB file sits under the share directory. `stringPropertyAttributes` holds
+        collected strings, `externalValueAttributes` holds values sourced from outside the collector.
+
+        An id whose grammar does not parse fails with 500 rather than 400.""",
+            operationId = "getResourceById"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The resource.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = ResourceDTO.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "id": "node[loopback-lab:lb-001]",
+                      "label": "loopback-001",
+                      "name": "loopback-lab:lb-001",
+                      "link": "element/node.jsp?node=loopback-lab:lb-001",
+                      "typeLabel": "Node",
+                      "parentId": null,
+                      "children": {
+                        "totalCount": 1,
+                        "count": 1,
+                        "offset": 0,
+                        "resource": [
+                          {
+                            "id": "node[loopback-lab:lb-001].responseTime[127.0.0.1]",
+                            "label": "Response Time for 127.0.0.1",
+                            "name": "127.0.0.1",
+                            "link": "element/interface.jsp?node=loopback-lab:lb-001&intf=127.0.0.1",
+                            "typeLabel": "Response Time",
+                            "parentId": "node[loopback-lab:lb-001]",
+                            "stringPropertyAttributes": {},
+                            "externalValueAttributes": {},
+                            "rrdGraphAttributes": {
+                              "http-8080": {
+                                "name": "http-8080",
+                                "relativePath": "response/127.0.0.1",
+                                "rrdFile": "http-8080.rrd"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = ResourceDTO.class))
+                    }),
+            @ApiResponse(responseCode = "404", description = "The id parses but names no resource.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "No resource with id 'node[99999]' found."))),
+            @ApiResponse(responseCode = "500", description = "The id does not match the resource-id grammar.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Ill-formed resource ID: not-an-id")))
+    })
+    public ResourceDTO getResourceById(
+            @Parameter(description = "Percent-encoded resource id.", required = true,
+                    example = "node[loopback-lab:lb-001].responseTime[127.0.0.1]")
+            @PathParam("resourceId") final String resourceId,
+            @Parameter(description = "How many levels of children to include. The default of -1 walks the whole subtree.",
+                    example = "-1")
             @DefaultValue("-1") @QueryParam("depth") final int depth) {
         OnmsResource resource = m_resourceDao.getResourceById(ResourceId.fromString(resourceId));
         if (resource == null) {
@@ -115,7 +264,31 @@ public class ResourceRestService extends OnmsRestService {
     @DELETE
     @Path("{resourceId}")
     @Transactional(readOnly=false)
-    public void deleteResourceById(@PathParam("resourceId") final String resourceId) {
+    @Operation(
+            summary = "Delete a resource and its collected data",
+            description = """
+        Remove the resource and the persisted data behind it. This deletes files under the share directory,
+        so it cannot be undone from the API.
+
+        The response carries no body on success. An id whose grammar does not parse fails with 500 rather
+        than 400.""",
+            operationId = "deleteResourceById"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The resource was deleted."),
+            @ApiResponse(responseCode = "404", description = "The id parses but names no resource.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "No resource with id 'node[99999]' found."))),
+            @ApiResponse(responseCode = "500", description = "The id does not match the resource-id grammar.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Ill-formed resource ID: not-an-id")))
+    })
+    public void deleteResourceById(
+            @Parameter(description = "Percent-encoded resource id.", required = true,
+                    example = "node[loopback-lab:lb-001].responseTime[127.0.0.1]")
+            @PathParam("resourceId") final String resourceId) {
         final boolean found = m_resourceDao.deleteResourceById(ResourceId.fromString(resourceId));
 
         if (!found) {
@@ -128,7 +301,73 @@ public class ResourceRestService extends OnmsRestService {
     @Path("fornode/{nodeCriteria}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional(readOnly=true)
-    public ResourceDTO getResourceForNode(@PathParam("nodeCriteria") final String nodeCriteria,
+    @Operation(
+            summary = "Get the resource tree for a node",
+            description = """
+        Return the node's own resource with, by default, its whole subtree. This is the usual way to get from
+        a node to the resource ids that can be graphed.
+
+        `nodeCriteria` is either the database node id (`1`) or `foreignSource:foreignId`
+        (`loopback-lab:lb-001`). A criteria string that is neither numeric nor contains a colon fails with
+        500 while trying to parse it as a number, rather than with 404.""",
+            operationId = "getResourceForNode"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The node resource.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = ResourceDTO.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "id": "node[loopback-lab:lb-001]",
+                      "label": "loopback-001",
+                      "name": "loopback-lab:lb-001",
+                      "link": "element/node.jsp?node=loopback-lab:lb-001",
+                      "typeLabel": "Node",
+                      "parentId": null,
+                      "children": {
+                        "totalCount": 1,
+                        "count": 1,
+                        "offset": 0,
+                        "resource": [
+                          {
+                            "id": "node[loopback-lab:lb-001].responseTime[127.0.0.1]",
+                            "label": "Response Time for 127.0.0.1",
+                            "name": "127.0.0.1",
+                            "link": "element/interface.jsp?node=loopback-lab:lb-001&intf=127.0.0.1",
+                            "typeLabel": "Response Time",
+                            "parentId": "node[loopback-lab:lb-001]",
+                            "stringPropertyAttributes": {},
+                            "externalValueAttributes": {},
+                            "rrdGraphAttributes": {
+                              "http-8080": {
+                                "name": "http-8080",
+                                "relativePath": "response/127.0.0.1",
+                                "rrdFile": "http-8080.rrd"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = ResourceDTO.class))
+                    }),
+            @ApiResponse(responseCode = "404", description = "No such node, or the node has no resource.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "No node found with criteria 'loopback-lab:nope'."))),
+            @ApiResponse(responseCode = "500", description = "The criteria is neither a node id nor a foreignSource:foreignId pair.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"not-a-node\"")))
+    })
+    public ResourceDTO getResourceForNode(
+            @Parameter(description = "Node database id, or foreignSource:foreignId.", required = true,
+                    example = "loopback-lab:lb-001")
+            @PathParam("nodeCriteria") final String nodeCriteria,
+            @Parameter(description = "How many levels of children to include. The default of -1 walks the whole subtree.",
+                    example = "-1")
             @DefaultValue("-1") @QueryParam("depth") final int depth) {
         OnmsNode node = m_nodeDao.get(nodeCriteria);
         if (node == null) {
@@ -160,10 +399,75 @@ public class ResourceRestService extends OnmsRestService {
     @Path("select")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional(readOnly=true)
+    @Operation(
+            summary = "Select node resources and prune them",
+            description = """
+        Return node resources for a set of nodes, pruned to the parts asked for. Nodes come from `nodes`,
+        from `filterRules`, or from both; the two sets are merged.
+
+        The node resource always comes back with its own attribute maps blanked. What happens below it
+        depends on `nodeSubresources`:
+
+        - omitted: every sub-resource is listed, but stripped of its children and attribute maps, which is
+          enough to browse the tree without carrying its contents;
+        - given: only sub-resources whose id ends in `.<name>` are kept, and those keep their
+          `stringPropertyAttributes`.
+
+        `stringProperties` narrows the string properties on the kept sub-resources to the named ones. It has
+        no effect unless `nodeSubresources` is also given.
+
+        Every parameter is a comma-separated list, and unknown node ids are dropped silently rather than
+        reported. The response is a bare JSON array, not the usual count/offset envelope.""",
+            operationId = "selectResources"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The selected node resources. An empty array when nothing matched.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    array = @ArraySchema(schema = @Schema(implementation = ResourceDTO.class)),
+                                    examples = @ExampleObject(value = """
+                    [
+                      {
+                        "id": "node[loopback-lab:lb-004]",
+                        "label": "loopback-004",
+                        "name": "loopback-lab:lb-004",
+                        "link": "element/node.jsp?node=loopback-lab:lb-004",
+                        "typeLabel": "Node",
+                        "parentId": null,
+                        "children": {
+                          "totalCount": 1,
+                          "count": 1,
+                          "offset": 0,
+                          "resource": [
+                            {
+                              "id": "node[loopback-lab:lb-004].responseTime[127.0.0.4]",
+                              "label": "Response Time for 127.0.0.4",
+                              "name": "127.0.0.4",
+                              "link": "element/interface.jsp?node=loopback-lab:lb-004&intf=127.0.0.4",
+                              "typeLabel": "Response Time",
+                              "parentId": "node[loopback-lab:lb-004]",
+                              "stringPropertyAttributes": {}
+                            }
+                          ]
+                        }
+                      }
+                    ]""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    array = @ArraySchema(schema = @Schema(implementation = ResourceDTO.class)))
+                    })
+    })
     public List<ResourceDTO> select(
+            @Parameter(description = "Comma-separated node ids. Database ids and foreignSource:foreignId pairs may be mixed.",
+                    example = "1,loopback-lab:lb-002")
             @DefaultValue("") @QueryParam("nodes") String nodes,
+            @Parameter(description = "Comma-separated filter rule names, each resolved to the node ids it matches. Merged with `nodes`.",
+                    example = "Routers")
             @DefaultValue("") @QueryParam("filterRules") String filterRules,
+            @Parameter(description = "Comma-separated sub-resource names, matched against the part of the id after the last dot. Omit to list all sub-resources without their contents.",
+                    example = "responseTime[127.0.0.4]")
             @DefaultValue("") @QueryParam("nodeSubresources") String nodeSubresources,
+            @Parameter(description = "Comma-separated string-property names to keep on the selected sub-resources. Only applies when `nodeSubresources` is given.",
+                    example = "sysName")
             @DefaultValue("") @QueryParam("stringProperties") String stringProperties
     ) {
         var allNodeIds = Stream.of(nodes.split(","))
@@ -259,6 +563,37 @@ public class ResourceRestService extends OnmsRestService {
     @Path("generateId")
     @Consumes({MediaType.APPLICATION_JSON})
     @Produces({MediaType.APPLICATION_JSON})
+    @Operation(
+            summary = "Store a list of resource ids under a generated key",
+            description = """
+        Store a list of resource ids in the JSON store and return the key they were filed under. The graph
+        results page uses this to hand a long list of resource ids to a later request by reference instead of
+        in a query string.
+
+        The key is a UUID derived from the JSON form of the list, so the same list always produces the same
+        key and re-posting it overwrites the entry with identical content. Order matters: a reordered list is
+        a different key.
+
+        The response body is a JSON string, quotes included. The ids are not validated.""",
+            operationId = "generateResourceIdKey"
+    )
+    @RequestBody(
+            required = true,
+            description = "The resource ids to store, as a JSON array of strings.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    array = @ArraySchema(schema = @Schema(type = "string")),
+                    examples = @ExampleObject(value = """
+                    [
+                      "node[loopback-lab:lb-001].responseTime[127.0.0.1]",
+                      "node[loopback-lab:lb-002].responseTime[127.0.0.2]"
+                    ]"""))
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The key the list was stored under, as a JSON string.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "\"3c9721e3-1213-37d4-b7d3-71407ad60eb7\"")))
+    })
     public Response saveResourcesWithId(String[] resources) {
 
         String resourcesInJson = m_gson.toJson(resources);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ScheduledOutagesRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ScheduledOutagesRestService.java
@@ -35,6 +35,14 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.config.CollectdConfigFactory;
@@ -84,7 +92,19 @@ import org.springframework.stereotype.Component;
  */
 @Component("scheduledOutagesRestService")
 @Path("sched-outages")
-@Tag(name = "Sched-outages", description = "Scheduled Outages API")
+@Tag(name = "Sched-outages", description = """
+        Scheduled Outages API.
+
+        A scheduled outage is a named calendar in `poll-outages.xml` listing time windows plus the nodes and
+        interfaces they cover. The calendar has no effect on its own: it has to be attached to a collectd, pollerd
+        or threshd package, or to notifd, through the endpoints below.
+
+        Every write here rewrites the affected configuration file through the JAXB marshaller and then sends
+        `uei.opennms.org/internal/schedOutagesChanged`. The rewrite is semantically faithful but reformats the file
+        and drops its XML comments.
+
+        A calendar whose window covers the current time suppresses polling, collection, thresholding or
+        notification for whatever it names, so scope test calendars to a window in the past.""")
 public class ScheduledOutagesRestService extends OnmsRestService {
 	
 	private static final Logger LOG = LoggerFactory.getLogger(ScheduledOutagesRestService.class);
@@ -107,6 +127,29 @@ public class ScheduledOutagesRestService extends OnmsRestService {
 
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "List scheduled outages",
+            description = "Return every scheduled outage calendar in `poll-outages.xml`. The response says nothing "
+                    + "about which packages or daemons each calendar is attached to.",
+            operationId = "getScheduledOutagesV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The configured calendars.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = Outages.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "outage": [ {
+                          "name": "Weekend maintenance",
+                          "type": "weekly",
+                          "time": [
+                            { "id": null, "day": "saturday", "begins": "00:00:00", "ends": "23:59:59" }
+                          ],
+                          "interface": [ { "address": "192.0.2.99" } ],
+                          "node": [ { "id": 2 } ]
+                        } ]
+                    }""")))
+    })
     public Outages getOutages() {
         Outages outages = new Outages();
         outages.setOutages(m_pollOutagesDao.getReadOnlyConfig().getOutages());
@@ -116,7 +159,37 @@ public class ScheduledOutagesRestService extends OnmsRestService {
     @GET
     @Path("{outageName}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    public Outage getOutage(@PathParam("outageName") String outageName) throws IllegalArgumentException {
+    @Operation(
+            summary = "Get a scheduled outage",
+            description = """
+                    Return one calendar by name. The name is matched exactly and may contain spaces, so it has to
+                    be URL-encoded.
+                    In JSON the `time` entries carry `id` and `day` as explicit nulls when they are unset.""",
+            operationId = "getScheduledOutageV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The calendar.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = Outage.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "name": "Weekend maintenance",
+                      "type": "weekly",
+                      "time": [
+                        { "id": null, "day": "saturday", "begins": "00:00:00", "ends": "23:59:59" }
+                      ],
+                      "interface": [ { "address": "192.0.2.99" } ],
+                      "node": [ { "id": 2 } ]
+                    }"""))),
+            @ApiResponse(responseCode = "404", description = "No scheduled outage with that name.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Scheduled outage Weekend maintenance was not found.")))
+    })
+    public Outage getOutage(
+            @Parameter(description = "Scheduled outage name as it appears in `poll-outages.xml`.",
+                    example = "Weekend maintenance", required = true)
+            @PathParam("outageName") String outageName) throws IllegalArgumentException {
         Outage outage = m_pollOutagesDao.getReadOnlyConfig().getOutage(outageName);
         if (outage == null) throw getException(Status.NOT_FOUND, "Scheduled outage {} was not found.", outageName);
         return outage;
@@ -124,6 +197,56 @@ public class ScheduledOutagesRestService extends OnmsRestService {
 
     @POST
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    @Operation(
+            summary = "Add or replace a scheduled outage",
+            description = """
+                    Create a calendar, or replace the existing one with the same `name`. A new calendar answers
+                    201 with a `Location` header; a replacement answers 204.
+                    `type` has to be one of `specific`, `daily`, `weekly` or `monthly`, and the `begins`/`ends`
+                    format depends on it: `dd-MMM-yyyy HH:mm:ss` for `specific`, `HH:mm:ss` for `daily`, `HH:mm:ss`
+                    with a `day` name for `weekly`, and `HH:mm:ss` with a numeric `day` for `monthly`. `type` is
+                    not validated on the way in; an unknown value is accepted into the in-memory configuration and
+                    then fails when the file is marshalled, leaving the invalid calendar in memory until it is
+                    deleted again.
+                    The XML form needs the `http://xmlns.opennms.org/xsd/config/poller/outages` namespace on the
+                    document element.
+                    A saved calendar has no effect until it is attached to a package or to notifd.""",
+            operationId = "saveOrUpdateScheduledOutageV1"
+    )
+    @RequestBody(required = true, description = "The calendar to store.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = Outage.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "name": "Weekend maintenance",
+                      "type": "weekly",
+                      "time": [ { "day": "saturday", "begins": "00:00:00", "ends": "23:59:59" } ],
+                      "interface": [ { "address": "192.0.2.99" } ],
+                      "node": [ { "id": 2 } ]
+                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = Outage.class),
+                            examples = @ExampleObject(value = """
+                    <outage xmlns="http://xmlns.opennms.org/xsd/config/poller/outages"
+                            name="Weekend maintenance" type="weekly">
+                      <time day="saturday" begins="00:00:00" ends="23:59:59"/>
+                      <interface address="192.0.2.99"/>
+                      <node id="2"/>
+                    </outage>"""))
+            })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "A new calendar was added. `Location` points at it."),
+            @ApiResponse(responseCode = "204", description = "An existing calendar with the same name was replaced."),
+            @ApiResponse(responseCode = "400", description = "The body was absent.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Outage object can't be null"))),
+            @ApiResponse(responseCode = "500", description = "The body could not be unmarshalled, or the configuration could not be written.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Can't save or update the scheduled outage Weekend maintenance because, Failed to marshal/unmarshal XML file while marshalling Outages: javax.xml.bind.MarshalException")))
+    })
     public Response saveOrUpdateOutage(@Context final UriInfo uriInfo, final Outage newOutage) {
         writeLock();
         try {
@@ -150,7 +273,30 @@ public class ScheduledOutagesRestService extends OnmsRestService {
 
     @DELETE
     @Path("{outageName}")
-    public Response deleteOutage(@PathParam("outageName") String outageName) {
+    @Operation(
+            summary = "Delete a scheduled outage",
+            description = """
+                    Detach the calendar from every collectd, pollerd and threshd package and from notifd, then
+                    remove it from `poll-outages.xml`. All five configuration files are rewritten.
+                    Because the detach step runs first and validates the name, deleting a calendar that is not
+                    there is a 404 rather than a no-op.""",
+            operationId = "deleteScheduledOutageV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The calendar was deleted."),
+            @ApiResponse(responseCode = "404", description = "No scheduled outage with that name.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Scheduled outage Weekend maintenance was not found."))),
+            @ApiResponse(responseCode = "500", description = "One of the configuration files could not be written.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Can't delete the scheduled outage Weekend maintenance because, java.io.IOException")))
+    })
+    public Response deleteOutage(
+            @Parameter(description = "Scheduled outage name as it appears in `poll-outages.xml`.",
+                    example = "Weekend maintenance", required = true)
+            @PathParam("outageName") String outageName) {
         writeLock();
         try {
             LOG.debug("deleteOutage: deleting outage {}", outageName);
@@ -173,7 +319,33 @@ public class ScheduledOutagesRestService extends OnmsRestService {
 
     @PUT
     @Path("{outageName}/collectd/{packageName}")
-    public Response addOutageToCollector(@PathParam("outageName") String outageName, @PathParam("packageName") String packageName) {
+    @Operation(
+            summary = "Attach a scheduled outage to a collectd package",
+            description = """
+                    Add the calendar to a collectd package's outage-calendar list. The request takes no body and
+                    is idempotent: attaching an already-attached calendar is a 204 and does not duplicate the
+                    entry.
+                    `collectd-configuration.xml` is rewritten and a configuration-changed event is sent.""",
+            operationId = "addScheduledOutageToCollectdV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The configuration was written."),
+            @ApiResponse(responseCode = "404", description = "No such calendar, or no such package.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Collector package example1 does not exist."))),
+            @ApiResponse(responseCode = "500", description = "The configuration could not be written.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Can't save collector's configuration: java.io.IOException")))
+    })
+    public Response addOutageToCollector(
+            @Parameter(description = "Scheduled outage name as it appears in `poll-outages.xml`.",
+                    example = "Weekend maintenance", required = true)
+            @PathParam("outageName") String outageName,
+            @Parameter(description = "Package name as it appears in the daemon's configuration file.",
+                    example = "example1", required = true)
+            @PathParam("packageName") String packageName) {
         writeLock();
         try {
             updateCollectd(ConfigAction.ADD, outageName, packageName);
@@ -186,7 +358,32 @@ public class ScheduledOutagesRestService extends OnmsRestService {
 
     @DELETE
     @Path("{outageName}/collectd/{packageName}")
-    public Response removeOutageFromCollector(@PathParam("outageName") String outageName, @PathParam("packageName") String packageName) {
+    @Operation(
+            summary = "Detach a scheduled outage from a collectd package",
+            description = """
+                    Remove the calendar from a collectd package's outage-calendar list. The request takes no body
+                    and is idempotent: detaching a calendar that is not attached is a 204.
+                    `collectd-configuration.xml` is rewritten and a configuration-changed event is sent.""",
+            operationId = "removeScheduledOutageFromCollectdV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The configuration was written."),
+            @ApiResponse(responseCode = "404", description = "No such calendar, or no such package.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Collector package example1 does not exist."))),
+            @ApiResponse(responseCode = "500", description = "The configuration could not be written.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Can't save collector's configuration: java.io.IOException")))
+    })
+    public Response removeOutageFromCollector(
+            @Parameter(description = "Scheduled outage name as it appears in `poll-outages.xml`.",
+                    example = "Weekend maintenance", required = true)
+            @PathParam("outageName") String outageName,
+            @Parameter(description = "Package name as it appears in the daemon's configuration file.",
+                    example = "example1", required = true)
+            @PathParam("packageName") String packageName) {
         writeLock();
         try {
             updateCollectd(ConfigAction.REMOVE, outageName, packageName);
@@ -199,7 +396,34 @@ public class ScheduledOutagesRestService extends OnmsRestService {
 
     @PUT
     @Path("{outageName}/pollerd/{packageName}")
-    public Response addOutageToPoller(@PathParam("outageName") final String outageName, @PathParam("packageName") final String packageName) {
+    @Operation(
+            summary = "Attach a scheduled outage to a pollerd package",
+            description = """
+                    Add the calendar to a pollerd package's outage-calendar list. The request takes no body and is
+                    idempotent.
+                    While the calendar's window is open, pollerd stops polling the nodes and interfaces the
+                    calendar names in that package. `poller-configuration.xml` is rewritten and a
+                    configuration-changed event is sent.""",
+            operationId = "addScheduledOutageToPollerdV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The configuration was written."),
+            @ApiResponse(responseCode = "404", description = "No such calendar, or no such package.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Poller package example1 does not exist."))),
+            @ApiResponse(responseCode = "500", description = "The configuration could not be written.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Can't save poller's configuration: java.io.IOException")))
+    })
+    public Response addOutageToPoller(
+            @Parameter(description = "Scheduled outage name as it appears in `poll-outages.xml`.",
+                    example = "Weekend maintenance", required = true)
+            @PathParam("outageName") final String outageName,
+            @Parameter(description = "Package name as it appears in the daemon's configuration file.",
+                    example = "example1", required = true)
+            @PathParam("packageName") final String packageName) {
         writeLock();
         try {
             updatePollerd(ConfigAction.ADD, outageName, packageName);
@@ -212,7 +436,32 @@ public class ScheduledOutagesRestService extends OnmsRestService {
 
     @DELETE
     @Path("{outageName}/pollerd/{packageName}")
-    public Response removeOutageFromPoller(@PathParam("outageName") final String outageName, @PathParam("packageName") final String packageName) {
+    @Operation(
+            summary = "Detach a scheduled outage from a pollerd package",
+            description = """
+                    Remove the calendar from a pollerd package's outage-calendar list. The request takes no body
+                    and is idempotent.
+                    `poller-configuration.xml` is rewritten and a configuration-changed event is sent.""",
+            operationId = "removeScheduledOutageFromPollerdV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The configuration was written."),
+            @ApiResponse(responseCode = "404", description = "No such calendar, or no such package.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Poller package example1 does not exist."))),
+            @ApiResponse(responseCode = "500", description = "The configuration could not be written.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Can't save poller's configuration: java.io.IOException")))
+    })
+    public Response removeOutageFromPoller(
+            @Parameter(description = "Scheduled outage name as it appears in `poll-outages.xml`.",
+                    example = "Weekend maintenance", required = true)
+            @PathParam("outageName") final String outageName,
+            @Parameter(description = "Package name as it appears in the daemon's configuration file.",
+                    example = "example1", required = true)
+            @PathParam("packageName") final String packageName) {
         writeLock();
         try {
             updatePollerd(ConfigAction.REMOVE, outageName, packageName);
@@ -225,7 +474,32 @@ public class ScheduledOutagesRestService extends OnmsRestService {
 
     @PUT
     @Path("{outageName}/threshd/{packageName}")
-    public Response addOutageToThresholder(@PathParam("outageName") String outageName, @PathParam("packageName") String packageName) {
+    @Operation(
+            summary = "Attach a scheduled outage to a threshd package",
+            description = """
+                    Add the calendar to a threshd package's outage-calendar list. The request takes no body and is
+                    idempotent.
+                    `threshd-configuration.xml` is rewritten and a configuration-changed event is sent.""",
+            operationId = "addScheduledOutageToThreshdV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The configuration was written."),
+            @ApiResponse(responseCode = "404", description = "No such calendar, or no such package.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Threshold package mib2 does not exist."))),
+            @ApiResponse(responseCode = "500", description = "The configuration could not be written.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Can't save thresholds configuration: java.io.IOException")))
+    })
+    public Response addOutageToThresholder(
+            @Parameter(description = "Scheduled outage name as it appears in `poll-outages.xml`.",
+                    example = "Weekend maintenance", required = true)
+            @PathParam("outageName") String outageName,
+            @Parameter(description = "Package name as it appears in the daemon's configuration file.",
+                    example = "example1", required = true)
+            @PathParam("packageName") String packageName) {
         writeLock();
         try {
             updateThreshd(ConfigAction.ADD, outageName, packageName);
@@ -238,7 +512,31 @@ public class ScheduledOutagesRestService extends OnmsRestService {
 
     @DELETE
     @Path("{outageName}/threshd/{packageName}")
-    public Response removeOutageFromThresholder(@PathParam("outageName") final String outageName, @PathParam("packageName") String packageName) {
+    @Operation(
+            summary = "Detach a scheduled outage from a threshd package",
+            description = """
+                    Remove the calendar from a threshd package's outage-calendar list. The request takes no body
+                    and is idempotent.
+                    `threshd-configuration.xml` is rewritten and a configuration-changed event is sent.
+                    This handler wraps every failure, including the not-found cases, into a 500, so an unknown
+                    calendar or package is reported here as 500 rather than as the 404 the other detach operations
+                    return.""",
+            operationId = "removeScheduledOutageFromThreshdV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The configuration was written."),
+            @ApiResponse(responseCode = "500", description = "No such calendar, no such package, or the configuration could not be written.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Can't delete the scheduled outage Weekend maintenance because, HTTP 404 Not Found")))
+    })
+    public Response removeOutageFromThresholder(
+            @Parameter(description = "Scheduled outage name as it appears in `poll-outages.xml`.",
+                    example = "Weekend maintenance", required = true)
+            @PathParam("outageName") final String outageName,
+            @Parameter(description = "Package name as it appears in the daemon's configuration file.",
+                    example = "example1", required = true)
+            @PathParam("packageName") String packageName) {
         writeLock();
         try {
             updateThreshd(ConfigAction.REMOVE, outageName, packageName);
@@ -253,7 +551,31 @@ public class ScheduledOutagesRestService extends OnmsRestService {
 
     @PUT
     @Path("{outageName}/notifd")
-    public Response addOutageToNotifications(@PathParam("outageName") String outageName) {
+    @Operation(
+            summary = "Attach a scheduled outage to notifd",
+            description = """
+                    Add the calendar to notifd's outage-calendar list, suppressing notifications while its window
+                    is open. The request takes no body.
+                    This one is not idempotent: repeating it appends the name again, and each detach removes only
+                    one occurrence.
+                    `notifd-configuration.xml` is rewritten and a configuration-changed event is sent.""",
+            operationId = "addScheduledOutageToNotifdV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The configuration was written."),
+            @ApiResponse(responseCode = "404", description = "No scheduled outage with that name.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Scheduled outage Weekend maintenance was not found."))),
+            @ApiResponse(responseCode = "500", description = "The configuration could not be written.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Can't save notifications configuration: java.io.IOException")))
+    })
+    public Response addOutageToNotifications(
+            @Parameter(description = "Scheduled outage name as it appears in `poll-outages.xml`.",
+                    example = "Weekend maintenance", required = true)
+            @PathParam("outageName") String outageName) {
         writeLock();
         try {
             updateNotifd(ConfigAction.ADD, outageName);
@@ -266,7 +588,29 @@ public class ScheduledOutagesRestService extends OnmsRestService {
 
     @DELETE
     @Path("{outageName}/notifd")
-    public Response removeOutageFromNotifications(@PathParam("outageName") String outageName) {
+    @Operation(
+            summary = "Detach a scheduled outage from notifd",
+            description = """
+                    Remove one occurrence of the calendar from notifd's outage-calendar list. The request takes no
+                    body and detaching a calendar that is not attached is a 204.
+                    `notifd-configuration.xml` is rewritten and a configuration-changed event is sent.""",
+            operationId = "removeScheduledOutageFromNotifdV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The configuration was written."),
+            @ApiResponse(responseCode = "404", description = "No scheduled outage with that name.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Scheduled outage Weekend maintenance was not found."))),
+            @ApiResponse(responseCode = "500", description = "The configuration could not be written.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Can't save notifications configuration: java.io.IOException")))
+    })
+    public Response removeOutageFromNotifications(
+            @Parameter(description = "Scheduled outage name as it appears in `poll-outages.xml`.",
+                    example = "Weekend maintenance", required = true)
+            @PathParam("outageName") String outageName) {
         writeLock();
         try {
             updateNotifd(ConfigAction.REMOVE, outageName);
@@ -280,7 +624,30 @@ public class ScheduledOutagesRestService extends OnmsRestService {
     @GET
     @Path("{outageName}/nodeInOutage/{nodeId}")
     @Produces(MediaType.TEXT_PLAIN)
-    public String isNodeInOutage(@PathParam("outageName") String outageName, @PathParam("nodeId") Integer nodeId) {
+    @Operation(
+            summary = "Check a node against one scheduled outage",
+            description = """
+                    Return `true` when the calendar names the node and the current time falls inside one of its
+                    windows, and `false` otherwise. The answer is about now, not about a window in general, so a
+                    calendar whose window is in the past always answers `false`.""",
+            operationId = "isNodeInScheduledOutageV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Whether the node is currently in this outage.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string", allowableValues = {"true", "false"}),
+                            examples = @ExampleObject(value = "false"))),
+            @ApiResponse(responseCode = "404", description = "No such calendar, or the node id is not an integer.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Scheduled outage Weekend maintenance was not found.")))
+    })
+    public String isNodeInOutage(
+            @Parameter(description = "Scheduled outage name as it appears in `poll-outages.xml`.",
+                    example = "Weekend maintenance", required = true)
+            @PathParam("outageName") String outageName,
+            @Parameter(description = "Node id.", example = "2", required = true)
+            @PathParam("nodeId") Integer nodeId) {
         Outage outage = getOutage(outageName);
         Boolean inOutage = m_pollOutagesDao.isNodeIdInOutage(nodeId, outage) && m_pollOutagesDao.isCurTimeInOutage(outage);
         return inOutage.toString();
@@ -289,7 +656,22 @@ public class ScheduledOutagesRestService extends OnmsRestService {
     @GET
     @Path("nodeInOutage/{nodeId}")
     @Produces(MediaType.TEXT_PLAIN)
-    public String isNodeInOutage(@PathParam("nodeId") int nodeId) {
+    @Operation(
+            summary = "Check a node against every scheduled outage",
+            description = "Return `true` when any calendar names the node and is currently inside one of its "
+                    + "windows. An unknown node id is not an error and answers `false`.",
+            operationId = "isNodeInAnyScheduledOutageV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Whether the node is currently in any scheduled outage.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string", allowableValues = {"true", "false"}),
+                            examples = @ExampleObject(value = "false"))),
+            @ApiResponse(responseCode = "404", description = "The node id is not an integer.")
+    })
+    public String isNodeInOutage(
+            @Parameter(description = "Node id.", example = "2", required = true)
+            @PathParam("nodeId") int nodeId) {
         for (Outage outage : m_pollOutagesDao.getReadOnlyConfig().getOutages()) {
             if (m_pollOutagesDao.isNodeIdInOutage(nodeId, outage) && m_pollOutagesDao.isCurTimeInOutage(outage)) {
                 return Boolean.TRUE.toString();
@@ -301,7 +683,35 @@ public class ScheduledOutagesRestService extends OnmsRestService {
     @GET
     @Path("{outageName}/interfaceInOutage/{ipAddr}")
     @Produces(MediaType.TEXT_PLAIN)
-    public String isInterfaceInOutage(@PathParam("outageName") String outageName, @PathParam("ipAddr") String ipAddr) {
+    @Operation(
+            summary = "Check an interface against one scheduled outage",
+            description = """
+                    Return `true` when the calendar covers the address and the current time falls inside one of its
+                    windows, and `false` otherwise. The address is checked against the calendar's `interface`
+                    entries, which may be exact addresses or ranges.
+                    The address is validated here, so a malformed one is a 400.""",
+            operationId = "isInterfaceInScheduledOutageV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Whether the interface is currently in this outage.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string", allowableValues = {"true", "false"}),
+                            examples = @ExampleObject(value = "false"))),
+            @ApiResponse(responseCode = "400", description = "The address could not be parsed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Malformed IP Address notanip"))),
+            @ApiResponse(responseCode = "404", description = "No scheduled outage with that name.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Scheduled outage Weekend maintenance was not found.")))
+    })
+    public String isInterfaceInOutage(
+            @Parameter(description = "Scheduled outage name as it appears in `poll-outages.xml`.",
+                    example = "Weekend maintenance", required = true)
+            @PathParam("outageName") String outageName,
+            @Parameter(description = "IPv4 or IPv6 address to test.", example = "192.0.2.99", required = true)
+            @PathParam("ipAddr") String ipAddr) {
         validateAddress(ipAddr);
         Outage outage = getOutage(outageName);
         Boolean inOutage = m_pollOutagesDao.isInterfaceInOutage(ipAddr, outage) && m_pollOutagesDao.isCurTimeInOutage(outage);
@@ -311,7 +721,23 @@ public class ScheduledOutagesRestService extends OnmsRestService {
     @GET
     @Path("interfaceInOutage/{ipAddr}")
     @Produces(MediaType.TEXT_PLAIN)
-    public String isInterfaceInOutage(@PathParam("ipAddr") String ipAddr) {
+    @Operation(
+            summary = "Check an interface against every scheduled outage",
+            description = """
+                    Return `true` when any calendar covers the address and is currently inside one of its windows.
+                    Unlike the calendar-scoped form, this one does not validate the address: a value that is not an
+                    address answers `false` rather than 400.""",
+            operationId = "isInterfaceInAnyScheduledOutageV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Whether the interface is currently in any scheduled outage.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string", allowableValues = {"true", "false"}),
+                            examples = @ExampleObject(value = "false")))
+    })
+    public String isInterfaceInOutage(
+            @Parameter(description = "IPv4 or IPv6 address to test.", example = "192.0.2.99", required = true)
+            @PathParam("ipAddr") String ipAddr) {
         for (Outage outage : m_pollOutagesDao.getReadOnlyConfig().getOutages()) {
             if (m_pollOutagesDao.isInterfaceInOutage(ipAddr, outage) && m_pollOutagesDao.isCurTimeInOutage(outage)) {
                 return Boolean.TRUE.toString();

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ScheduledOutagesRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ScheduledOutagesRestService.java
@@ -93,18 +93,15 @@ import org.springframework.stereotype.Component;
 @Component("scheduledOutagesRestService")
 @Path("sched-outages")
 @Tag(name = "Sched-outages", description = """
-        Scheduled Outages API.
-
         A scheduled outage is a named calendar in `poll-outages.xml` listing time windows plus the nodes and
         interfaces they cover. The calendar has no effect on its own: it has to be attached to a collectd, pollerd
-        or threshd package, or to notifd, through the endpoints below.
+        or threshd package, or to notifd.
 
-        Every write here rewrites the affected configuration file through the JAXB marshaller and then sends
-        `uei.opennms.org/internal/schedOutagesChanged`. The rewrite is semantically faithful but reformats the file
-        and drops its XML comments.
+        Every write rewrites the affected configuration file through the JAXB marshaller, which reformats the file
+        and drops its XML comments, and then sends `uei.opennms.org/internal/schedOutagesChanged`.
 
         A calendar whose window covers the current time suppresses polling, collection, thresholding or
-        notification for whatever it names, so scope test calendars to a window in the past.""")
+        notification for whatever it names.""")
 public class ScheduledOutagesRestService extends OnmsRestService {
 	
 	private static final Logger LOG = LoggerFactory.getLogger(ScheduledOutagesRestService.class);
@@ -129,8 +126,7 @@ public class ScheduledOutagesRestService extends OnmsRestService {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Operation(
             summary = "List scheduled outages",
-            description = "Return every scheduled outage calendar in `poll-outages.xml`. The response says nothing "
-                    + "about which packages or daemons each calendar is attached to.",
+            description = "Return every scheduled outage calendar in `poll-outages.xml`.",
             operationId = "getScheduledOutagesV1"
     )
     @ApiResponses(value = {
@@ -209,8 +205,7 @@ public class ScheduledOutagesRestService extends OnmsRestService {
                     then fails when the file is marshalled, leaving the invalid calendar in memory until it is
                     deleted again.
                     The XML form needs the `http://xmlns.opennms.org/xsd/config/poller/outages` namespace on the
-                    document element.
-                    A saved calendar has no effect until it is attached to a package or to notifd.""",
+                    document element.""",
             operationId = "saveOrUpdateScheduledOutageV1"
     )
     @RequestBody(required = true, description = "The calendar to store.",
@@ -278,8 +273,8 @@ public class ScheduledOutagesRestService extends OnmsRestService {
             description = """
                     Detach the calendar from every collectd, pollerd and threshd package and from notifd, then
                     remove it from `poll-outages.xml`. All five configuration files are rewritten.
-                    Because the detach step runs first and validates the name, deleting a calendar that is not
-                    there is a 404 rather than a no-op.""",
+                    The detach step validates the name first, so deleting a calendar that is not there is a 404
+                    rather than a no-op.""",
             operationId = "deleteScheduledOutageV1"
     )
     @ApiResponses(value = {
@@ -519,8 +514,7 @@ public class ScheduledOutagesRestService extends OnmsRestService {
                     and is idempotent.
                     `threshd-configuration.xml` is rewritten and a configuration-changed event is sent.
                     This handler wraps every failure, including the not-found cases, into a 500, so an unknown
-                    calendar or package is reported here as 500 rather than as the 404 the other detach operations
-                    return.""",
+                    calendar or package is a 500 here rather than the 404 the other detach operations return.""",
             operationId = "removeScheduledOutageFromThreshdV1"
     )
     @ApiResponses(value = {
@@ -628,8 +622,7 @@ public class ScheduledOutagesRestService extends OnmsRestService {
             summary = "Check a node against one scheduled outage",
             description = """
                     Return `true` when the calendar names the node and the current time falls inside one of its
-                    windows, and `false` otherwise. The answer is about now, not about a window in general, so a
-                    calendar whose window is in the past always answers `false`.""",
+                    windows, and `false` otherwise. A calendar whose window is in the past answers `false`.""",
             operationId = "isNodeInScheduledOutageV1"
     )
     @ApiResponses(value = {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ScheduledOutagesRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ScheduledOutagesRestService.java
@@ -178,7 +178,7 @@ public class ScheduledOutagesRestService extends OnmsRestService {
                       "node": [ { "id": 2 } ]
                     }"""))),
             @ApiResponse(responseCode = "404", description = "No scheduled outage with that name.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Scheduled outage Weekend maintenance was not found.")))
     })
@@ -233,12 +233,8 @@ public class ScheduledOutagesRestService extends OnmsRestService {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "A new calendar was added. `Location` points at it."),
             @ApiResponse(responseCode = "204", description = "An existing calendar with the same name was replaced."),
-            @ApiResponse(responseCode = "400", description = "The body was absent.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
-                            schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "Outage object can't be null"))),
-            @ApiResponse(responseCode = "500", description = "The body could not be unmarshalled, or the configuration could not be written.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+            @ApiResponse(responseCode = "500", description = "The body was absent or could not be unmarshalled, or the configuration could not be written. The in-handler null check is unreachable: the providers reject a missing body first.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Can't save or update the scheduled outage Weekend maintenance because, Failed to marshal/unmarshal XML file while marshalling Outages: javax.xml.bind.MarshalException")))
     })
@@ -280,11 +276,11 @@ public class ScheduledOutagesRestService extends OnmsRestService {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "The calendar was deleted."),
             @ApiResponse(responseCode = "404", description = "No scheduled outage with that name.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Scheduled outage Weekend maintenance was not found."))),
             @ApiResponse(responseCode = "500", description = "One of the configuration files could not be written.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Can't delete the scheduled outage Weekend maintenance because, java.io.IOException")))
     })
@@ -326,11 +322,11 @@ public class ScheduledOutagesRestService extends OnmsRestService {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "The configuration was written."),
             @ApiResponse(responseCode = "404", description = "No such calendar, or no such package.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Collector package example1 does not exist."))),
             @ApiResponse(responseCode = "500", description = "The configuration could not be written.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Can't save collector's configuration: java.io.IOException")))
     })
@@ -364,11 +360,11 @@ public class ScheduledOutagesRestService extends OnmsRestService {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "The configuration was written."),
             @ApiResponse(responseCode = "404", description = "No such calendar, or no such package.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Collector package example1 does not exist."))),
             @ApiResponse(responseCode = "500", description = "The configuration could not be written.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Can't save collector's configuration: java.io.IOException")))
     })
@@ -404,11 +400,11 @@ public class ScheduledOutagesRestService extends OnmsRestService {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "The configuration was written."),
             @ApiResponse(responseCode = "404", description = "No such calendar, or no such package.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Poller package example1 does not exist."))),
             @ApiResponse(responseCode = "500", description = "The configuration could not be written.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Can't save poller's configuration: java.io.IOException")))
     })
@@ -442,11 +438,11 @@ public class ScheduledOutagesRestService extends OnmsRestService {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "The configuration was written."),
             @ApiResponse(responseCode = "404", description = "No such calendar, or no such package.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Poller package example1 does not exist."))),
             @ApiResponse(responseCode = "500", description = "The configuration could not be written.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Can't save poller's configuration: java.io.IOException")))
     })
@@ -480,11 +476,11 @@ public class ScheduledOutagesRestService extends OnmsRestService {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "The configuration was written."),
             @ApiResponse(responseCode = "404", description = "No such calendar, or no such package.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Threshold package mib2 does not exist."))),
             @ApiResponse(responseCode = "500", description = "The configuration could not be written.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Can't save thresholds configuration: java.io.IOException")))
     })
@@ -520,7 +516,7 @@ public class ScheduledOutagesRestService extends OnmsRestService {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "The configuration was written."),
             @ApiResponse(responseCode = "500", description = "No such calendar, no such package, or the configuration could not be written.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Can't delete the scheduled outage Weekend maintenance because, HTTP 404 Not Found")))
     })
@@ -558,11 +554,11 @@ public class ScheduledOutagesRestService extends OnmsRestService {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "The configuration was written."),
             @ApiResponse(responseCode = "404", description = "No scheduled outage with that name.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Scheduled outage Weekend maintenance was not found."))),
             @ApiResponse(responseCode = "500", description = "The configuration could not be written.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Can't save notifications configuration: java.io.IOException")))
     })
@@ -593,11 +589,11 @@ public class ScheduledOutagesRestService extends OnmsRestService {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "The configuration was written."),
             @ApiResponse(responseCode = "404", description = "No scheduled outage with that name.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Scheduled outage Weekend maintenance was not found."))),
             @ApiResponse(responseCode = "500", description = "The configuration could not be written.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Can't save notifications configuration: java.io.IOException")))
     })
@@ -695,7 +691,7 @@ public class ScheduledOutagesRestService extends OnmsRestService {
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Malformed IP Address notanip"))),
             @ApiResponse(responseCode = "404", description = "No scheduled outage with that name.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Scheduled outage Weekend maintenance was not found.")))
     })

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/SnmpConfigRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/SnmpConfigRestService.java
@@ -112,13 +112,11 @@ import org.springframework.transaction.annotation.Transactional;
         merged over the file's defaults. It always answers, because every address has a default, so a 200
         does not mean a definition exists for that address.
 
-        `PUT` is an update rather than a create, for the same reason. The address may be a single address or a
-        dash-separated range (`10.1.1.1-10.1.1.20`), in which case the definition is written for the whole
-        range. The factory then merges and optimises the definitions in the file, so the entry that ends up
-        stored is not necessarily the one that was sent.
+        `PUT` takes a single address or a dash-separated range (`10.1.1.1-10.1.1.20`), in which case the
+        definition is written for the whole range. The factory then merges and optimises the definitions in
+        the file, so the entry that ends up stored is not necessarily the one that was sent.
 
-        Writes affect live polling of the addresses they cover. There is no delete: narrowing or removing a
-        definition means editing the configuration directly.""")
+        Writes affect live polling of the addresses they cover. There is no delete operation.""")
 @Transactional
 @Deprecated(forRemoval = true)
 public class SnmpConfigRestService extends OnmsRestService {
@@ -148,12 +146,10 @@ public class SnmpConfigRestService extends OnmsRestService {
         Return the SNMP agent configuration that would be used for one IP address: the most specific matching
         definition in `snmp-config.xml` merged over the file's defaults.
 
-        Every address resolves to something, so this always answers 200 for a parseable address. To tell
-        whether a definition actually exists, compare the result with that of a neighbouring address outside
-        the range.
+        Every address resolves to something, so this always answers 200 for a parseable address.
 
-        `community` and `readCommunity` carry the same value; `community` is the older spelling. Fields the
-        configuration does not set come back null.
+        `community` and `readCommunity` carry the same value. Fields the configuration does not set come back
+        null.
 
         A string that is not a valid IP address fails with 500, not 400.""",
             operationId = "getSnmpInfo"
@@ -214,7 +210,7 @@ public class SnmpConfigRestService extends OnmsRestService {
             @Parameter(description = "Single IP address to resolve. A range is not accepted here.",
                     required = true, example = "192.0.2.10")
             @PathParam("ipAddr") String ipAddr,
-            @Parameter(description = "Monitoring location the configuration should be resolved for. Defaults to the core location.",
+            @Parameter(description = "Monitoring location to resolve the configuration for. Defaults to the core location.",
                     example = "Default")
             @QueryParam("location") String location) {
         final InetAddress addr = InetAddressUtils.addr(ipAddr);
@@ -249,8 +245,7 @@ public class SnmpConfigRestService extends OnmsRestService {
         encoding (`community=public&port=161&...`). The field names are the same in all three.
 
         Values are not validated on the way in. A `version` outside `v1`, `v2c` and `v3` is accepted with 204
-        and only surfaces later, as a validation error on the next `GET` for a covered address, so check the
-        result of a write with a `GET` before relying on it.""",
+        and surfaces only later, as a validation error on the next `GET` for a covered address.""",
             operationId = "setSnmpInfo"
     )
     @RequestBody(

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/SnmpConfigRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/SnmpConfigRestService.java
@@ -35,6 +35,14 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.config.SnmpConfigAccessService;
@@ -96,7 +104,21 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component("snmpConfigRestService")
 @Path("snmpConfig")
-@Tag(name = "SnmpConfig", description = "SNMP Config API")
+@Tag(name = "SnmpConfig", description = """
+        SNMP configuration API over `snmp-config.xml`. Deprecated in favour of the v2 SNMP configuration API
+        and slated for removal.
+
+        `GET` reports the *effective* configuration for one address: the most specific matching definition
+        merged over the file's defaults. It always answers, because every address has a default, so a 200
+        does not mean a definition exists for that address.
+
+        `PUT` is an update rather than a create, for the same reason. The address may be a single address or a
+        dash-separated range (`10.1.1.1-10.1.1.20`), in which case the definition is written for the whole
+        range. The factory then merges and optimises the definitions in the file, so the entry that ends up
+        stored is not necessarily the one that was sent.
+
+        Writes affect live polling of the addresses they cover. There is no delete: narrowing or removing a
+        definition means editing the configuration directly.""")
 @Transactional
 @Deprecated(forRemoval = true)
 public class SnmpConfigRestService extends OnmsRestService {
@@ -120,7 +142,81 @@ public class SnmpConfigRestService extends OnmsRestService {
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Path("{ipAddr}")
-    public SnmpInfo getSnmpInfo(@PathParam("ipAddr") String ipAddr, @QueryParam("location")String location) {
+    @Operation(
+            summary = "Get the effective SNMP configuration for an address",
+            description = """
+        Return the SNMP agent configuration that would be used for one IP address: the most specific matching
+        definition in `snmp-config.xml` merged over the file's defaults.
+
+        Every address resolves to something, so this always answers 200 for a parseable address. To tell
+        whether a definition actually exists, compare the result with that of a neighbouring address outside
+        the range.
+
+        `community` and `readCommunity` carry the same value; `community` is the older spelling. Fields the
+        configuration does not set come back null.
+
+        A string that is not a valid IP address fails with 500, not 400.""",
+            operationId = "getSnmpInfo"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The effective configuration for the address.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = SnmpInfo.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "location": null,
+                      "port": 161,
+                      "version": "v2c",
+                      "contextName": null,
+                      "timeout": 1800,
+                      "retries": 1,
+                      "authPassPhrase": null,
+                      "privPassPhrase": null,
+                      "securityLevel": null,
+                      "authProtocol": null,
+                      "privProtocol": null,
+                      "engineId": null,
+                      "contextEngineId": null,
+                      "enterpriseId": null,
+                      "maxRequestSize": 65535,
+                      "maxVarsPerPdu": 10,
+                      "maxRepetitions": 2,
+                      "ttl": null,
+                      "proxyHost": null,
+                      "securityName": null,
+                      "readCommunity": "public",
+                      "writeCommunity": "private",
+                      "community": "public"
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = SnmpInfo.class),
+                                    examples = @ExampleObject(value = """
+                    <snmp-info>
+                      <community>public</community>
+                      <maxRepetitions>2</maxRepetitions>
+                      <maxRequestSize>65535</maxRequestSize>
+                      <maxVarsPerPdu>10</maxVarsPerPdu>
+                      <port>161</port>
+                      <readCommunity>public</readCommunity>
+                      <retries>1</retries>
+                      <timeout>1800</timeout>
+                      <version>v2c</version>
+                      <writeCommunity>private</writeCommunity>
+                    </snmp-info>"""))
+                    }),
+            @ApiResponse(responseCode = "500", description = "The path segment is not a valid IP address, or a previous write left the configuration unreadable.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Invalid IPAddress not-an-ip")))
+    })
+    public SnmpInfo getSnmpInfo(
+            @Parameter(description = "Single IP address to resolve. A range is not accepted here.",
+                    required = true, example = "192.0.2.10")
+            @PathParam("ipAddr") String ipAddr,
+            @Parameter(description = "Monitoring location the configuration should be resolved for. Defaults to the core location.",
+                    example = "Default")
+            @QueryParam("location") String location) {
         final InetAddress addr = InetAddressUtils.addr(ipAddr);
         if (addr == null) {
             throw getException(Status.BAD_REQUEST, "Malformed IP Address: {}.", ipAddr);
@@ -139,7 +235,64 @@ public class SnmpConfigRestService extends OnmsRestService {
     @PUT
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Path("{ipAddr}")
-    public Response setSnmpInfo(@PathParam("ipAddr") final String ipAddress, final SnmpInfo snmpInfo) {
+    @Operation(
+            summary = "Set the SNMP configuration for an address or range",
+            description = """
+        Write an SNMP definition covering one address, or a dash-separated range such as
+        `10.1.1.1-10.1.1.20`. Only the fields present in the body are set; the rest keep the file's defaults.
+
+        This changes how the addresses are polled, and it takes effect without a restart. The definition is
+        merged into `snmp-config.xml` by the factory, so an address already covered by a wider definition may
+        cause that definition to be split.
+
+        Three body formats are accepted: JSON, XML (`<snmp-info>` with one element per field) and form
+        encoding (`community=public&port=161&...`). The field names are the same in all three.
+
+        Values are not validated on the way in. A `version` outside `v1`, `v2c` and `v3` is accepted with 204
+        and only surfaces later, as a validation error on the next `GET` for a covered address, so check the
+        result of a write with a `GET` before relying on it.""",
+            operationId = "setSnmpInfo"
+    )
+    @RequestBody(
+            required = true,
+            description = "The fields to set. Omitted fields keep the configuration defaults.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = SnmpInfo.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "community": "public",
+                      "port": 161,
+                      "retries": 1,
+                      "timeout": 1800,
+                      "version": "v2c"
+                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = SnmpInfo.class),
+                            examples = @ExampleObject(value = """
+                    <snmp-info>
+                      <community>public</community>
+                      <port>161</port>
+                      <retries>1</retries>
+                      <timeout>1800</timeout>
+                      <version>v2c</version>
+                    </snmp-info>""")),
+                    @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                            schema = @Schema(implementation = SnmpInfo.class),
+                            examples = @ExampleObject(value = "community=public&port=161&retries=1&timeout=1800&version=v2c"))
+            }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The definition was written. This is also the answer for a body containing invalid values."),
+            @ApiResponse(responseCode = "500", description = "The address or range could not be parsed, or the configuration could not be written.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Can't update SNMP configuration for not-an-ip : <cause>")))
+    })
+    public Response setSnmpInfo(
+            @Parameter(description = "Single IP address, or a dash-separated inclusive range such as `10.1.1.1-10.1.1.20`.",
+                    required = true, example = "192.0.2.10-192.0.2.20")
+            @PathParam("ipAddr") final String ipAddress, final SnmpInfo snmpInfo) {
         writeLock();
         try {
             final SnmpEventInfo eventInfo;
@@ -170,6 +323,9 @@ public class SnmpConfigRestService extends OnmsRestService {
     @Path("{ipAddr}")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Transactional
+    // Same path and method as setSnmpInfo, so it would collide in the document; the form-encoded
+    // body is documented as one of that operation's request content types instead.
+    @Operation(hidden = true)
     public Response updateInterface(@PathParam("ipAddr") final String ipAddress, final MultivaluedMapImpl params) {
         writeLock();
         try {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/TimelineRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/TimelineRestService.java
@@ -67,19 +67,18 @@ import org.springframework.transaction.annotation.Transactional;
 @Component("timelineRestService")
 @Path("timeline")
 @Tag(name = "Timeline", description = """
-        Timeline API: server-rendered outage strips for the node and service pages.
+        Server-rendered outage strips.
 
         Every operation takes `start`, `end` and `width` as path segments. **`start` and `end` are epoch
-        seconds, not milliseconds**, which is the usual mistake with these endpoints: passing milliseconds
-        produces a strip covering the year 58000 and no drawn outages.
+        seconds, not milliseconds**: passing milliseconds produces a strip covering the year 58000 with no
+        drawn outages.
 
         `width` is the pixel width of the image; the height is always 20. `width` also divides the time
         range, so it must be at least 1 and the range must be at least `width` seconds wide. Passing 0, or a
         range narrower than the width, fails with 500 on the division.
 
         Three of the four operations return a PNG. `html` returns an `<img>` element plus the client-side
-        image map of the outage rectangles, so the caller can render the same strip with links to the outage
-        detail pages.
+        image map of the outage rectangles.
 
         Query parameters other than the path segments are applied as extra criteria on the outage query, the
         same way as elsewhere in v1.""")
@@ -407,9 +406,8 @@ public class TimelineRestService extends OnmsRestService {
     @Operation(
             summary = "Render the timeline time axis",
             description = """
-        Render the labelled time axis that sits above a row of timeline strips: tick marks and date or time
-        labels for the given window, and nothing else. The label granularity is chosen from the window length
-        and the width, so a wider image gets more labels.
+        Render the labelled time axis: tick marks and date or time labels for the given window. The label
+        granularity is chosen from the window length and the width.
 
         `start` and `end` are epoch seconds.""",
             operationId = "getTimelineHeader"
@@ -469,8 +467,7 @@ public class TimelineRestService extends OnmsRestService {
         client-side image map that turns each drawn outage into a link to its outage detail page. Each `area`
         carries the outage id in its `alt` and the lost-service timestamp in its `title`.
 
-        No image is produced here, only the markup; the browser fetches the PNG separately. A node id that
-        does not exist is not an error: the map simply comes back empty.
+        A node id that does not exist is not an error: the map comes back empty.
 
         `start` and `end` are epoch seconds.""",
             operationId = "getTimelineHtml"
@@ -646,8 +643,8 @@ public class TimelineRestService extends OnmsRestService {
     @Operation(
             summary = "Render an empty timeline strip",
             description = """
-        Render a strip with only the vertical grid lines and no outage or node bar, for use as a placeholder
-        where a service has nothing to show. Nothing is read from the database.
+        Render a strip with only the vertical grid lines and no outage or node bar. Nothing is read from the
+        database.
 
         `start` and `end` are epoch seconds. This operation narrows them to `int` before subtracting, so a
         window that does not fit in a signed 32-bit number of seconds produces a wrong or negative range.""",

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/TimelineRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/TimelineRestService.java
@@ -481,7 +481,7 @@ public class TimelineRestService extends OnmsRestService {
             @ApiResponse(responseCode = "404", description = "A numeric path segment was not a number.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"))),
-            @ApiResponse(responseCode = "500", description = "`width` was 0, or the window was narrower than `width` seconds.",
+            @ApiResponse(responseCode = "500", description = "`width` was 0, or the window was narrower than `width` seconds while at least one outage fell in it; with no outage in the window the division is never reached and the response is 200.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string")))
     })

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/TimelineRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/TimelineRestService.java
@@ -40,9 +40,17 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.core.criteria.restrictions.Restrictions;
@@ -58,7 +66,23 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Component("timelineRestService")
 @Path("timeline")
-@Tag(name = "Timeline", description = "Timeline API")
+@Tag(name = "Timeline", description = """
+        Timeline API: server-rendered outage strips for the node and service pages.
+
+        Every operation takes `start`, `end` and `width` as path segments. **`start` and `end` are epoch
+        seconds, not milliseconds**, which is the usual mistake with these endpoints: passing milliseconds
+        produces a strip covering the year 58000 and no drawn outages.
+
+        `width` is the pixel width of the image; the height is always 20. `width` also divides the time
+        range, so it must be at least 1 and the range must be at least `width` seconds wide. Passing 0, or a
+        range narrower than the width, fails with 500 on the division.
+
+        Three of the four operations return a PNG. `html` returns an `<img>` element plus the client-side
+        image map of the outage rectangles, so the caller can render the same strip with links to the outage
+        detail pages.
+
+        Query parameters other than the path segments are applied as extra criteria on the outage query, the
+        same way as elsewhere in v1.""")
 public class TimelineRestService extends OnmsRestService {
 
     private static class TimescaleDescriptor {
@@ -380,7 +404,35 @@ public class TimelineRestService extends OnmsRestService {
     @Produces("image/png")
     @Transactional
     @Path("header/{start}/{end}/{width}")
-    public Response header(@PathParam("start") final long start, @PathParam("end") final long end, @PathParam("width") final int width) throws IOException {
+    @Operation(
+            summary = "Render the timeline time axis",
+            description = """
+        Render the labelled time axis that sits above a row of timeline strips: tick marks and date or time
+        labels for the given window, and nothing else. The label granularity is chosen from the window length
+        and the width, so a wider image gets more labels.
+
+        `start` and `end` are epoch seconds.""",
+            operationId = "getTimelineHeader"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "A 20-pixel-high PNG of the time axis.",
+                    content = @Content(mediaType = "image/png",
+                            schema = @Schema(type = "string", format = "binary"))),
+            @ApiResponse(responseCode = "404", description = "A path segment was not a number.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"))),
+            @ApiResponse(responseCode = "500", description = "`width` was 0, or the window was narrower than `width` seconds.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string")))
+    })
+    public Response header(
+            @Parameter(description = "Start of the window, in epoch **seconds**.", required = true, example = "1787011200")
+            @PathParam("start") final long start,
+            @Parameter(description = "End of the window, in epoch **seconds**. Must be at least `width` seconds after `start`.",
+                    required = true, example = "1787097600")
+            @PathParam("end") final long end,
+            @Parameter(description = "Image width in pixels. Must be at least 1.", required = true, example = "800")
+            @PathParam("width") final int width) throws IOException {
         long delta = end - start;
 
         BufferedImage bufferedImage = new BufferedImage(width, 20, BufferedImage.TYPE_INT_ARGB);
@@ -410,7 +462,47 @@ public class TimelineRestService extends OnmsRestService {
     @Produces("text/html")
     @Transactional
     @Path("html/{nodeId}/{ipAddress}/{serviceId}/{start}/{end}/{width}")
-    public Response html(@Context final UriInfo uriInfo, @PathParam("nodeId") final int nodeId, @PathParam("ipAddress") final String ipAddress, @PathParam("serviceId") final int serviceId, @PathParam("start") final long start, @PathParam("end") final long end, @PathParam("width") final int width) throws IOException {
+    @Operation(
+            summary = "Render the HTML wrapper and image map for a service timeline",
+            description = """
+        Return an `<img>` element pointing at the matching `timeline/image/...` URL, together with the
+        client-side image map that turns each drawn outage into a link to its outage detail page. Each `area`
+        carries the outage id in its `alt` and the lost-service timestamp in its `title`.
+
+        No image is produced here, only the markup; the browser fetches the PNG separately. A node id that
+        does not exist is not an error: the map simply comes back empty.
+
+        `start` and `end` are epoch seconds.""",
+            operationId = "getTimelineHtml"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The `<img>` element and its image map. The map is empty when no outage falls in the window.",
+                    content = @Content(mediaType = MediaType.TEXT_HTML,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = """
+                    <img src="/opennms/rest/timeline/image/1/127.0.0.4/2/1787011200/1787097600/800" usemap="#1-127.0.0.4-2"><map name="1-127.0.0.4-2"><area shape="rect" coords="585,2,586,18" href="/opennms/outage/detail.htm?id=3543" alt="Id 3543" title="2026-08-18 13:34:47.697"></map>"""))),
+            @ApiResponse(responseCode = "404", description = "A numeric path segment was not a number.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"))),
+            @ApiResponse(responseCode = "500", description = "`width` was 0, or the window was narrower than `width` seconds.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string")))
+    })
+    public Response html(@Context final UriInfo uriInfo,
+            @Parameter(description = "Database id of the node.", required = true, example = "1")
+            @PathParam("nodeId") final int nodeId,
+            @Parameter(description = "IP address of the interface the service runs on.", required = true, example = "127.0.0.4")
+            @PathParam("ipAddress") final String ipAddress,
+            @Parameter(description = "Service type id from the `service` table, not the monitored-service id.",
+                    required = true, example = "2")
+            @PathParam("serviceId") final int serviceId,
+            @Parameter(description = "Start of the window, in epoch **seconds**.", required = true, example = "1787011200")
+            @PathParam("start") final long start,
+            @Parameter(description = "End of the window, in epoch **seconds**. Must be at least `width` seconds after `start`.",
+                    required = true, example = "1787097600")
+            @PathParam("end") final long end,
+            @Parameter(description = "Image width in pixels. Must be at least 1.", required = true, example = "800")
+            @PathParam("width") final int width) throws IOException {
         long delta = end - start;
 
         OnmsOutageCollection onmsOutageCollection = queryOutages(uriInfo, nodeId, ipAddress, serviceId, start, end);
@@ -472,7 +564,46 @@ public class TimelineRestService extends OnmsRestService {
     @Produces("image/png")
     @Transactional
     @Path("image/{nodeId}/{ipAddress}/{serviceId}/{start}/{end}/{width}")
-    public Response image(@Context final UriInfo uriInfo, @PathParam("nodeId") final int nodeId, @PathParam("ipAddress") final String ipAddress, @PathParam("serviceId") final int serviceId, @PathParam("start") final long start, @PathParam("end") final long end, @PathParam("width") final int width) throws IOException {
+    @Operation(
+            summary = "Render the outage strip for one monitored service",
+            description = """
+        Render a 20-pixel-high strip for one monitored service over the window: a green bar from the node's
+        creation time onward, red blocks for the outages that overlap the window, and the vertical grid lines.
+        An outage that has not been resolved is drawn to the right-hand edge.
+
+        The service is addressed by node id, interface IP address and service type id. Only outages with no
+        perspective (that is, from the core poller rather than a remote perspective) are drawn.
+
+        An unknown node id fails with 500, because the node is drawn before it is checked. `start` and `end`
+        are epoch seconds.""",
+            operationId = "getTimelineImage"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "A 20-pixel-high PNG of the outage strip.",
+                    content = @Content(mediaType = "image/png",
+                            schema = @Schema(type = "string", format = "binary"))),
+            @ApiResponse(responseCode = "404", description = "A numeric path segment was not a number.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"))),
+            @ApiResponse(responseCode = "500", description = "The node does not exist, `width` was 0, or the window was narrower than `width` seconds.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string")))
+    })
+    public Response image(@Context final UriInfo uriInfo,
+            @Parameter(description = "Database id of the node.", required = true, example = "1")
+            @PathParam("nodeId") final int nodeId,
+            @Parameter(description = "IP address of the interface the service runs on.", required = true, example = "127.0.0.4")
+            @PathParam("ipAddress") final String ipAddress,
+            @Parameter(description = "Service type id from the `service` table, not the monitored-service id.",
+                    required = true, example = "2")
+            @PathParam("serviceId") final int serviceId,
+            @Parameter(description = "Start of the window, in epoch **seconds**.", required = true, example = "1787011200")
+            @PathParam("start") final long start,
+            @Parameter(description = "End of the window, in epoch **seconds**. Must be at least `width` seconds after `start`.",
+                    required = true, example = "1787097600")
+            @PathParam("end") final long end,
+            @Parameter(description = "Image width in pixels. Must be at least 1.", required = true, example = "800")
+            @PathParam("width") final int width) throws IOException {
         long delta = end - start;
 
         OnmsOutageCollection onmsOutageCollection = queryOutages(uriInfo, nodeId, ipAddress, serviceId, start, end);
@@ -512,7 +643,35 @@ public class TimelineRestService extends OnmsRestService {
     @Produces("image/png")
     @Transactional
     @Path("empty/{start}/{end}/{width}")
-    public Response empty(@PathParam("start") final long start, @PathParam("end") final long end, @PathParam("width") final int width) throws IOException {
+    @Operation(
+            summary = "Render an empty timeline strip",
+            description = """
+        Render a strip with only the vertical grid lines and no outage or node bar, for use as a placeholder
+        where a service has nothing to show. Nothing is read from the database.
+
+        `start` and `end` are epoch seconds. This operation narrows them to `int` before subtracting, so a
+        window that does not fit in a signed 32-bit number of seconds produces a wrong or negative range.""",
+            operationId = "getTimelineEmpty"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "A 20-pixel-high PNG containing only grid lines.",
+                    content = @Content(mediaType = "image/png",
+                            schema = @Schema(type = "string", format = "binary"))),
+            @ApiResponse(responseCode = "404", description = "A path segment was not a number.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"))),
+            @ApiResponse(responseCode = "500", description = "`width` was 0, or the window was narrower than `width` seconds.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string")))
+    })
+    public Response empty(
+            @Parameter(description = "Start of the window, in epoch **seconds**.", required = true, example = "1787011200")
+            @PathParam("start") final long start,
+            @Parameter(description = "End of the window, in epoch **seconds**. Must be at least `width` seconds after `start`.",
+                    required = true, example = "1787097600")
+            @PathParam("end") final long end,
+            @Parameter(description = "Image width in pixels. Must be at least 1.", required = true, example = "800")
+            @PathParam("width") final int width) throws IOException {
         int delta = (int) end - (int) start;
 
         BufferedImage bufferedImage = new BufferedImage(width, 20, BufferedImage.TYPE_INT_ARGB);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/UserRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/UserRestService.java
@@ -149,8 +149,8 @@ public class UserRestService extends OnmsRestService {
             description = """
                     Return the `users.xml` entry for the authenticated principal. `password` and `passwordSalt`
                     are stripped from the response, so they are absent rather than masked.
-                    An authenticated principal that has no `users.xml` entry (a Spring Security or LDAP-only
-                    login, for instance) yields an empty body with status 204.""",
+                    An authenticated principal that has no `users.xml` entry yields an empty body with status
+                    204.""",
             operationId = "getAuthenticatedUserV1"
     )
     @ApiResponses(value = {
@@ -223,8 +223,8 @@ public class UserRestService extends OnmsRestService {
             description = """
                     Create a user from an XML `<user>` document. Only `application/xml` is consumed; a JSON body is
                     rejected with 415.
-                    Posting a `user-id` that already exists overwrites that entry rather than failing, so this is a
-                    replace as much as a create. `password` has to be present: a body without one fails with 500.
+                    Posting a `user-id` that already exists overwrites that entry rather than failing. `password`
+                    has to be present: a body without one fails with 500.
                     The response carries no entity; the new user's URI is in the `Location` header.""",
             operationId = "addUserV1"
     )

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/UserRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/UserRestService.java
@@ -129,7 +129,7 @@ public class UserRestService extends OnmsRestService {
                       ]
                     }"""))),
             @ApiResponse(responseCode = "500", description = "The user configuration could not be read.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "java.io.FileNotFoundException: users.xml")))
     })
@@ -149,8 +149,8 @@ public class UserRestService extends OnmsRestService {
             description = """
                     Return the `users.xml` entry for the authenticated principal. `password` and `passwordSalt`
                     are stripped from the response, so they are absent rather than masked.
-                    An authenticated principal that has no `users.xml` entry yields an empty body with status
-                    204.""",
+                    An authenticated principal that has no `users.xml` entry is answered with 404
+                    `User <name> does not exist.` before the handler's own null check runs.""",
             operationId = "getAuthenticatedUserV1"
     )
     @ApiResponses(value = {
@@ -166,7 +166,10 @@ public class UserRestService extends OnmsRestService {
                       "duty-schedule": [],
                       "role": [ "ROLE_ADMIN" ]
                     }"""))),
-            @ApiResponse(responseCode = "204", description = "The authenticated principal has no `users.xml` entry.")
+            @ApiResponse(responseCode = "404", description = "The authenticated principal has no `users.xml` entry.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User admin does not exist.")))
     })
     public OnmsUser whoami(@Context final SecurityContext securityContext) {
         final String userName = securityContext.getUserPrincipal().getName();
@@ -205,7 +208,7 @@ public class UserRestService extends OnmsRestService {
                       "role": [ "ROLE_ADMIN" ]
                     }"""))),
             @ApiResponse(responseCode = "404", description = "No such user.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "User jroe does not exist.")))
     })
@@ -244,12 +247,12 @@ public class UserRestService extends OnmsRestService {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "User stored. `Location` points at the new user."),
             @ApiResponse(responseCode = "400", description = "The caller does not hold `ROLE_ADMIN`.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "User jroe does not have write access to users!"))),
             @ApiResponse(responseCode = "415", description = "The body was not `application/xml`."),
             @ApiResponse(responseCode = "500", description = "The body could not be unmarshalled, or the user could not be saved.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "'password' cannot be null!")))
     })
@@ -295,15 +298,15 @@ public class UserRestService extends OnmsRestService {
             @ApiResponse(responseCode = "204", description = "The user was updated."),
             @ApiResponse(responseCode = "304", description = "No supplied key matched a writable property, so nothing was written."),
             @ApiResponse(responseCode = "400", description = "The caller does not hold `ROLE_ADMIN`.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "User jroe does not have write access to users!"))),
             @ApiResponse(responseCode = "404", description = "No such user.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "User jroe does not exist."))),
             @ApiResponse(responseCode = "500", description = "The user could not be saved.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "java.io.IOException: users.xml is not writable")))
     })
@@ -364,15 +367,15 @@ public class UserRestService extends OnmsRestService {
             @ApiResponse(responseCode = "204", description = "The role was added."),
             @ApiResponse(responseCode = "304", description = "The user already held the role."),
             @ApiResponse(responseCode = "400", description = "Unknown role name, or the caller does not hold `ROLE_ADMIN`.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Invalid role ROLE_BOGUS!"))),
             @ApiResponse(responseCode = "404", description = "No such user.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "User jroe does not exist."))),
             @ApiResponse(responseCode = "500", description = "The user could not be saved.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "java.io.IOException: users.xml is not writable")))
     })
@@ -380,10 +383,7 @@ public class UserRestService extends OnmsRestService {
             @Parameter(description = "User name as it appears in `users.xml`.", example = "jroe", required = true)
             @PathParam("userCriteria") final String userCriteria,
             @Parameter(description = "Security role to grant.", example = "ROLE_PROVISION", required = true,
-                    schema = @Schema(type = "string", allowableValues = {"ROLE_USER", "ROLE_ADMIN", "ROLE_READONLY", "ROLE_DASHBOARD", "ROLE_DELEGATE", "ROLE_RTC",
-                            "ROLE_PROVISION", "ROLE_REST", "ROLE_ASSET_EDITOR", "ROLE_FILESYSTEM_EDITOR",
-                            "ROLE_MOBILE", "ROLE_JMX", "ROLE_MINION", "ROLE_REPORT_DESIGNER",
-                            "ROLE_FLOW_MANAGER", "ROLE_DEVICE_CONFIG_BACKUP"}))
+                    schema = @Schema(type = "string"))
             @PathParam("roleName") final String roleName) {
         writeLock();
         try {
@@ -426,15 +426,15 @@ public class UserRestService extends OnmsRestService {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "The user was deleted."),
             @ApiResponse(responseCode = "400", description = "The caller does not hold `ROLE_ADMIN`.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "User jroe does not have write access to users!"))),
             @ApiResponse(responseCode = "404", description = "No such user.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "User jroe does not exist."))),
             @ApiResponse(responseCode = "500", description = "The user could not be removed.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "java.io.IOException: users.xml is not writable")))
     })
@@ -471,15 +471,15 @@ public class UserRestService extends OnmsRestService {
             @ApiResponse(responseCode = "204", description = "The role was removed."),
             @ApiResponse(responseCode = "304", description = "The user did not hold the role."),
             @ApiResponse(responseCode = "400", description = "Unknown role name, or the caller does not hold `ROLE_ADMIN`.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Invalid role ROLE_BOGUS!"))),
             @ApiResponse(responseCode = "404", description = "No such user.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "User jroe does not exist."))),
             @ApiResponse(responseCode = "500", description = "The user could not be saved.",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "java.io.IOException: users.xml is not writable")))
     })
@@ -487,10 +487,7 @@ public class UserRestService extends OnmsRestService {
             @Parameter(description = "User name as it appears in `users.xml`.", example = "jroe", required = true)
             @PathParam("userCriteria") final String userCriteria,
             @Parameter(description = "Security role to revoke.", example = "ROLE_PROVISION", required = true,
-                    schema = @Schema(type = "string", allowableValues = {"ROLE_USER", "ROLE_ADMIN", "ROLE_READONLY", "ROLE_DASHBOARD", "ROLE_DELEGATE", "ROLE_RTC",
-                            "ROLE_PROVISION", "ROLE_REST", "ROLE_ASSET_EDITOR", "ROLE_FILESYSTEM_EDITOR",
-                            "ROLE_MOBILE", "ROLE_JMX", "ROLE_MINION", "ROLE_REPORT_DESIGNER",
-                            "ROLE_FLOW_MANAGER", "ROLE_DEVICE_CONFIG_BACKUP"}))
+                    schema = @Schema(type = "string"))
             @PathParam("roleName") final String roleName) {
         writeLock();
         try {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/UserRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/UserRestService.java
@@ -41,8 +41,17 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.netmgt.config.UserManager;
+import org.opennms.web.rest.v1.model.UserUpdateForm;
 import org.opennms.netmgt.model.OnmsUser;
 import org.opennms.netmgt.model.OnmsUserList;
 import org.opennms.web.api.Authentication;
@@ -78,6 +87,52 @@ public class UserRestService extends OnmsRestService {
 
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "List users",
+            description = """
+                    Return every user defined in `users.xml`, sorted by user name. The list is not paged and
+                    ignores query parameters.
+                    A caller without `ROLE_ADMIN` sees the literal `xxxxxxxx` in place of every password hash
+                    except their own.""",
+            operationId = "getUsersV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The configured users.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsUserList.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 2,
+                      "count": 2,
+                      "offset": 0,
+                      "user": [
+                        {
+                              "user-id": "admin",
+                              "full-name": "Administrator",
+                              "user-comments": "Default administrator, do not delete",
+                              "email": "",
+                              "password": "gU2wmSW7k9v1xg4/MrAsaI+VyddBAhJJt4zPX5SGG0BK+qiASGnJsqM8JOug/aEL",
+                              "passwordSalt": true,
+                              "duty-schedule": [],
+                              "role": [ "ROLE_ADMIN" ]
+                            },
+                        {
+                          "user-id": "rtc",
+                          "full-name": "RTC",
+                          "user-comments": "RTC user, do not delete",
+                          "email": "",
+                          "password": "sHMy+HycWKGJC/uUMF0IGlXUXP1KhcqD0GEchFlvYTw40jT9r+zMxOb3F+phWNzX",
+                          "passwordSalt": true,
+                          "duty-schedule": [],
+                          "role": [ "ROLE_RTC" ]
+                        }
+                      ]
+                    }"""))),
+            @ApiResponse(responseCode = "500", description = "The user configuration could not be read.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "java.io.FileNotFoundException: users.xml")))
+    })
     public OnmsUserList getUsers(@Context final SecurityContext securityContext) {
         try {
             return filterUserPasswords(securityContext, m_userManager.getOnmsUserList());
@@ -89,6 +144,30 @@ public class UserRestService extends OnmsRestService {
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Path("whoami")
+    @Operation(
+            summary = "Get the authenticated user",
+            description = """
+                    Return the `users.xml` entry for the authenticated principal. `password` and `passwordSalt`
+                    are stripped from the response, so they are absent rather than masked.
+                    An authenticated principal that has no `users.xml` entry (a Spring Security or LDAP-only
+                    login, for instance) yields an empty body with status 204.""",
+            operationId = "getAuthenticatedUserV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The authenticated user, without password fields.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsUser.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "user-id": "admin",
+                      "full-name": "Administrator",
+                      "user-comments": "Default administrator, do not delete",
+                      "email": "",
+                      "duty-schedule": [],
+                      "role": [ "ROLE_ADMIN" ]
+                    }"""))),
+            @ApiResponse(responseCode = "204", description = "The authenticated principal has no `users.xml` entry.")
+    })
     public OnmsUser whoami(@Context final SecurityContext securityContext) {
         final String userName = securityContext.getUserPrincipal().getName();
         final OnmsUser user = getOnmsUser(userName);
@@ -103,14 +182,80 @@ public class UserRestService extends OnmsRestService {
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Path("{username}")
-    public OnmsUser getUser(@Context final SecurityContext securityContext, @PathParam("username") final String username) {
+    @Operation(
+            summary = "Get a user",
+            description = """
+                    Return one user by name. A caller without `ROLE_ADMIN` asking for somebody else sees the
+                    literal `xxxxxxxx` in place of the password hash.""",
+            operationId = "getUserByNameV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The user.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsUser.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "user-id": "admin",
+                      "full-name": "Administrator",
+                      "user-comments": "Default administrator, do not delete",
+                      "email": "",
+                      "password": "gU2wmSW7k9v1xg4/MrAsaI+VyddBAhJJt4zPX5SGG0BK+qiASGnJsqM8JOug/aEL",
+                      "passwordSalt": true,
+                      "duty-schedule": [],
+                      "role": [ "ROLE_ADMIN" ]
+                    }"""))),
+            @ApiResponse(responseCode = "404", description = "No such user.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User jroe does not exist.")))
+    })
+    public OnmsUser getUser(@Context final SecurityContext securityContext,
+            @Parameter(description = "User name as it appears in `users.xml`.", example = "admin", required = true)
+            @PathParam("username") final String username) {
         final OnmsUser user = getOnmsUser(username);
         return filterUserPassword(securityContext, user);
     }
 
     @POST
     @Consumes(MediaType.APPLICATION_XML)
-    public Response addUser(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo, final OnmsUser user, @QueryParam("hashPassword") final boolean hashPassword) {
+    @Operation(
+            summary = "Add or replace a user",
+            description = """
+                    Create a user from an XML `<user>` document. Only `application/xml` is consumed; a JSON body is
+                    rejected with 415.
+                    Posting a `user-id` that already exists overwrites that entry rather than failing, so this is a
+                    replace as much as a create. `password` has to be present: a body without one fails with 500.
+                    The response carries no entity; the new user's URI is in the `Location` header.""",
+            operationId = "addUserV1"
+    )
+    @RequestBody(required = true, description = "The user to store.",
+            content = @Content(mediaType = MediaType.APPLICATION_XML,
+                    schema = @Schema(implementation = OnmsUser.class),
+                    examples = @ExampleObject(value = """
+                    <user>
+                      <user-id>jroe</user-id>
+                      <full-name>Jane Roe</full-name>
+                      <user-comments>On call for the NOC</user-comments>
+                      <email>jane.roe@example.org</email>
+                      <password>s3cret</password>
+                      <duty-schedule>MoTuWeThFr800-1700</duty-schedule>
+                      <role>ROLE_USER</role>
+                    </user>""")))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "User stored. `Location` points at the new user."),
+            @ApiResponse(responseCode = "400", description = "The caller does not hold `ROLE_ADMIN`.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User jroe does not have write access to users!"))),
+            @ApiResponse(responseCode = "415", description = "The body was not `application/xml`."),
+            @ApiResponse(responseCode = "500", description = "The body could not be unmarshalled, or the user could not be saved.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "'password' cannot be null!")))
+    })
+    public Response addUser(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo, final OnmsUser user,
+            @Parameter(description = "Hash and salt the supplied password before storing it.", example = "true")
+            @QueryParam("hashPassword") final boolean hashPassword) {
         writeLock();
         try {
             if (!hasEditRights(securityContext)) {
@@ -132,7 +277,39 @@ public class UserRestService extends OnmsRestService {
     @PUT
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("{userCriteria}")
-    public Response updateUser(@Context final SecurityContext securityContext, @PathParam("userCriteria") final String userCriteria, final MultivaluedMapImpl params) {
+    @Operation(
+            summary = "Update a user",
+            description = """
+                    Apply form-encoded fields to an existing user. Keys are matched against the writable
+                    `OnmsUser` bean properties, so they are `fullName` and `comments` rather than the `full-name`
+                    and `user-comments` spellings the read endpoints emit. A key that matches no writable property
+                    is skipped, and a request that wrote nothing comes back as 304.
+                    `password` is stored verbatim unless `hashPassword=true` is sent in the same request.""",
+            operationId = "updateUserV1"
+    )
+    @RequestBody(required = true, description = "Fields to apply.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(implementation = UserUpdateForm.class),
+                    examples = @ExampleObject(value = "fullName=Jane+Roe&comments=On+call+for+the+NOC&email=jane.roe@example.org")))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The user was updated."),
+            @ApiResponse(responseCode = "304", description = "No supplied key matched a writable property, so nothing was written."),
+            @ApiResponse(responseCode = "400", description = "The caller does not hold `ROLE_ADMIN`.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User jroe does not have write access to users!"))),
+            @ApiResponse(responseCode = "404", description = "No such user.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User jroe does not exist."))),
+            @ApiResponse(responseCode = "500", description = "The user could not be saved.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "java.io.IOException: users.xml is not writable")))
+    })
+    public Response updateUser(@Context final SecurityContext securityContext,
+            @Parameter(description = "User name as it appears in `users.xml`.", example = "jroe", required = true)
+            @PathParam("userCriteria") final String userCriteria, final MultivaluedMapImpl params) {
         writeLock();
         try {
             if (!hasEditRights(securityContext)) {
@@ -175,7 +352,39 @@ public class UserRestService extends OnmsRestService {
 
     @PUT
     @Path("{userCriteria}/roles/{roleName}")
-    public Response addRole(@Context final SecurityContext securityContext, @PathParam("userCriteria") final String userCriteria, @PathParam("roleName") final String roleName) {
+    @Operation(
+            summary = "Grant a role to a user",
+            description = """
+                    Add one security role to a user. The role has to be a known role name, either one of the
+                    built-in `ROLE_*` constants or one declared in `etc/security-roles.properties`.
+                    The request takes no body.""",
+            operationId = "addUserRoleV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The role was added."),
+            @ApiResponse(responseCode = "304", description = "The user already held the role."),
+            @ApiResponse(responseCode = "400", description = "Unknown role name, or the caller does not hold `ROLE_ADMIN`.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Invalid role ROLE_BOGUS!"))),
+            @ApiResponse(responseCode = "404", description = "No such user.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User jroe does not exist."))),
+            @ApiResponse(responseCode = "500", description = "The user could not be saved.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "java.io.IOException: users.xml is not writable")))
+    })
+    public Response addRole(@Context final SecurityContext securityContext,
+            @Parameter(description = "User name as it appears in `users.xml`.", example = "jroe", required = true)
+            @PathParam("userCriteria") final String userCriteria,
+            @Parameter(description = "Security role to grant.", example = "ROLE_PROVISION", required = true,
+                    schema = @Schema(type = "string", allowableValues = {"ROLE_USER", "ROLE_ADMIN", "ROLE_READONLY", "ROLE_DASHBOARD", "ROLE_DELEGATE", "ROLE_RTC",
+                            "ROLE_PROVISION", "ROLE_REST", "ROLE_ASSET_EDITOR", "ROLE_FILESYSTEM_EDITOR",
+                            "ROLE_MOBILE", "ROLE_JMX", "ROLE_MINION", "ROLE_REPORT_DESIGNER",
+                            "ROLE_FLOW_MANAGER", "ROLE_DEVICE_CONFIG_BACKUP"}))
+            @PathParam("roleName") final String roleName) {
         writeLock();
         try {
             if (!hasEditRights(securityContext)) {
@@ -208,7 +417,30 @@ public class UserRestService extends OnmsRestService {
 
     @DELETE
     @Path("{userCriteria}")
-    public Response deleteUser(@Context final SecurityContext securityContext, @PathParam("userCriteria") final String userCriteria) {
+    @Operation(
+            summary = "Delete a user",
+            description = "Remove a user from `users.xml`. Group memberships and acknowledgements that name the "
+                    + "user are left alone.",
+            operationId = "deleteUserV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The user was deleted."),
+            @ApiResponse(responseCode = "400", description = "The caller does not hold `ROLE_ADMIN`.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User jroe does not have write access to users!"))),
+            @ApiResponse(responseCode = "404", description = "No such user.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User jroe does not exist."))),
+            @ApiResponse(responseCode = "500", description = "The user could not be removed.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "java.io.IOException: users.xml is not writable")))
+    })
+    public Response deleteUser(@Context final SecurityContext securityContext,
+            @Parameter(description = "User name as it appears in `users.xml`.", example = "jroe", required = true)
+            @PathParam("userCriteria") final String userCriteria) {
         writeLock();
         try {
             if (!hasEditRights(securityContext)) {
@@ -229,7 +461,37 @@ public class UserRestService extends OnmsRestService {
 
     @DELETE
     @Path("{userCriteria}/roles/{roleName}")
-    public Response deleteRole(@Context final SecurityContext securityContext, @PathParam("userCriteria") final String userCriteria, @PathParam("roleName") final String roleName) {
+    @Operation(
+            summary = "Revoke a role from a user",
+            description = "Remove one security role from a user. The role has to be a known role name even when "
+                    + "the user does not hold it.",
+            operationId = "deleteUserRoleV1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "The role was removed."),
+            @ApiResponse(responseCode = "304", description = "The user did not hold the role."),
+            @ApiResponse(responseCode = "400", description = "Unknown role name, or the caller does not hold `ROLE_ADMIN`.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Invalid role ROLE_BOGUS!"))),
+            @ApiResponse(responseCode = "404", description = "No such user.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User jroe does not exist."))),
+            @ApiResponse(responseCode = "500", description = "The user could not be saved.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "java.io.IOException: users.xml is not writable")))
+    })
+    public Response deleteRole(@Context final SecurityContext securityContext,
+            @Parameter(description = "User name as it appears in `users.xml`.", example = "jroe", required = true)
+            @PathParam("userCriteria") final String userCriteria,
+            @Parameter(description = "Security role to revoke.", example = "ROLE_PROVISION", required = true,
+                    schema = @Schema(type = "string", allowableValues = {"ROLE_USER", "ROLE_ADMIN", "ROLE_READONLY", "ROLE_DASHBOARD", "ROLE_DELEGATE", "ROLE_RTC",
+                            "ROLE_PROVISION", "ROLE_REST", "ROLE_ASSET_EDITOR", "ROLE_FILESYSTEM_EDITOR",
+                            "ROLE_MOBILE", "ROLE_JMX", "ROLE_MINION", "ROLE_REPORT_DESIGNER",
+                            "ROLE_FLOW_MANAGER", "ROLE_DEVICE_CONFIG_BACKUP"}))
+            @PathParam("roleName") final String roleName) {
         writeLock();
         try {
             if (!hasEditRights(securityContext)) {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/WebAssetsRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/WebAssetsRestService.java
@@ -66,11 +66,7 @@ import org.springframework.util.FileCopyUtils;
         web UI loads, addressed by the logical asset name the build assigned them.
 
         An asset name usually maps to more than one file, one per type: `opennms` covers both `opennms.css`
-        and `opennms.min.js`. The listing operations report that mapping; the third operation serves the file
-        itself.
-
-        These endpoints exist for the UI's own use, and the asset names are a build artefact rather than a
-        stable interface.""")
+        and `opennms.min.js`.""")
 public class WebAssetsRestService extends OnmsRestService {
     private static final Logger LOG = LoggerFactory.getLogger(WebAssetsRestService.class);
 
@@ -83,8 +79,7 @@ public class WebAssetsRestService extends OnmsRestService {
     @Operation(
             summary = "List asset names",
             description = """
-        List every known asset name. The list is unsorted and, on the builds checked, includes one empty
-        string, so callers should not assume every entry addresses a real asset.""",
+        List every known asset name. The list is unsorted and includes one empty string.""",
             operationId = "listWebAssets"
     )
     @ApiResponses(value = {
@@ -159,8 +154,8 @@ public class WebAssetsRestService extends OnmsRestService {
         name is dropped and, if that shorter name registers a file whose path is the originally requested
         one, that file is served.
 
-        This operation depends on the built asset files being present on the classpath. Where they are not,
-        the request fails with 500 even though the asset is listed.""",
+        When the registered file is not present on the classpath the request fails with 500 even though the
+        asset is listed.""",
             operationId = "getWebAssetFile"
     )
     @ApiResponses(value = {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/WebAssetsRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/WebAssetsRestService.java
@@ -150,9 +150,8 @@ public class WebAssetsRestService extends OnmsRestService {
         get their own, `md`, `sh`, `txt`, `yml` and `jsp` come back as `text/plain`, `xml` as `text/xml`, and
         anything unrecognised as `application/octet-stream`.
 
-        When the exact name is not registered, one fallback is tried: the last `-`-separated component of the
-        name is dropped and, if that shorter name registers a file whose path is the originally requested
-        one, that file is served.
+        When the exact name is not registered a fallback is attempted, but its list handling throws before
+        it can run, so an unregistered name containing `-` fails with 500 rather than falling back.
 
         When the registered file is not present on the classpath the request fails with 500 even though the
         asset is listed.""",
@@ -161,8 +160,8 @@ public class WebAssetsRestService extends OnmsRestService {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "The asset file. The media type follows the `type` segment.",
                     content = @Content(schema = @Schema(type = "string", format = "binary"))),
-            @ApiResponse(responseCode = "404", description = "No file is registered for that asset name and type. The body is empty."),
-            @ApiResponse(responseCode = "500", description = "The file is registered but could not be read.",
+            @ApiResponse(responseCode = "404", description = "No file is registered for that asset name and type, and the name contains no `-`. The body is empty."),
+            @ApiResponse(responseCode = "500", description = "The file is registered but could not be read, or an unregistered name containing `-` hit the broken fallback.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "java.io.FileNotFoundException: class path resource [opennms.css] cannot be opened because it does not exist")))

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/WebAssetsRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/WebAssetsRestService.java
@@ -41,6 +41,14 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.StreamingOutput;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.commons.io.IOUtils;
 import org.opennms.web.utils.assets.AssetLocator;
@@ -53,7 +61,16 @@ import org.springframework.util.FileCopyUtils;
 
 @Component("webAssetsRestService")
 @Path("web-assets")
-@Tag(name = "Web-Assets", description = "Web Assets API")
+@Tag(name = "Web-Assets", description = """
+        Web Assets API: the bundled front-end assets (scripts, stylesheets, fonts, images) that the OpenNMS
+        web UI loads, addressed by the logical asset name the build assigned them.
+
+        An asset name usually maps to more than one file, one per type: `opennms` covers both `opennms.css`
+        and `opennms.min.js`. The listing operations report that mapping; the third operation serves the file
+        itself.
+
+        These endpoints exist for the UI's own use, and the asset names are a build artefact rather than a
+        stable interface.""")
 public class WebAssetsRestService extends OnmsRestService {
     private static final Logger LOG = LoggerFactory.getLogger(WebAssetsRestService.class);
 
@@ -63,6 +80,25 @@ public class WebAssetsRestService extends OnmsRestService {
     @GET
     @Produces({MediaType.APPLICATION_JSON})
     @Path("/")
+    @Operation(
+            summary = "List asset names",
+            description = """
+        List every known asset name. The list is unsorted and, on the builds checked, includes one empty
+        string, so callers should not assume every entry addresses a real asset.""",
+            operationId = "listWebAssets"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The asset names.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            array = @ArraySchema(schema = @Schema(type = "string")),
+                            examples = @ExampleObject(value = """
+                    [
+                      "onms-assets",
+                      "opennms",
+                      "font-awesome",
+                      "global"
+                    ]""")))
+    })
     public List<String> listAssets() {
         return new ArrayList<>(m_assetLocator.getAssets());
     }
@@ -70,7 +106,38 @@ public class WebAssetsRestService extends OnmsRestService {
     @GET
     @Produces({MediaType.APPLICATION_JSON})
     @Path("{assetName}")
-    public List<AssetResource> getResources(@PathParam("assetName") final String assetName) {
+    @Operation(
+            summary = "List the files that make up one asset",
+            description = """
+        List the files registered under an asset name. Each entry gives the asset name, its type and the path
+        the file is served from, which is what `GET /web-assets/{assetName}.{type}` addresses.
+
+        A few assets carry inline content rather than a file: for those the `type` is `text` and `path` holds
+        the content itself rather than a filename.""",
+            operationId = "getWebAssetResources"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The files registered under the asset name.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            array = @ArraySchema(schema = @Schema(implementation = AssetResource.class)),
+                            examples = @ExampleObject(value = """
+                    [
+                      {
+                        "asset": "opennms",
+                        "type": "css",
+                        "path": "opennms.css"
+                      },
+                      {
+                        "asset": "opennms",
+                        "type": "js",
+                        "path": "opennms.min.js"
+                      }
+                    ]"""))),
+            @ApiResponse(responseCode = "404", description = "No asset with that name is registered. The body is empty.")
+    })
+    public List<AssetResource> getResources(
+            @Parameter(description = "Asset name, as listed by `GET /web-assets`.", required = true, example = "opennms")
+            @PathParam("assetName") final String assetName) {
         final Optional<Collection<AssetResource>> resources = m_assetLocator.getResources(assetName);
         if (!resources.isPresent()) {
             throw new WebApplicationException(Status.NOT_FOUND);
@@ -80,7 +147,36 @@ public class WebAssetsRestService extends OnmsRestService {
 
     @GET
     @Path("{assetName}.{type}")
-    public Response getResource(@PathParam("assetName") final String assetName, @PathParam("type") final String type) {
+    @Operation(
+            summary = "Fetch an asset file",
+            description = """
+        Serve the file registered for an asset name and type. The response media type is chosen from the
+        `type` segment: `js` becomes `application/javascript`, `css` becomes `text/css`, image and font types
+        get their own, `md`, `sh`, `txt`, `yml` and `jsp` come back as `text/plain`, `xml` as `text/xml`, and
+        anything unrecognised as `application/octet-stream`.
+
+        When the exact name is not registered, one fallback is tried: the last `-`-separated component of the
+        name is dropped and, if that shorter name registers a file whose path is the originally requested
+        one, that file is served.
+
+        This operation depends on the built asset files being present on the classpath. Where they are not,
+        the request fails with 500 even though the asset is listed.""",
+            operationId = "getWebAssetFile"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The asset file. The media type follows the `type` segment.",
+                    content = @Content(schema = @Schema(type = "string", format = "binary"))),
+            @ApiResponse(responseCode = "404", description = "No file is registered for that asset name and type. The body is empty."),
+            @ApiResponse(responseCode = "500", description = "The file is registered but could not be read.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "java.io.FileNotFoundException: class path resource [opennms.css] cannot be opened because it does not exist")))
+    })
+    public Response getResource(
+            @Parameter(description = "Asset name, as listed by `GET /web-assets`.", required = true, example = "opennms")
+            @PathParam("assetName") final String assetName,
+            @Parameter(description = "File type, as reported by `GET /web-assets/{assetName}`.", required = true, example = "css")
+            @PathParam("type") final String type) {
         InputStream is = null;
 
         try {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/WhoamiRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/WhoamiRestService.java
@@ -31,12 +31,19 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.opennms.netmgt.config.UserManager;
 import org.opennms.netmgt.model.OnmsUser;
 import org.opennms.web.api.Authentication;
+import org.opennms.web.rest.v1.model.WhoamiResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -53,6 +60,32 @@ public class WhoamiRestService {
     @GET
     @Produces({MediaType.APPLICATION_JSON})
     @Path("/")
+    @Operation(
+            summary = "Describe the authenticated user",
+            description = """
+        Report the login name of the authenticated principal together with the roles it holds. Roles are
+        filtered against the set OpenNMS knows about, so a role granted by an external authentication
+        source that OpenNMS does not define is not listed.
+
+        `internal` says whether the principal is defined in users.xml. `email` and `fullName` are present
+        only for internal users, and only when the corresponding field is set.""",
+            operationId = "whoami"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Identity of the authenticated principal.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = WhoamiResponse.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "id": "admin",
+                      "roles": [
+                        "ROLE_USER",
+                        "ROLE_ADMIN"
+                      ],
+                      "internal": true,
+                      "fullName": "Administrator"
+                    }""")))
+    })
     public Response whoami(@Context final SecurityContext securityContext) {
         final String userName = securityContext.getUserPrincipal().getName();
         final JSONArray userRoles = new JSONArray();

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/AgentConfigurationResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/AgentConfigurationResource.java
@@ -300,7 +300,7 @@ public class AgentConfigurationResource implements InitializingBean {
             description = """
                     Identical to `/config/agents/{filterName}/{serviceName}.json`, reached by sending
                     `Accept: application/json` to the extensionless path. Two handlers share that path and only
-                    one of them survives into this document, so this entry may not appear.
+                    one of them appears in this document.
 
                     `filterName` is matched first against the `name` attribute of a collectd `filter`, then against
                     the enclosing `package` name, so a package whose filter is unnamed can be addressed by the

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/AgentConfigurationResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/AgentConfigurationResource.java
@@ -62,6 +62,13 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 @Component("agentConfigurationResource")
 public class AgentConfigurationResource implements InitializingBean {
@@ -106,14 +113,115 @@ public class AgentConfigurationResource implements InitializingBean {
     @GET
     @Path("{filterName}/{serviceName}.xml")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
-    public Response getAgentsXmlWithExtension(@PathParam("filterName") final String filterName, @PathParam("serviceName") final String serviceName) throws ConfigurationResourceException {
+    @Operation(
+            summary = "List collectable agents for a filter and service (XML)",
+            description = """
+                    `filterName` is matched first against the `name` attribute of a collectd `filter`, then against
+                    the enclosing `package` name, so a package whose filter is unnamed can be addressed by the
+                    package name. The filter rule is evaluated against the current database to get the matching
+                    interfaces, and those are then narrowed to the ones that actually have `serviceName`
+                    monitored.
+
+                    Each entry carries the collectd service parameters verbatim, so `${requisition:...}`
+                    placeholders are returned unexpanded. `nodeId`, `foreignSource` and `foreignId` are added
+                    when known. For `SNMP` the port comes from snmp-config.xml for that address and location
+                    rather than from the collectd `port` parameter, and `sysObjectId` is added when the node
+                    has one.
+
+                    The XML form wraps the entries in an `agents` element carrying `count`, `offset` and
+                    `totalCount` attributes; the map is rendered as repeated `entry` elements.""",
+            operationId = "getAgentsForFilterXml")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "One entry per matching agent.",
+                    content = @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = AgentResponseCollection.class),
+                            examples = @ExampleObject(value = """
+                                    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                                            <agents count="1" offset="0" totalCount="1">
+                                              <agent>
+                                                <address>127.0.0.1</address>
+                                                <port>1161</port>
+                                                <serviceName>SNMP</serviceName>
+                                                <parameters>
+                                                  <entry>
+                                                    <key>collection</key>
+                                                    <value>${requisition:collection|detector:collection|default}</value>
+                                                  </entry>
+                                                  <entry>
+                                                    <key>nodeId</key>
+                                                    <value>2</value>
+                                                  </entry>
+                                                </parameters>
+                                              </agent>
+                                            </agents>"""))),
+            @ApiResponse(responseCode = "204", description = "The filter matched, but no interface has that service monitored. Bodiless."),
+            @ApiResponse(responseCode = "404", description = "No collectd filter or package is named `filterName`. Bodiless."),
+            @ApiResponse(responseCode = "500", description = "`serviceName` is not configured on the matched package. The body is the plain string `Service name not part of package!`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Service name not part of package!")))
+    })
+    public Response getAgentsXmlWithExtension(@io.swagger.v3.oas.annotations.Parameter(description = "Name of a collectd filter, or of the collectd package that owns it.", required = true, example = "example1") @PathParam("filterName") final String filterName, @io.swagger.v3.oas.annotations.Parameter(description = "Name of the monitored service to restrict the result to. Must be one of the services configured on that package.", required = true, example = "SNMP") @PathParam("serviceName") final String serviceName) throws ConfigurationResourceException {
         return getAgentsXml(filterName, serviceName);
     }
 
     @GET
     @Path("{filterName}/{serviceName}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
-    public Response getAgentsXmlWithoutExtension(@PathParam("filterName") final String filterName, @PathParam("serviceName") final String serviceName) throws ConfigurationResourceException {
+    @Operation(
+            summary = "List collectable agents for a filter and service",
+            description = """
+                    `filterName` is matched first against the `name` attribute of a collectd `filter`, then against
+                    the enclosing `package` name, so a package whose filter is unnamed can be addressed by the
+                    package name. The filter rule is evaluated against the current database to get the matching
+                    interfaces, and those are then narrowed to the ones that actually have `serviceName`
+                    monitored.
+
+                    Each entry carries the collectd service parameters verbatim, so `${requisition:...}`
+                    placeholders are returned unexpanded. `nodeId`, `foreignSource` and `foreignId` are added
+                    when known. For `SNMP` the port comes from snmp-config.xml for that address and location
+                    rather than from the collectd `port` parameter, and `sysObjectId` is added when the node
+                    has one.
+
+                    This path is served by two handlers selected by content negotiation: `Accept: application/xml`
+                    (or application/atom+xml) returns the wrapped XML form, `Accept: application/json` returns the
+                    bare JSON array. Only one of the two appears in this document, so the JSON response of this
+                    path is documented on `/config/agents/{filterName}/{serviceName}.json` instead.
+
+                    The XML form wraps the entries in an `agents` element carrying `count`, `offset` and
+                    `totalCount` attributes; the map is rendered as repeated `entry` elements.""",
+            operationId = "getAgentsForFilter")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "One entry per matching agent.",
+                    content = @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = AgentResponseCollection.class),
+                            examples = @ExampleObject(value = """
+                                    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                                            <agents count="1" offset="0" totalCount="1">
+                                              <agent>
+                                                <address>127.0.0.1</address>
+                                                <port>1161</port>
+                                                <serviceName>SNMP</serviceName>
+                                                <parameters>
+                                                  <entry>
+                                                    <key>collection</key>
+                                                    <value>${requisition:collection|detector:collection|default}</value>
+                                                  </entry>
+                                                  <entry>
+                                                    <key>nodeId</key>
+                                                    <value>2</value>
+                                                  </entry>
+                                                </parameters>
+                                              </agent>
+                                            </agents>"""))),
+            @ApiResponse(responseCode = "204", description = "The filter matched, but no interface has that service monitored. Bodiless."),
+            @ApiResponse(responseCode = "404", description = "No collectd filter or package is named `filterName`. Bodiless."),
+            @ApiResponse(responseCode = "500", description = "`serviceName` is not configured on the matched package. The body is the plain string `Service name not part of package!`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Service name not part of package!")))
+    })
+    public Response getAgentsXmlWithoutExtension(@io.swagger.v3.oas.annotations.Parameter(description = "Name of a collectd filter, or of the collectd package that owns it.", required = true, example = "example1") @PathParam("filterName") final String filterName, @io.swagger.v3.oas.annotations.Parameter(description = "Name of the monitored service to restrict the result to. Must be one of the services configured on that package.", required = true, example = "SNMP") @PathParam("serviceName") final String serviceName) throws ConfigurationResourceException {
         return getAgentsXml(filterName, serviceName);
     }
 
@@ -130,14 +238,118 @@ public class AgentConfigurationResource implements InitializingBean {
     @GET
     @Path("{filterName}/{serviceName}.json")
     @Produces({MediaType.APPLICATION_JSON})
-    public Response getAgentsJsonWithExtension(@PathParam("filterName") final String filterName, @PathParam("serviceName") final String serviceName) throws ConfigurationResourceException {
+    @Operation(
+            summary = "List collectable agents for a filter and service (JSON)",
+            description = """
+                    `filterName` is matched first against the `name` attribute of a collectd `filter`, then against
+                    the enclosing `package` name, so a package whose filter is unnamed can be addressed by the
+                    package name. The filter rule is evaluated against the current database to get the matching
+                    interfaces, and those are then narrowed to the ones that actually have `serviceName`
+                    monitored.
+
+                    Each entry carries the collectd service parameters verbatim, so `${requisition:...}`
+                    placeholders are returned unexpanded. `nodeId`, `foreignSource` and `foreignId` are added
+                    when known. For `SNMP` the port comes from snmp-config.xml for that address and location
+                    rather than from the collectd `port` parameter, and `sysObjectId` is added when the node
+                    has one.
+
+                    The JSON form is a bare array with no wrapper, and each `parameters` map is rendered as a
+                    JAXB-style `{"entry": [{"key": ..., "value": ...}]}` object rather than as a plain
+                    object.""",
+            operationId = "getAgentsForFilterJson")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "One entry per matching agent.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            array = @ArraySchema(schema = @Schema(implementation = AgentResponse.class)),
+                            examples = @ExampleObject(value = """
+                                    [
+                                              {
+                                                "address": "127.0.0.1",
+                                                "port": 1161,
+                                                "serviceName": "SNMP",
+                                                "parameters": {
+                                                  "entry": [
+                                                    {
+                                                      "key": "collection",
+                                                      "value": "${requisition:collection|detector:collection|default}"
+                                                    },
+                                                    {
+                                                      "key": "nodeId",
+                                                      "value": "2"
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]"""))),
+            @ApiResponse(responseCode = "204", description = "The filter matched, but no interface has that service monitored. Bodiless."),
+            @ApiResponse(responseCode = "404", description = "No collectd filter or package is named `filterName`. Bodiless."),
+            @ApiResponse(responseCode = "500", description = "`serviceName` is not configured on the matched package. The body is the plain string `Service name not part of package!`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Service name not part of package!")))
+    })
+    public Response getAgentsJsonWithExtension(@io.swagger.v3.oas.annotations.Parameter(description = "Name of a collectd filter, or of the collectd package that owns it.", required = true, example = "example1") @PathParam("filterName") final String filterName, @io.swagger.v3.oas.annotations.Parameter(description = "Name of the monitored service to restrict the result to. Must be one of the services configured on that package.", required = true, example = "SNMP") @PathParam("serviceName") final String serviceName) throws ConfigurationResourceException {
         return getAgentsJson(filterName, serviceName);
     }
 
     @GET
     @Path("{filterName}/{serviceName}")
     @Produces({MediaType.APPLICATION_JSON})
-    public Response getAgentsJsonWithoutExtension(@PathParam("filterName") final String filterName, @PathParam("serviceName") final String serviceName) throws ConfigurationResourceException {
+    @Operation(
+            summary = "List collectable agents for a filter and service (JSON, negotiated)",
+            description = """
+                    Identical to `/config/agents/{filterName}/{serviceName}.json`, reached by sending
+                    `Accept: application/json` to the extensionless path. Two handlers share that path and only
+                    one of them survives into this document, so this entry may not appear.
+
+                    `filterName` is matched first against the `name` attribute of a collectd `filter`, then against
+                    the enclosing `package` name, so a package whose filter is unnamed can be addressed by the
+                    package name. The filter rule is evaluated against the current database to get the matching
+                    interfaces, and those are then narrowed to the ones that actually have `serviceName`
+                    monitored.
+
+                    Each entry carries the collectd service parameters verbatim, so `${requisition:...}`
+                    placeholders are returned unexpanded. `nodeId`, `foreignSource` and `foreignId` are added
+                    when known. For `SNMP` the port comes from snmp-config.xml for that address and location
+                    rather than from the collectd `port` parameter, and `sysObjectId` is added when the node
+                    has one.
+
+                    The JSON form is a bare array with no wrapper, and each `parameters` map is rendered as a
+                    JAXB-style `{"entry": [{"key": ..., "value": ...}]}` object rather than as a plain
+                    object.""",
+            operationId = "getAgentsForFilterNegotiatedJson")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "One entry per matching agent.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            array = @ArraySchema(schema = @Schema(implementation = AgentResponse.class)),
+                            examples = @ExampleObject(value = """
+                                    [
+                                              {
+                                                "address": "127.0.0.1",
+                                                "port": 1161,
+                                                "serviceName": "SNMP",
+                                                "parameters": {
+                                                  "entry": [
+                                                    {
+                                                      "key": "collection",
+                                                      "value": "${requisition:collection|detector:collection|default}"
+                                                    },
+                                                    {
+                                                      "key": "nodeId",
+                                                      "value": "2"
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]"""))),
+            @ApiResponse(responseCode = "204", description = "The filter matched, but no interface has that service monitored. Bodiless."),
+            @ApiResponse(responseCode = "404", description = "No collectd filter or package is named `filterName`. Bodiless."),
+            @ApiResponse(responseCode = "500", description = "`serviceName` is not configured on the matched package. The body is the plain string `Service name not part of package!`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Service name not part of package!")))
+    })
+    public Response getAgentsJsonWithoutExtension(@io.swagger.v3.oas.annotations.Parameter(description = "Name of a collectd filter, or of the collectd package that owns it.", required = true, example = "example1") @PathParam("filterName") final String filterName, @io.swagger.v3.oas.annotations.Parameter(description = "Name of the monitored service to restrict the result to. Must be one of the services configured on that package.", required = true, example = "SNMP") @PathParam("serviceName") final String serviceName) throws ConfigurationResourceException {
         return getAgentsJson(filterName, serviceName);
     }
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/DataCollectionConfigResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/DataCollectionConfigResource.java
@@ -45,6 +45,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 @Component
 public class DataCollectionConfigResource implements InitializingBean {
@@ -64,6 +71,56 @@ public class DataCollectionConfigResource implements InitializingBean {
 
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get the SNMP data collection configuration",
+            description = """
+                    Returns datacollection-config.xml with every `datacollection-group` include already
+                    resolved and flattened into the owning `snmp-collection`. The response is very large:
+                    on a stock installation it is several hundred kilobytes of JSON, because it carries
+                    every shipped MIB group, table, resource type and systemDef.
+
+                    Prefer `/config/datacollection/status` for a summary, or
+                    `/config/datacollection/lookup` to see what a single agent would be collected for.""",
+            operationId = "getDataCollectionConfiguration")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The resolved data collection configuration. The example is abbreviated to one group and one MIB group.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = DatacollectionConfig.class),
+                                    examples = @ExampleObject(value = """
+                                            {
+                                              "snmp-collection": [
+                                                {
+                                                  "name": "default",
+                                                  "datacollection-group": [
+                                                    {
+                                                      "name": "default-all",
+                                                      "resourceType": [],
+                                                      "table": [],
+                                                      "group": [
+                                                        {
+                                                          "name": "mib2-icmp",
+                                                          "mibObj": [
+                                                            {
+                                                              "oid": ".1.3.6.1.2.1.5.2",
+                                                              "instance": "0",
+                                                              "alias": "icmpInErrors",
+                                                              "type": "counter"
+                                                            }
+                                                          ]
+                                                        }
+                                                      ],
+                                                      "systemDef": []
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = DatacollectionConfig.class))
+                    }),
+            @ApiResponse(responseCode = "404", description = "The data collection DAO holds no root configuration. Bodiless.")
+    })
     public Response getDataCollectionConfiguration() throws ConfigurationResourceException {
         LOG.debug("getDatacollectionConfigurationForLocation()");
 
@@ -84,10 +141,52 @@ public class DataCollectionConfigResource implements InitializingBean {
     @GET
     @Path("/lookup")
     @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Resolve the MIB objects for one agent",
+            description = """
+                    Diagnostic endpoint. Resolves `sysoid`, `address`, `collection` and `ifType` through the
+                    same systemDef matching that collectd uses, and returns the MIB objects that would be
+                    collected. Nothing is queried over SNMP and no node has to exist: the address is used
+                    only for the address-range tests inside the systemDef rules.
+
+                    Leave `ifType` at its default of -1 for the node-level objects. Pass a positive IANA
+                    interface type (6 for ethernetCsmacd, for example) to also include the interface-level
+                    objects that apply to that type.""",
+            operationId = "lookupDataCollectionMibObjects")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The resolved MIB objects. The example is abbreviated to one object.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionLookupResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "sysoid": ".1.3.6.1.4.1.8072.3.2.10",
+                                      "address": "127.0.0.1",
+                                      "collection": "default",
+                                      "ifType": -1,
+                                      "matchedObjectCount": 191,
+                                      "objects": [
+                                        {
+                                          "group": "mib2-tcp",
+                                          "oid": ".1.3.6.1.2.1.6.5",
+                                          "alias": "tcpActiveOpens",
+                                          "type": "Counter32",
+                                          "instance": "0"
+                                        }
+                                      ]
+                                    }"""))),
+            @ApiResponse(responseCode = "400", description = "`sysoid` was absent or empty. The body is a plain string, even though the response is labelled application/json.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "sysoid parameter is required")))
+    })
     public Response lookupMibObjects(
+            @Parameter(description = "sysObjectID of the agent to resolve, including the leading dot.", required = true, example = ".1.3.6.1.4.1.8072.3.2.10")
             @QueryParam("sysoid") final String sysoid,
+            @Parameter(description = "Interface address used for the address-range tests in the systemDef rules.", example = "127.0.0.1")
             @QueryParam("address") @DefaultValue("127.0.0.1") final String address,
+            @Parameter(description = "Name of the snmp-collection to resolve against, as named in datacollection-config.xml.", example = "default")
             @QueryParam("collection") @DefaultValue("default") final String collection,
+            @Parameter(description = "IANA interface type. -1 returns the node-level objects only.", example = "-1")
             @QueryParam("ifType") @DefaultValue("-1") final int ifType) {
 
         if (sysoid == null || sysoid.isEmpty()) {
@@ -121,6 +220,39 @@ public class DataCollectionConfigResource implements InitializingBean {
     @GET
     @Path("/status")
     @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Summarize the loaded data collection configuration",
+            description = """
+                    Diagnostic endpoint. Returns counts drawn from the data collection configuration
+                    currently held in memory, without serializing the configuration itself. Useful for
+                    confirming that a datacollection.d file was picked up after a reload.
+
+                    `lastUpdate` is epoch milliseconds. The internal `__resource_type_collection` entry is
+                    filtered out of `snmpCollections` but is still counted by the `available*` totals.""",
+            operationId = "getDataCollectionConfigStatus")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Summary of the loaded configuration. `availableCollectionGroups` is abbreviated in the example.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionStatusResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "availableCollectionGroups": ["MIB2", "Cisco", "Net-SNMP"],
+                                      "availableSystemDefs": 216,
+                                      "availableMibGroups": 328,
+                                      "configuredResourceTypes": 195,
+                                      "lastUpdate": 1787685418848,
+                                      "snmpCollections": [
+                                        {
+                                          "name": "default",
+                                          "storageFlag": "select",
+                                          "rrdStep": 300,
+                                          "groups": 324,
+                                          "systemDefs": 215,
+                                          "resourceTypes": 194
+                                        }
+                                      ]
+                                    }""")))
+    })
     public Response getConfigStatus() {
         final Map<String, Object> status = new LinkedHashMap<>();
         status.put("availableCollectionGroups", m_dataCollectionConfigDao.getAvailableDataCollectionGroups());

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/DataCollectionConfigResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/DataCollectionConfigResource.java
@@ -83,7 +83,7 @@ public class DataCollectionConfigResource implements InitializingBean {
             @ApiResponse(responseCode = "200", description = "The resolved data collection configuration. The example is abbreviated to one group and one MIB group.",
                     content = {
                             @Content(mediaType = MediaType.APPLICATION_JSON,
-                                    schema = @Schema(implementation = DatacollectionConfig.class),
+                                    schema = @Schema(implementation = org.opennms.netmgt.config.internal.collection.DataCollectionConfigImpl.class),
                                     examples = @ExampleObject(value = """
                                             {
                                               "snmp-collection": [
@@ -114,7 +114,7 @@ public class DataCollectionConfigResource implements InitializingBean {
                                               ]
                                             }""")),
                             @Content(mediaType = MediaType.APPLICATION_XML,
-                                    schema = @Schema(implementation = DatacollectionConfig.class))
+                                    schema = @Schema(implementation = org.opennms.netmgt.config.internal.collection.DataCollectionConfigImpl.class))
                     }),
             @ApiResponse(responseCode = "404", description = "The data collection DAO holds no root configuration. Bodiless.")
     })

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/DataCollectionConfigResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/DataCollectionConfigResource.java
@@ -75,12 +75,9 @@ public class DataCollectionConfigResource implements InitializingBean {
             summary = "Get the SNMP data collection configuration",
             description = """
                     Returns datacollection-config.xml with every `datacollection-group` include already
-                    resolved and flattened into the owning `snmp-collection`. The response is very large:
-                    on a stock installation it is several hundred kilobytes of JSON, because it carries
-                    every shipped MIB group, table, resource type and systemDef.
-
-                    Prefer `/config/datacollection/status` for a summary, or
-                    `/config/datacollection/lookup` to see what a single agent would be collected for.""",
+                    resolved and flattened into the owning `snmp-collection`. On a stock installation the
+                    response is several hundred kilobytes of JSON, carrying every shipped MIB group, table,
+                    resource type and systemDef.""",
             operationId = "getDataCollectionConfiguration")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "The resolved data collection configuration. The example is abbreviated to one group and one MIB group.",
@@ -144,14 +141,14 @@ public class DataCollectionConfigResource implements InitializingBean {
     @Operation(
             summary = "Resolve the MIB objects for one agent",
             description = """
-                    Diagnostic endpoint. Resolves `sysoid`, `address`, `collection` and `ifType` through the
-                    same systemDef matching that collectd uses, and returns the MIB objects that would be
-                    collected. Nothing is queried over SNMP and no node has to exist: the address is used
-                    only for the address-range tests inside the systemDef rules.
+                    Resolves `sysoid`, `address`, `collection` and `ifType` through the same systemDef
+                    matching that collectd uses, and returns the MIB objects that would be collected. Nothing
+                    is queried over SNMP and no node has to exist: the address is used only for the
+                    address-range tests inside the systemDef rules.
 
-                    Leave `ifType` at its default of -1 for the node-level objects. Pass a positive IANA
-                    interface type (6 for ethernetCsmacd, for example) to also include the interface-level
-                    objects that apply to that type.""",
+                    `ifType` defaults to -1, which returns the node-level objects. A positive IANA interface
+                    type (6 for ethernetCsmacd) also includes the interface-level objects that apply to that
+                    type.""",
             operationId = "lookupDataCollectionMibObjects")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "The resolved MIB objects. The example is abbreviated to one object.",
@@ -223,9 +220,8 @@ public class DataCollectionConfigResource implements InitializingBean {
     @Operation(
             summary = "Summarize the loaded data collection configuration",
             description = """
-                    Diagnostic endpoint. Returns counts drawn from the data collection configuration
-                    currently held in memory, without serializing the configuration itself. Useful for
-                    confirming that a datacollection.d file was picked up after a reload.
+                    Returns counts drawn from the data collection configuration currently held in memory,
+                    without serializing the configuration itself.
 
                     `lastUpdate` is epoch milliseconds. The internal `__resource_type_collection` entry is
                     filtered out of `snmpCollections` but is still counted by the `available*` totals.""",

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/DataCollectionLookupResponse.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/DataCollectionLookupResponse.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v1.config;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Describes the shape of the ad-hoc map returned by
+ * {@code GET /rest/config/datacollection/lookup}. It is a documentation-only type: the handler
+ * builds a {@link java.util.LinkedHashMap} rather than an instance of this class.
+ */
+@Schema(name = "DataCollectionLookupResponse", description = "MIB objects that SNMP collection would gather for a given sysObjectID, address, collection and ifType.")
+public class DataCollectionLookupResponse {
+
+    @Schema(description = "The sysObjectID the lookup was performed for, echoed back from the request.", example = ".1.3.6.1.4.1.8072.3.2.10")
+    private String sysoid;
+
+    @Schema(description = "The interface address the lookup was performed for, echoed back from the request.", example = "127.0.0.1")
+    private String address;
+
+    @Schema(description = "The SNMP collection name the lookup was performed against, echoed back from the request.", example = "default")
+    private String collection;
+
+    @Schema(description = "The ifType the lookup was performed for, echoed back from the request. -1 means node-level objects only.", example = "-1")
+    private int ifType;
+
+    @Schema(description = "Number of entries in objects.", example = "191")
+    private int matchedObjectCount;
+
+    @Schema(description = "The matched MIB objects, in the order the data collection config returned them.")
+    private List<MibObjectSummary> objects;
+
+    public String getSysoid() {
+        return sysoid;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public String getCollection() {
+        return collection;
+    }
+
+    public int getIfType() {
+        return ifType;
+    }
+
+    public int getMatchedObjectCount() {
+        return matchedObjectCount;
+    }
+
+    public List<MibObjectSummary> getObjects() {
+        return objects;
+    }
+
+    @Schema(name = "MibObjectSummary", description = "One MIB object from the resolved collection.")
+    public static class MibObjectSummary {
+
+        @Schema(description = "Name of the MIB group the object belongs to.", example = "mib2-tcp")
+        private String group;
+
+        @Schema(description = "Object identifier, without the instance part.", example = ".1.3.6.1.2.1.6.5")
+        private String oid;
+
+        @Schema(description = "Data source alias the value is stored under. RRD data source names are limited to 19 characters.", example = "tcpActiveOpens")
+        private String alias;
+
+        @Schema(description = "Declared type of the object, as spelled in datacollection-config.xml.", example = "Counter32")
+        private String type;
+
+        @Schema(description = "Instance selector: a literal sub-identifier for scalars, or a resource type name for tabular objects.", example = "0")
+        private String instance;
+
+        public String getGroup() {
+            return group;
+        }
+
+        public String getOid() {
+            return oid;
+        }
+
+        public String getAlias() {
+            return alias;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public String getInstance() {
+            return instance;
+        }
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/DataCollectionStatusResponse.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/DataCollectionStatusResponse.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v1.config;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Describes the shape of the ad-hoc map returned by
+ * {@code GET /rest/config/datacollection/status}. It is a documentation-only type: the handler
+ * builds a {@link java.util.LinkedHashMap} rather than an instance of this class.
+ */
+@Schema(name = "DataCollectionStatusResponse", description = "Summary of the SNMP data collection configuration currently held in memory.")
+public class DataCollectionStatusResponse {
+
+    @Schema(description = "Names of the datacollection-group elements loaded from datacollection-config.xml and the datacollection.d include directory.", example = "[\"MIB2\",\"Cisco\",\"Net-SNMP\"]")
+    private List<String> availableCollectionGroups;
+
+    @Schema(description = "Number of systemDef elements across all loaded groups.", example = "216")
+    private int availableSystemDefs;
+
+    @Schema(description = "Number of MIB groups across all loaded groups.", example = "328")
+    private int availableMibGroups;
+
+    @Schema(description = "Number of resourceType elements across all loaded groups.", example = "195")
+    private int configuredResourceTypes;
+
+    // Serialized as epoch milliseconds, not as the ISO-8601 string a Date would otherwise imply.
+    @Schema(description = "When the configuration was last (re)loaded, as epoch milliseconds. Null if it has not been loaded from a file.", type = "integer", format = "int64", example = "1787685418848")
+    private Long lastUpdate;
+
+    @Schema(description = "One entry per snmp-collection, excluding the internal __resource_type_collection entry.")
+    private List<SnmpCollectionSummary> snmpCollections;
+
+    public List<String> getAvailableCollectionGroups() {
+        return availableCollectionGroups;
+    }
+
+    public int getAvailableSystemDefs() {
+        return availableSystemDefs;
+    }
+
+    public int getAvailableMibGroups() {
+        return availableMibGroups;
+    }
+
+    public int getConfiguredResourceTypes() {
+        return configuredResourceTypes;
+    }
+
+    public Long getLastUpdate() {
+        return lastUpdate;
+    }
+
+    public List<SnmpCollectionSummary> getSnmpCollections() {
+        return snmpCollections;
+    }
+
+    @Schema(name = "SnmpCollectionSummary", description = "Counts for one snmp-collection.")
+    public static class SnmpCollectionSummary {
+
+        @Schema(description = "The snmp-collection name, as referenced by the collectd collection parameter.", example = "default")
+        private String name;
+
+        @Schema(description = "Value of snmpStorageFlag for the collection.", example = "select", allowableValues = {"select", "primary", "all"})
+        private String storageFlag;
+
+        @Schema(description = "RRD step in seconds, or null when the collection declares no rrd element.", example = "300")
+        private Integer rrdStep;
+
+        @Schema(description = "Number of groups referenced by the collection.", example = "324")
+        private int groups;
+
+        @Schema(description = "Number of systemDefs referenced by the collection.", example = "215")
+        private int systemDefs;
+
+        @Schema(description = "Number of resourceTypes referenced by the collection.", example = "194")
+        private int resourceTypes;
+
+        public String getName() {
+            return name;
+        }
+
+        public String getStorageFlag() {
+            return storageFlag;
+        }
+
+        public Integer getRrdStep() {
+            return rrdStep;
+        }
+
+        public int getGroups() {
+            return groups;
+        }
+
+        public int getSystemDefs() {
+            return systemDefs;
+        }
+
+        public int getResourceTypes() {
+            return resourceTypes;
+        }
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/DatetimeformatConfig.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/DatetimeformatConfig.java
@@ -25,7 +25,7 @@ import java.time.ZoneId;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "DatetimeformatConfig", description = "Time zone and date format the web UI should render timestamps with.")
+@Schema(name = "DatetimeformatConfig", description = "Time zone and date format the web UI renders timestamps with.")
 public class DatetimeformatConfig {
 
     @Schema(description = "IANA time zone id, taken from the user's session when one is set and from the server default otherwise.", example = "America/New_York")

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/DatetimeformatConfig.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/DatetimeformatConfig.java
@@ -23,8 +23,15 @@ package org.opennms.web.rest.v1.config;
 
 import java.time.ZoneId;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "DatetimeformatConfig", description = "Time zone and date format the web UI should render timestamps with.")
 public class DatetimeformatConfig {
+
+    @Schema(description = "IANA time zone id, taken from the user's session when one is set and from the server default otherwise.", example = "America/New_York")
     private String zoneId;
+
+    @Schema(description = "java.time date format pattern, from the org.opennms.ui.datettimeformat system property. Defaults to yyyy-MM-dd'T'HH:mm:ssxxx.", example = "yyyy-MM-dd'T'HH:mm:ssxxx")
     private String datetimeformat;
 
     public String getZoneId() {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/EmailNorthbounderConfigurationResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/EmailNorthbounderConfigurationResource.java
@@ -58,6 +58,14 @@ import org.springframework.beans.PropertyAccessorFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 /**
  * The Class EmailNorthbounderConfigurationResource.
@@ -123,6 +131,60 @@ public class EmailNorthbounderConfigurationResource extends OnmsRestService impl
      */
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get the Email northbounder configuration",
+            description = """
+                    Returns the whole of email-northbounder-configuration.xml. `destination[].name` has to match
+                    a `sendmail-config` entry in javamail-configuration.xml, which is what supplies the SMTP
+                    host and credentials; the northbounder destination only carries the filters and the
+                    per-filter message overrides.
+
+                    A `filter` with no `from`, `to`, `subject` or `body` inherits the message from the
+                    sendmail-config. `filter[].enabled` comes back as null when the attribute is absent, which
+                    the northbounder treats as enabled.""",
+            operationId = "getEmailNorthbounderConfiguration")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The current Email northbounder configuration.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = EmailNorthbounderConfig.class),
+                                    examples = @ExampleObject(value = """
+                                            {
+                                              "enabled": false,
+                                              "nagles-delay": 1000,
+                                              "batch-size": 100,
+                                              "queue-size": 300000,
+                                              "destination": [
+                                                {
+                                                  "name": "google",
+                                                  "filter": [
+                                                    {
+                                                      "enabled": null,
+                                                      "name": "Only Servers",
+                                                      "rule": "foreignSource matches '^Servers.*'"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = EmailNorthbounderConfig.class),
+                                    examples = @ExampleObject(value = """
+                                            <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                                        <email-northbounder-config>
+                                              <enabled>false</enabled>
+                                              <nagles-delay>1000</nagles-delay>
+                                              <batch-size>100</batch-size>
+                                              <queue-size>300000</queue-size>
+                                              <destination>
+                                                <name>google</name>
+                                                <filter name="Only Servers">
+                                                  <rule>foreignSource matches '^Servers.*'</rule>
+                                                </filter>
+                                              </destination>
+                                            </email-northbounder-config>"""))
+                    })
+    })
     public Response getConfiguration() {
         return Response.ok(m_emailNorthbounderConfigDao.getConfig()).build();
     }
@@ -134,6 +196,63 @@ public class EmailNorthbounderConfigurationResource extends OnmsRestService impl
      * @return the response
      */
     @POST
+    @Operation(
+            summary = "Replace the Email northbounder configuration",
+            description = """
+                    Marshals the request body straight over email-northbounder-configuration.xml, then sends a
+                    `reloadDaemonConfig` event for `EmailNBI`. The whole file is replaced, so anything absent
+                    from the body is dropped, including comments. There is no merge and no dry run.
+
+                    The handler declares no `@Consumes`, so the media type is whatever the JAXB and Jackson
+                    providers accept for the body type. A body that fails to parse surfaces as a 500 rather
+                    than a 400: the null check that would produce the 400 is unreachable through those
+                    providers.""",
+            operationId = "setEmailNorthbounderConfiguration")
+    @RequestBody(required = true, description = "The complete replacement configuration.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = EmailNorthbounderConfig.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                              "enabled": false,
+                                              "nagles-delay": 1000,
+                                              "batch-size": 100,
+                                              "queue-size": 300000,
+                                              "destination": [
+                                                {
+                                                  "name": "google",
+                                                  "filter": [
+                                                    {
+                                                      "enabled": null,
+                                                      "name": "Only Servers",
+                                                      "rule": "foreignSource matches '^Servers.*'"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = EmailNorthbounderConfig.class),
+                            examples = @ExampleObject(value = """
+                                    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                                        <email-northbounder-config>
+                                              <enabled>false</enabled>
+                                              <nagles-delay>1000</nagles-delay>
+                                              <batch-size>100</batch-size>
+                                              <queue-size>300000</queue-size>
+                                              <destination>
+                                                <name>google</name>
+                                                <filter name="Only Servers">
+                                                  <rule>foreignSource matches '^Servers.*'</rule>
+                                                </filter>
+                                              </destination>
+                                            </email-northbounder-config>"""))
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The file was written and the reload event sent."),
+            @ApiResponse(responseCode = "500", description = "The body could not be parsed, or the file could not be written.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
     public Response setConfiguration(final EmailNorthbounderConfig config) {
         writeLock();
         if (config == null) {
@@ -159,6 +278,21 @@ public class EmailNorthbounderConfigurationResource extends OnmsRestService impl
     @GET
     @Path("status")
     @Produces(MediaType.TEXT_PLAIN)
+    @Operation(
+            summary = "Get whether the Email northbounder is enabled",
+            description = """
+                    Returns the `enabled` flag from email-northbounder-configuration.xml as the literal text
+                    `true` or `false`. An absent flag reads back as `false`.
+
+                    This operation produces text/plain only, so a request sent with
+                    `Accept: application/json` is rejected with a 406.""",
+            operationId = "getEmailNorthbounderStatus")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The current enabled flag.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "boolean"),
+                            examples = @ExampleObject(value = "false")))
+    })
     public Response getStatus() {
         return Response.ok(m_emailNorthbounderConfigDao.getConfig().isEnabled()).build();
     }
@@ -173,7 +307,22 @@ public class EmailNorthbounderConfigurationResource extends OnmsRestService impl
     @PUT
     @Path("status")
     @Produces(MediaType.TEXT_PLAIN)
-    public Response getStatus(@QueryParam("enabled") final Boolean enabled) throws WebApplicationException {
+    @Operation(
+            summary = "Enable or disable the Email northbounder",
+            description = """
+                    Sets the `enabled` flag, rewrites email-northbounder-configuration.xml and sends a
+                    `reloadDaemonConfig` event for `EmailNBI`. Comments and formatting in the file are lost,
+                    because the whole file is re-marshalled from the in-memory model.
+
+                    Omitting `enabled` clears the flag rather than leaving it alone, which then reads back as
+                    `false`. Despite the text/plain declaration the success response has no body.""",
+            operationId = "setEmailNorthbounderStatus")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The flag was written and the reload event sent."),
+            @ApiResponse(responseCode = "500", description = "The configuration could not be saved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
+    public Response getStatus(@Parameter(description = "New value for the enabled flag. Omitting it clears the flag, which reads back as false.", example = "true") @QueryParam("enabled") final Boolean enabled) throws WebApplicationException {
         writeLock();
         try {
             m_emailNorthbounderConfigDao.getConfig().setEnabled(enabled);
@@ -191,6 +340,36 @@ public class EmailNorthbounderConfigurationResource extends OnmsRestService impl
     @GET
     @Path("destinations")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "List the Email northbounder destination names",
+            description = """
+                    Returns only the destination names, not the destinations themselves. Fetch a single
+                    destination to see its filters.
+
+                    `count` and `totalCount` are always equal here: the listing is not paged and `offset` is
+                    always 0.""",
+            operationId = "getEmailDestinations")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The configured destination names.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = EmailDestinationList.class),
+                                    examples = @ExampleObject(value = """
+                                            {
+                                              "totalCount": 1,
+                                              "count": 1,
+                                              "offset": 0,
+                                              "destination": ["google"]
+                                            }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = EmailDestinationList.class),
+                                    examples = @ExampleObject(value = """
+                                            <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                                            <email-destinations count="1" offset="0" totalCount="1">
+                                              <destination>google</destination>
+                                            </email-destinations>"""))
+                    })
+    })
     public Response getEmailDestinations() {
         final EmailDestinationList destinations = new EmailDestinationList(m_emailNorthbounderConfigDao.getConfig().getEmailDestinations());
         return Response.ok(destinations).build();
@@ -205,7 +384,51 @@ public class EmailNorthbounderConfigurationResource extends OnmsRestService impl
     @GET
     @Path("destinations/{destinationName}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    public EmailDestination getEmailDestination(@PathParam("destinationName") final String destinationName) {
+    @Operation(
+            summary = "Get one Email northbounder destination",
+            description = """
+                    Returns the destination and its filters. `filter[].enabled` is null when the attribute is
+                    absent from the file.""",
+            operationId = "getEmailDestination")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The destination.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = EmailDestination.class),
+                                    examples = @ExampleObject(value = """
+                                            {
+                                              "name": "ApiDocDest",
+                                              "filter": [
+                                                {
+                                                  "name": "Only Routers",
+                                                  "rule": "foreignSource matches '^Routers.*'",
+                                                  "from": "donotreply@example.org",
+                                                  "to": "noc@example.org",
+                                                  "subject": "${nodeLabel} : Something is wrong!",
+                                                  "body": "${logMsg}"
+                                                }
+                                              ]
+                                            }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = EmailDestination.class),
+                                    examples = @ExampleObject(value = """
+                                            <email-destination>
+                                              <name>ApiDocDest</name>
+                                              <filter name="Only Routers">
+                                                <rule>foreignSource matches '^Routers.*'</rule>
+                                                <from>donotreply@example.org</from>
+                                                <to>noc@example.org</to>
+                                                <subject>${nodeLabel} : Something is wrong!</subject>
+                                                <body>${logMsg}</body>
+                                              </filter>
+                                            </email-destination>"""))
+                    }),
+            @ApiResponse(responseCode = "404", description = "No destination has that name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Email destination ApiDocDest was not found.")))
+    })
+    public EmailDestination getEmailDestination(@Parameter(description = "Name of the destination, matching a sendmail-config entry in javamail-configuration.xml.", required = true, example = "google") @PathParam("destinationName") final String destinationName) {
        final EmailDestination destination = m_emailNorthbounderConfigDao.getConfig().getEmailDestination(destinationName);
         if (destination == null) {
             throw getException(Status.NOT_FOUND, "Email destination {} was not found.", destinationName);
@@ -223,6 +446,57 @@ public class EmailNorthbounderConfigurationResource extends OnmsRestService impl
     @POST
     @Path("destinations")
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Add or replace an Email northbounder destination",
+            description = """
+                    Adds the destination to email-northbounder-configuration.xml, rewriting the whole file and
+                    sending a `reloadDaemonConfig` event for `EmailNBI`. A destination with the same `name` is
+                    replaced outright, so this is the only way to change a destination's filters: the PUT can
+                    reach the name but not the filter list.
+
+                    `name` has to match a `sendmail-config` entry in javamail-configuration.xml. Nothing
+                    validates that at write time; a destination naming a config that does not exist is
+                    accepted and fails later in the northbounder.
+
+                    An empty or unparseable body surfaces as a 500 rather than the documented 400.""",
+            operationId = "setEmailDestination")
+    @RequestBody(required = true, description = "The destination to add or replace.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = EmailDestination.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                              "name": "ApiDocDest",
+                                              "filter": [
+                                                {
+                                                  "name": "Only Routers",
+                                                  "rule": "foreignSource matches '^Routers.*'",
+                                                  "from": "donotreply@example.org",
+                                                  "to": "noc@example.org",
+                                                  "subject": "${nodeLabel} : Something is wrong!",
+                                                  "body": "${logMsg}"
+                                                }
+                                              ]
+                                            }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = EmailDestination.class),
+                            examples = @ExampleObject(value = """
+                                    <email-destination>
+                                              <name>ApiDocDest</name>
+                                              <filter name="Only Routers">
+                                                <rule>foreignSource matches '^Routers.*'</rule>
+                                                <from>donotreply@example.org</from>
+                                                <to>noc@example.org</to>
+                                                <subject>${nodeLabel} : Something is wrong!</subject>
+                                                <body>${logMsg}</body>
+                                              </filter>
+                                            </email-destination>"""))
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The destination was stored and the reload event sent."),
+            @ApiResponse(responseCode = "500", description = "The body could not be parsed, or the configuration could not be saved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
     public Response setEmailDestination(final EmailDestination destination) {
         writeLock();
         try {
@@ -247,7 +521,33 @@ public class EmailNorthbounderConfigurationResource extends OnmsRestService impl
     @PUT
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("destinations/{destinationName}")
-    public Response updateEmailDestination(@PathParam("destinationName") final String destinationName, final MultivaluedMapImpl params) {
+    @Operation(
+            summary = "Update fields on an Email northbounder destination",
+            description = """
+                    Takes a form-encoded body and applies each key to the matching writable bean property of
+                    the destination, then rewrites the file and sends a `reloadDaemonConfig` event for
+                    `EmailNBI`. Keys are bean property names, not XML element names, and unrecognised keys are
+                    ignored rather than rejected.
+
+                    `EmailDestination` exposes only `name` and `filters` as writable properties, and a form
+                    value cannot express a filter list, so in practice this operation can only rename a
+                    destination. POST the destination again to change its filters.""",
+            operationId = "updateEmailDestination")
+    @RequestBody(required = true, description = "Form-encoded property assignments. `name` is the only property a form value can usefully set.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "object"),
+                    examples = @ExampleObject(value = "name=ApiDocDestRenamed")))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "At least one property was applied and the configuration was saved."),
+            @ApiResponse(responseCode = "304", description = "No key in the body matched a writable property, so nothing was changed."),
+            @ApiResponse(responseCode = "404", description = "No destination has that name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Email destination ApiDocDest was not found."))),
+            @ApiResponse(responseCode = "500", description = "The configuration could not be saved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
+    public Response updateEmailDestination(@Parameter(description = "Name of the destination, matching a sendmail-config entry in javamail-configuration.xml.", required = true, example = "google") @PathParam("destinationName") final String destinationName, final MultivaluedMapImpl params) {
         writeLock();
         try {
             boolean modified = false;
@@ -280,7 +580,20 @@ public class EmailNorthbounderConfigurationResource extends OnmsRestService impl
     @DELETE
     @Path("destinations/{destinationName}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    public Response removeEmailDestination(@PathParam("destinationName") final String destinationName) {
+    @Operation(
+            summary = "Delete an Email northbounder destination",
+            description = """
+                    Removes the destination, rewrites email-northbounder-configuration.xml and sends a
+                    `reloadDaemonConfig` event for `EmailNBI`. The matching `sendmail-config` in
+                    javamail-configuration.xml is left alone.""",
+            operationId = "removeEmailDestination")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The destination was removed and the reload event sent."),
+            @ApiResponse(responseCode = "404", description = "No destination has that name. Bodiless."),
+            @ApiResponse(responseCode = "500", description = "The configuration could not be saved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
+    public Response removeEmailDestination(@Parameter(description = "Name of the destination, matching a sendmail-config entry in javamail-configuration.xml.", required = true, example = "google") @PathParam("destinationName") final String destinationName) {
         if (m_emailNorthbounderConfigDao.getConfig().removeEmailDestination(destinationName)) {
             return saveConfiguration();
         }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/EmailNorthbounderConfigurationResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/EmailNorthbounderConfigurationResource.java
@@ -201,7 +201,7 @@ public class EmailNorthbounderConfigurationResource extends OnmsRestService impl
             description = """
                     Marshals the request body straight over email-northbounder-configuration.xml, then sends a
                     `reloadDaemonConfig` event for `EmailNBI`. The whole file is replaced, so anything absent
-                    from the body is dropped, including comments. There is no merge and no dry run.
+                    from the body is dropped, including comments.
 
                     The handler declares no `@Consumes`, so the media type is whatever the JAXB and Jackson
                     providers accept for the body type. A body that fails to parse surfaces as a 500 rather
@@ -343,8 +343,7 @@ public class EmailNorthbounderConfigurationResource extends OnmsRestService impl
     @Operation(
             summary = "List the Email northbounder destination names",
             description = """
-                    Returns only the destination names, not the destinations themselves. Fetch a single
-                    destination to see its filters.
+                    Returns only the destination names, not the destinations themselves.
 
                     `count` and `totalCount` are always equal here: the listing is not paged and `offset` is
                     always 0.""",
@@ -530,8 +529,7 @@ public class EmailNorthbounderConfigurationResource extends OnmsRestService impl
                     ignored rather than rejected.
 
                     `EmailDestination` exposes only `name` and `filters` as writable properties, and a form
-                    value cannot express a filter list, so in practice this operation can only rename a
-                    destination. POST the destination again to change its filters.""",
+                    value cannot express a filter list, so this operation can only rename a destination.""",
             operationId = "updateEmailDestination")
     @RequestBody(required = true, description = "Form-encoded property assignments. `name` is the only property a form value can usefully set.",
             content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/JavamailConfigurationResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/JavamailConfigurationResource.java
@@ -278,9 +278,8 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
                     Sets `default-read-config-name` on the root element of javamail-configuration.xml. The name
                     is taken from the path; there is no request body.
 
-                    A name that matches no `readmail-config` entry is silently ignored: the call still returns
-                    204 and the stored default is left unchanged. Check with
-                    `GET /config/javamail/default/readmail` afterwards.
+                    A name that matches no `readmail-config` entry is ignored: the call still returns 204 and
+                    the stored default is left unchanged.
 
                     Any write here re-marshals the whole of javamail-configuration.xml from the in-memory model and
                     then sends a `reloadDaemonConfig` event naming `EmailNBI`, so comments and formatting in the
@@ -310,9 +309,8 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
                     Sets `default-send-config-name` on the root element of javamail-configuration.xml. The name
                     is taken from the path; there is no request body.
 
-                    A name that matches no `sendmail-config` entry is silently ignored: the call still returns
-                    204 and the stored default is left unchanged. Check with
-                    `GET /config/javamail/default/sendmail` afterwards.
+                    A name that matches no `sendmail-config` entry is ignored: the call still returns 204 and
+                    the stored default is left unchanged.
 
                     Any write here re-marshals the whole of javamail-configuration.xml from the in-memory model and
                     then sends a `reloadDaemonConfig` event naming `EmailNBI`, so comments and formatting in the
@@ -425,8 +423,8 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
             summary = "List the end2end mail configuration names",
             description = """
                     Returns only the names of the `end2end-mail-config` entries. Each pairs a sendmail
-                    configuration with a readmail configuration for the mail transport monitor to send through
-                    one and read back from the other.""",
+                    configuration with a readmail configuration; the mail transport monitor sends through one
+                    and reads back from the other.""",
             operationId = "getEnd2endConfigurationNames")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "The end2end configuration names.",
@@ -764,8 +762,7 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
                     `sendmail-message`, `user-auth` or `javamail-property` blocks: the PUT reaches the scalar
                     fields only.
 
-                    Email northbounder destinations reference these entries by name, so the name is what ties a
-                    destination to its SMTP settings.
+                    Email northbounder destinations reference these entries by name.
 
                     Any write here re-marshals the whole of javamail-configuration.xml from the in-memory model and
                     then sends a `reloadDaemonConfig` event naming `EmailNBI`, so comments and formatting in the
@@ -917,8 +914,9 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
                     the configuration, then saves. Keys are bean property names, not XML element or attribute
                     names, and unrecognised keys are ignored rather than rejected.
 
-                    The writable properties are `name`, `debug`, `attemptInterval`, `deleteAllMail`, `mailFolder`, `javamailProperties`, `readmailHost` and `userAuth`. The ones holding nested objects or lists cannot be
-                    expressed as a form value, so POST the configuration again to change those.
+                    The writable properties are `name`, `debug`, `attemptInterval`, `deleteAllMail`,
+                    `mailFolder`, `javamailProperties`, `readmailHost` and `userAuth`. The ones holding nested
+                    objects or lists cannot be expressed as a form value.
 
                     Any write here re-marshals the whole of javamail-configuration.xml from the in-memory model and
                     then sends a `reloadDaemonConfig` event naming `EmailNBI`, so comments and formatting in the
@@ -969,8 +967,9 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
                     the configuration, then saves. Keys are bean property names, not XML element or attribute
                     names, and unrecognised keys are ignored rather than rejected.
 
-                    The writable properties are `name`, `debug`, `attemptInterval`, `useAuthentication`, `useJmta`, `javamailProperties`, `sendmailHost`, `sendmailProtocol`, `sendmailMessage` and `userAuth`. The ones holding nested objects or lists cannot be
-                    expressed as a form value, so POST the configuration again to change those.
+                    The writable properties are `name`, `debug`, `attemptInterval`, `useAuthentication`,
+                    `useJmta`, `javamailProperties`, `sendmailHost`, `sendmailProtocol`, `sendmailMessage` and
+                    `userAuth`. The ones holding nested objects or lists cannot be expressed as a form value.
 
                     Any write here re-marshals the whole of javamail-configuration.xml from the in-memory model and
                     then sends a `reloadDaemonConfig` event naming `EmailNBI`, so comments and formatting in the
@@ -1021,8 +1020,7 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
                     the configuration, then saves. Keys are bean property names, not XML element or attribute
                     names, and unrecognised keys are ignored rather than rejected.
 
-                    The writable properties are `name`, `sendmailConfigName` and `readmailConfigName`. The ones holding nested objects or lists cannot be
-                    expressed as a form value, so POST the configuration again to change those.
+                    The writable properties are `name`, `sendmailConfigName` and `readmailConfigName`.
 
                     Any write here re-marshals the whole of javamail-configuration.xml from the in-memory model and
                     then sends a `reloadDaemonConfig` event naming `EmailNBI`, so comments and formatting in the
@@ -1068,7 +1066,8 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
     @Operation(
             summary = "Delete a readmail configuration",
             description = """
-                    Removes the entry and saves javamail-configuration.xml. Nothing checks whether an `end2end-mail-config` or the `default-read-config-name` attribute still points at it.
+                    Removes the entry and saves javamail-configuration.xml. Nothing checks whether an
+                    `end2end-mail-config` or the `default-read-config-name` attribute still points at it.
 
                     Any write here re-marshals the whole of javamail-configuration.xml from the in-memory model and
                     then sends a `reloadDaemonConfig` event naming `EmailNBI`, so comments and formatting in the
@@ -1099,7 +1098,9 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
     @Operation(
             summary = "Delete a sendmail configuration",
             description = """
-                    Removes the entry and saves javamail-configuration.xml. Nothing checks whether an `end2end-mail-config`, the `default-send-config-name` attribute or an Email northbounder destination still points at it.
+                    Removes the entry and saves javamail-configuration.xml. Nothing checks whether an
+                    `end2end-mail-config`, the `default-send-config-name` attribute or an Email northbounder
+                    destination still points at it.
 
                     Any write here re-marshals the whole of javamail-configuration.xml from the in-memory model and
                     then sends a `reloadDaemonConfig` event naming `EmailNBI`, so comments and formatting in the

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/JavamailConfigurationResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/JavamailConfigurationResource.java
@@ -53,6 +53,14 @@ import org.springframework.beans.PropertyAccessorFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 /**
  * The Class JavamailConfigurationResource.
@@ -200,6 +208,22 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
     @GET
     @Path("default/readmail")
     @Produces(MediaType.TEXT_PLAIN)
+    @Operation(
+            summary = "Get the name of the default readmail configuration",
+            description = """
+                    Returns the value of the `default-read-config-name` attribute on the root element of
+                    javamail-configuration.xml as a bare string, not as a JSON or XML document.
+
+                    This operation produces text/plain only, so a request sent with
+                    `Accept: application/json` is rejected with a 406.""",
+            operationId = "getDefaultReadmailConfigurationName")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The default readmail configuration name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "localhost"))),
+            @ApiResponse(responseCode = "404", description = "No default readmail configuration is set. Bodiless.")
+    })
     public Response getDefaultReadmailConfiguration() {
         ReadmailConfig config = m_javamailConfigurationDao.getDefaultReadmailConfig();
         if (config == null) {
@@ -216,6 +240,22 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
     @GET
     @Path("default/sendmail")
     @Produces(MediaType.TEXT_PLAIN)
+    @Operation(
+            summary = "Get the name of the default sendmail configuration",
+            description = """
+                    Returns the value of the `default-send-config-name` attribute on the root element of
+                    javamail-configuration.xml as a bare string, not as a JSON or XML document.
+
+                    This operation produces text/plain only, so a request sent with
+                    `Accept: application/json` is rejected with a 406.""",
+            operationId = "getDefaultSendmailConfigurationName")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The default sendmail configuration name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "localhost"))),
+            @ApiResponse(responseCode = "404", description = "No default sendmail configuration is set. Bodiless.")
+    })
     public Response getDefaultSendmailConfiguration() {
         SendmailConfig config = m_javamailConfigurationDao.getDefaultSendmailConfig();
         if (config == null) {
@@ -232,7 +272,26 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
      */
     @PUT
     @Path("default/readmail/{readmailConfig}")
-    public Response setDefaultReadmailConfiguration(@PathParam("readmailConfig") final String readmailConfigName) {
+    @Operation(
+            summary = "Set the default readmail configuration",
+            description = """
+                    Sets `default-read-config-name` on the root element of javamail-configuration.xml. The name
+                    is taken from the path; there is no request body.
+
+                    A name that matches no `readmail-config` entry is silently ignored: the call still returns
+                    204 and the stored default is left unchanged. Check with
+                    `GET /config/javamail/default/readmail` afterwards.
+
+                    Any write here re-marshals the whole of javamail-configuration.xml from the in-memory model and
+                    then sends a `reloadDaemonConfig` event naming `EmailNBI`, so comments and formatting in the
+                    file are lost. The passwords in `user-auth` are stored and returned in the clear.""",
+            operationId = "setDefaultReadmailConfiguration")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The request was accepted and the configuration saved. This does not confirm that the name matched an existing configuration."),
+            @ApiResponse(responseCode = "500", description = "The configuration could not be saved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
+    public Response setDefaultReadmailConfiguration(@Parameter(description = "Name of the readmail-config entry.", required = true, example = "localhost") @PathParam("readmailConfig") final String readmailConfigName) {
         m_javamailConfigurationDao.setDefaultReadmailConfig(readmailConfigName);
         return saveConfiguration();
     }
@@ -245,7 +304,26 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
      */
     @PUT
     @Path("default/sendmail/{sendmailConfig}")
-    public Response setDefaultSendmailConfiguration(@PathParam("sendmailConfig") final String sendmailConfigName) {
+    @Operation(
+            summary = "Set the default sendmail configuration",
+            description = """
+                    Sets `default-send-config-name` on the root element of javamail-configuration.xml. The name
+                    is taken from the path; there is no request body.
+
+                    A name that matches no `sendmail-config` entry is silently ignored: the call still returns
+                    204 and the stored default is left unchanged. Check with
+                    `GET /config/javamail/default/sendmail` afterwards.
+
+                    Any write here re-marshals the whole of javamail-configuration.xml from the in-memory model and
+                    then sends a `reloadDaemonConfig` event naming `EmailNBI`, so comments and formatting in the
+                    file are lost. The passwords in `user-auth` are stored and returned in the clear.""",
+            operationId = "setDefaultSendmailConfiguration")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The request was accepted and the configuration saved. This does not confirm that the name matched an existing configuration."),
+            @ApiResponse(responseCode = "500", description = "The configuration could not be saved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
+    public Response setDefaultSendmailConfiguration(@Parameter(description = "Name of the sendmail-config entry.", required = true, example = "localhost") @PathParam("sendmailConfig") final String sendmailConfigName) {
         m_javamailConfigurationDao.setDefaultSendmailConfig(sendmailConfigName);
         return saveConfiguration();
     }
@@ -258,6 +336,37 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
     @GET
     @Path("readmails")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "List the readmail configuration names",
+            description = """
+                    Returns only the names of the `readmail-config` entries, not the configurations themselves.
+                    Entries with no `name` are skipped.
+
+                    The XML form is rooted at `sendmail-configs` even though the child elements are
+                    `readmail-config`; the wrapper class carries the sendmail root element name.""",
+            operationId = "getReadmailConfigurationNames")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The readmail configuration names.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = ReadmailConfigList.class),
+                                    examples = @ExampleObject(value = """
+                                            {
+                                              "totalCount": 2,
+                                              "count": 2,
+                                              "offset": 0,
+                                              "readmail-config": ["localhost", "google"]
+                                            }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = ReadmailConfigList.class),
+                                    examples = @ExampleObject(value = """
+                                            <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                                            <sendmail-configs count="2" offset="0" totalCount="2">
+                                              <readmail-config>localhost</readmail-config>
+                                              <readmail-config>google</readmail-config>
+                                            </sendmail-configs>"""))
+                    })
+    })
     public Response getReadmailConfigurations() {
         ReadmailConfigList readmails = new ReadmailConfigList(m_javamailConfigurationDao.getReadmailConfigs());
         return Response.ok(readmails).build();
@@ -271,6 +380,34 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
     @GET
     @Path("sendmails")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "List the sendmail configuration names",
+            description = """
+                    Returns only the names of the `sendmail-config` entries, not the configurations themselves.
+                    Entries with no `name` are skipped.""",
+            operationId = "getSendmailConfigurationNames")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The sendmail configuration names.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = SendmailConfigList.class),
+                                    examples = @ExampleObject(value = """
+                                            {
+                                              "totalCount": 2,
+                                              "count": 2,
+                                              "offset": 0,
+                                              "sendmail-config": ["localhost", "google"]
+                                            }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = SendmailConfigList.class),
+                                    examples = @ExampleObject(value = """
+                                            <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                                            <sendmail-configs count="2" offset="0" totalCount="2">
+                                              <sendmail-config>localhost</sendmail-config>
+                                              <sendmail-config>google</sendmail-config>
+                                            </sendmail-configs>"""))
+                    })
+    })
     public Response getSendmailConfigurations() {
         SendmailConfigList sendmails = new SendmailConfigList(m_javamailConfigurationDao.getSendmailConfigs());
         return Response.ok(sendmails).build();
@@ -284,6 +421,34 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
     @GET
     @Path("end2ends")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "List the end2end mail configuration names",
+            description = """
+                    Returns only the names of the `end2end-mail-config` entries. Each pairs a sendmail
+                    configuration with a readmail configuration for the mail transport monitor to send through
+                    one and read back from the other.""",
+            operationId = "getEnd2endConfigurationNames")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The end2end configuration names.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = End2endConfigList.class),
+                                    examples = @ExampleObject(value = """
+                                            {
+                                              "totalCount": 1,
+                                              "count": 1,
+                                              "offset": 0,
+                                              "end2end-config": ["default"]
+                                            }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = End2endConfigList.class),
+                                    examples = @ExampleObject(value = """
+                                            <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                                            <end2end-configs count="1" offset="0" totalCount="1">
+                                              <end2end-config>default</end2end-config>
+                                            </end2end-configs>"""))
+                    })
+    })
     public Response getEnd2endConfigurations() {
         End2endConfigList sendmails = new End2endConfigList(m_javamailConfigurationDao.getEnd2EndConfigs());
         return Response.ok(sendmails).build();
@@ -298,7 +463,65 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
     @GET
     @Path("readmails/{readmailConfig}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    public ReadmailConfig getReadmailConfiguration(@PathParam("readmailConfig") final String readmailConfig) {
+    @Operation(
+            summary = "Get one readmail configuration",
+            description = """
+                    Returns the named `readmail-config`. The literal name `default` is special-cased to the
+                    configuration named by `default-read-config-name`, so a configuration actually called
+                    `default` cannot be fetched by name.
+
+                    `user-auth.password` is returned in the clear.""",
+            operationId = "getReadmailConfiguration")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The readmail configuration.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = ReadmailConfig.class),
+                                    examples = @ExampleObject(value = """
+                                            {
+                                              "name": "ApiDocReadmail",
+                                              "debug": false,
+                                              "mail-folder": "INBOX",
+                                              "attempt-interval": 1000,
+                                              "delete-all-mail": false,
+                                              "javamail-property": [
+                                                {
+                                                  "name": "mail.pop3.rsetbeforequit",
+                                                  "value": "false"
+                                                }
+                                              ],
+                                              "readmail-host": {
+                                                "host": "127.0.0.1",
+                                                "port": 110,
+                                                "readmail-protocol": {
+                                                  "transport": "pop3",
+                                                  "ssl-enable": false,
+                                                  "start-tls": false
+                                                }
+                                              },
+                                              "user-auth": {
+                                                "user-name": "opennms",
+                                                "password": "opennms"
+                                              }
+                                            }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = ReadmailConfig.class),
+                                    examples = @ExampleObject(value = """
+                                            <readmail-config xmlns="http://xmlns.opennms.org/xsd/config/javamail-configuration" name="ApiDocReadmail" attempt-interval="1000" delete-all-mail="false"
+                                                            mail-folder="INBOX" debug="false">
+                                              <javamail-property name="mail.pop3.rsetbeforequit" value="false"/>
+                                              <readmail-host host="127.0.0.1" port="110">
+                                                <readmail-protocol transport="pop3" ssl-enable="false" start-tls="false"/>
+                                              </readmail-host>
+                                              <user-auth user-name="opennms" password="opennms"/>
+                                            </readmail-config>"""))
+                    }),
+            @ApiResponse(responseCode = "404", description = "No readmail configuration has that name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Readmail configuration ApiDocReadmail was not found.")))
+    })
+    public ReadmailConfig getReadmailConfiguration(@Parameter(description = "Name of the readmail-config entry.", required = true, example = "localhost") @PathParam("readmailConfig") final String readmailConfig) {
         ReadmailConfig readmail = "default".equals(readmailConfig) ? m_javamailConfigurationDao.getDefaultReadmailConfig() : m_javamailConfigurationDao.getReadMailConfig(readmailConfig);
         if (readmail == null) {
             throw getException(Status.NOT_FOUND, "Readmail configuration {} was not found.", readmailConfig);
@@ -315,7 +538,76 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
     @GET
     @Path("sendmails/{sendmailConfig}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    public SendmailConfig getSendmailConfiguration(@PathParam("sendmailConfig") final String sendmailConfig) {
+    @Operation(
+            summary = "Get one sendmail configuration",
+            description = """
+                    Returns the named `sendmail-config`. The literal name `default` is special-cased to the
+                    configuration named by `default-send-config-name`, so a configuration actually called
+                    `default` cannot be fetched by name.
+
+                    `user-auth.password` is returned in the clear.""",
+            operationId = "getSendmailConfiguration")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The sendmail configuration.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = SendmailConfig.class),
+                                    examples = @ExampleObject(value = """
+                                            {
+                                              "name": "ApiDocSendmail",
+                                              "debug": false,
+                                              "use-authentication": false,
+                                              "use-jmta": false,
+                                              "attempt-interval": 3000,
+                                              "javamail-property": [],
+                                              "sendmail-host": {
+                                                "host": "127.0.0.1",
+                                                "port": 25
+                                              },
+                                              "sendmail-protocol": {
+                                                "char-set": "us-ascii",
+                                                "mailer": "smtpsend",
+                                                "message-content-type": "text/plain",
+                                                "message-encoding": "7-bit",
+                                                "quit-wait": true,
+                                                "transport": "smtp",
+                                                "ssl-enable": false,
+                                                "start-tls": false
+                                              },
+                                              "sendmail-message": {
+                                                "to": "root@localhost",
+                                                "from": "root@[127.0.0.1]",
+                                                "reply-to": null,
+                                                "subject": "OpenNMS Test Message",
+                                                "body": "This is an OpenNMS test message."
+                                              },
+                                              "user-auth": {
+                                                "user-name": "opennms",
+                                                "password": "opennms"
+                                              }
+                                            }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = SendmailConfig.class),
+                                    examples = @ExampleObject(value = """
+                                            <sendmail-config xmlns="http://xmlns.opennms.org/xsd/config/javamail-configuration" name="ApiDocSendmail" attempt-interval="3000" use-authentication="false"
+                                                            use-jmta="false" debug="false">
+                                              <sendmail-host host="127.0.0.1" port="25"/>
+                                              <sendmail-protocol char-set="us-ascii" mailer="smtpsend"
+                                                                 message-content-type="text/plain" message-encoding="7-bit"
+                                                                 quit-wait="true" transport="smtp" ssl-enable="false"
+                                                                 start-tls="false"/>
+                                              <sendmail-message to="root@localhost" from="root@[127.0.0.1]"
+                                                                subject="OpenNMS Test Message"
+                                                                body="This is an OpenNMS test message."/>
+                                              <user-auth user-name="opennms" password="opennms"/>
+                                            </sendmail-config>"""))
+                    }),
+            @ApiResponse(responseCode = "404", description = "No sendmail configuration has that name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Sendmail configuration ApiDocSendmail was not found.")))
+    })
+    public SendmailConfig getSendmailConfiguration(@Parameter(description = "Name of the sendmail-config entry.", required = true, example = "localhost") @PathParam("sendmailConfig") final String sendmailConfig) {
         SendmailConfig sendmail = "default".equals(sendmailConfig) ? m_javamailConfigurationDao.getDefaultSendmailConfig() : m_javamailConfigurationDao.getSendMailConfig(sendmailConfig);
         if (sendmail == null) {
             throw getException(Status.NOT_FOUND, "Sendmail configuration {} was not found.", sendmailConfig);
@@ -332,7 +624,38 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
     @GET
     @Path("end2ends/{end2endConfig}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    public End2endMailConfig getEnd2EndMailConfiguration(@PathParam("end2endConfig") final String end2endConfig) {
+    @Operation(
+            summary = "Get one end2end mail configuration",
+            description = """
+                    Returns the named `end2end-mail-config`. Unlike the readmail and sendmail lookups there is
+                    no `default` special case, so `default` here means an entry actually named `default`.
+
+                    Neither name is validated against the configurations that exist.""",
+            operationId = "getEnd2endMailConfiguration")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The end2end mail configuration.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = End2endMailConfig.class),
+                                    examples = @ExampleObject(value = """
+                                            {
+                                              "name": "ApiDocEnd2End",
+                                              "sendmail-config-name": "localhost",
+                                              "readmail-config-name": "localhost"
+                                            }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = End2endMailConfig.class),
+                                    examples = @ExampleObject(value = """
+                                            <end2end-mail-config xmlns="http://xmlns.opennms.org/xsd/config/javamail-configuration"
+                                                             name="ApiDocEnd2End" sendmail-config-name="localhost"
+                                                                 readmail-config-name="localhost"/>"""))
+                    }),
+            @ApiResponse(responseCode = "404", description = "No end2end configuration has that name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "End2End configuration ApiDocEnd2End was not found.")))
+    })
+    public End2endMailConfig getEnd2EndMailConfiguration(@Parameter(description = "Name of the end2end-mail-config entry.", required = true, example = "default") @PathParam("end2endConfig") final String end2endConfig) {
         End2endMailConfig end2end = m_javamailConfigurationDao.getEnd2endConfig(end2endConfig);
         if (end2end == null) {
             throw getException(Status.NOT_FOUND, "End2End configuration {} was not found.", end2endConfig);
@@ -350,6 +673,65 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
     @POST
     @Path("readmails")
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Add or replace a readmail configuration",
+            description = """
+                    Stores the `readmail-config` under its `name`, replacing any existing entry of that name
+                    outright. This is the only way to change the nested `readmail-host`, `readmail-protocol`,
+                    `user-auth` or `javamail-property` blocks: the PUT reaches the scalar fields only.
+
+                    Any write here re-marshals the whole of javamail-configuration.xml from the in-memory model and
+                    then sends a `reloadDaemonConfig` event naming `EmailNBI`, so comments and formatting in the
+                    file are lost.""",
+            operationId = "setReadmailConfiguration")
+    @RequestBody(required = true, description = "The readmail configuration to add or replace.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ReadmailConfig.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                              "name": "ApiDocReadmail",
+                                              "debug": false,
+                                              "mail-folder": "INBOX",
+                                              "attempt-interval": 1000,
+                                              "delete-all-mail": false,
+                                              "javamail-property": [
+                                                {
+                                                  "name": "mail.pop3.rsetbeforequit",
+                                                  "value": "false"
+                                                }
+                                              ],
+                                              "readmail-host": {
+                                                "host": "127.0.0.1",
+                                                "port": 110,
+                                                "readmail-protocol": {
+                                                  "transport": "pop3",
+                                                  "ssl-enable": false,
+                                                  "start-tls": false
+                                                }
+                                              },
+                                              "user-auth": {
+                                                "user-name": "opennms",
+                                                "password": "opennms"
+                                              }
+                                            }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = ReadmailConfig.class),
+                            examples = @ExampleObject(value = """
+                                    <readmail-config xmlns="http://xmlns.opennms.org/xsd/config/javamail-configuration" name="ApiDocReadmail" attempt-interval="1000" delete-all-mail="false"
+                                                            mail-folder="INBOX" debug="false">
+                                              <javamail-property name="mail.pop3.rsetbeforequit" value="false"/>
+                                              <readmail-host host="127.0.0.1" port="110">
+                                                <readmail-protocol transport="pop3" ssl-enable="false" start-tls="false"/>
+                                              </readmail-host>
+                                              <user-auth user-name="opennms" password="opennms"/>
+                                            </readmail-config>"""))
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The configuration was stored and the reload event sent."),
+            @ApiResponse(responseCode = "500", description = "The body could not be parsed, or the configuration could not be saved. An empty body reaches this rather than the 400 the null check suggests.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
     public Response setReadmailConfiguration(final ReadmailConfig readmailConfig) {
         writeLock();
         try {
@@ -374,6 +756,79 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
     @POST
     @Path("sendmails")
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Add or replace a sendmail configuration",
+            description = """
+                    Stores the `sendmail-config` under its `name`, replacing any existing entry of that name
+                    outright. This is the only way to change the nested `sendmail-host`, `sendmail-protocol`,
+                    `sendmail-message`, `user-auth` or `javamail-property` blocks: the PUT reaches the scalar
+                    fields only.
+
+                    Email northbounder destinations reference these entries by name, so the name is what ties a
+                    destination to its SMTP settings.
+
+                    Any write here re-marshals the whole of javamail-configuration.xml from the in-memory model and
+                    then sends a `reloadDaemonConfig` event naming `EmailNBI`, so comments and formatting in the
+                    file are lost.""",
+            operationId = "setSendmailConfiguration")
+    @RequestBody(required = true, description = "The sendmail configuration to add or replace.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = SendmailConfig.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                              "name": "ApiDocSendmail",
+                                              "debug": false,
+                                              "use-authentication": false,
+                                              "use-jmta": false,
+                                              "attempt-interval": 3000,
+                                              "javamail-property": [],
+                                              "sendmail-host": {
+                                                "host": "127.0.0.1",
+                                                "port": 25
+                                              },
+                                              "sendmail-protocol": {
+                                                "char-set": "us-ascii",
+                                                "mailer": "smtpsend",
+                                                "message-content-type": "text/plain",
+                                                "message-encoding": "7-bit",
+                                                "quit-wait": true,
+                                                "transport": "smtp",
+                                                "ssl-enable": false,
+                                                "start-tls": false
+                                              },
+                                              "sendmail-message": {
+                                                "to": "root@localhost",
+                                                "from": "root@[127.0.0.1]",
+                                                "subject": "OpenNMS Test Message",
+                                                "body": "This is an OpenNMS test message."
+                                              },
+                                              "user-auth": {
+                                                "user-name": "opennms",
+                                                "password": "opennms"
+                                              }
+                                            }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = SendmailConfig.class),
+                            examples = @ExampleObject(value = """
+                                    <sendmail-config xmlns="http://xmlns.opennms.org/xsd/config/javamail-configuration" name="ApiDocSendmail" attempt-interval="3000" use-authentication="false"
+                                                            use-jmta="false" debug="false">
+                                              <sendmail-host host="127.0.0.1" port="25"/>
+                                              <sendmail-protocol char-set="us-ascii" mailer="smtpsend"
+                                                                 message-content-type="text/plain" message-encoding="7-bit"
+                                                                 quit-wait="true" transport="smtp" ssl-enable="false"
+                                                                 start-tls="false"/>
+                                              <sendmail-message to="root@localhost" from="root@[127.0.0.1]"
+                                                                subject="OpenNMS Test Message"
+                                                                body="This is an OpenNMS test message."/>
+                                              <user-auth user-name="opennms" password="opennms"/>
+                                            </sendmail-config>"""))
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The configuration was stored and the reload event sent."),
+            @ApiResponse(responseCode = "500", description = "The body could not be parsed, or the configuration could not be saved. An empty body reaches this rather than the 400 the null check suggests.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
     public Response setSendmailConfiguration(final SendmailConfig sendmailConfig) {
         writeLock();
         try {
@@ -398,6 +853,39 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
     @POST
     @Path("end2ends")
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Add or replace an end2end mail configuration",
+            description = """
+                    Stores the `end2end-mail-config` under its `name`, replacing any existing entry of that name
+                    outright. Neither `sendmail-config-name` nor `readmail-config-name` is validated at write
+                    time.
+
+                    Any write here re-marshals the whole of javamail-configuration.xml from the in-memory model and
+                    then sends a `reloadDaemonConfig` event naming `EmailNBI`, so comments and formatting in the
+                    file are lost.""",
+            operationId = "setEnd2endMailConfiguration")
+    @RequestBody(required = true, description = "The end2end mail configuration to add or replace.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = End2endMailConfig.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                              "name": "ApiDocEnd2End",
+                                              "sendmail-config-name": "localhost",
+                                              "readmail-config-name": "localhost"
+                                            }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = End2endMailConfig.class),
+                            examples = @ExampleObject(value = """
+                                    <end2end-mail-config xmlns="http://xmlns.opennms.org/xsd/config/javamail-configuration"
+                                                             name="ApiDocEnd2End" sendmail-config-name="localhost"
+                                                                 readmail-config-name="localhost"/>"""))
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The configuration was stored and the reload event sent."),
+            @ApiResponse(responseCode = "500", description = "The body could not be parsed, or the configuration could not be saved. An empty body reaches this rather than the 400 the null check suggests.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
     public Response setEnd2EndMailConfiguration(final End2endMailConfig end2endMailConfig) {
         writeLock();
         try {
@@ -422,7 +910,35 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
     @PUT
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("readmails/{readmailConfig}")
-    public Response updateReadmailConfiguration(@PathParam("readmailConfig") final String readmailConfigName, final MultivaluedMapImpl params) {
+    @Operation(
+            summary = "Update fields on a readmail configuration",
+            description = """
+                    Takes a form-encoded body and applies each key to the matching writable bean property of
+                    the configuration, then saves. Keys are bean property names, not XML element or attribute
+                    names, and unrecognised keys are ignored rather than rejected.
+
+                    The writable properties are `name`, `debug`, `attemptInterval`, `deleteAllMail`, `mailFolder`, `javamailProperties`, `readmailHost` and `userAuth`. The ones holding nested objects or lists cannot be
+                    expressed as a form value, so POST the configuration again to change those.
+
+                    Any write here re-marshals the whole of javamail-configuration.xml from the in-memory model and
+                    then sends a `reloadDaemonConfig` event naming `EmailNBI`, so comments and formatting in the
+                    file are lost.""",
+            operationId = "updateReadmailConfiguration")
+    @RequestBody(required = true, description = "Form-encoded property assignments, keyed by bean property name.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "object"),
+                    examples = @ExampleObject(value = "debug=true&attemptInterval=2000&mailFolder=INBOX")))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "At least one property was applied and the configuration was saved."),
+            @ApiResponse(responseCode = "304", description = "No key in the body matched a writable property, so nothing was changed."),
+            @ApiResponse(responseCode = "404", description = "No readmail configuration has that name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Readmail configuration ApiDocReadmail was not found."))),
+            @ApiResponse(responseCode = "500", description = "The configuration could not be saved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
+    public Response updateReadmailConfiguration(@Parameter(description = "Name of the readmail-config entry.", required = true, example = "localhost") @PathParam("readmailConfig") final String readmailConfigName, final MultivaluedMapImpl params) {
         writeLock();
         try {
             ReadmailConfig readmailConfig = getReadmailConfiguration(readmailConfigName);
@@ -446,7 +962,35 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
     @PUT
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("sendmails/{sendmailConfig}")
-    public Response updateSendmailConfiguration(@PathParam("sendmailConfig") final String sendmailConfigName, final MultivaluedMapImpl params) {
+    @Operation(
+            summary = "Update fields on a sendmail configuration",
+            description = """
+                    Takes a form-encoded body and applies each key to the matching writable bean property of
+                    the configuration, then saves. Keys are bean property names, not XML element or attribute
+                    names, and unrecognised keys are ignored rather than rejected.
+
+                    The writable properties are `name`, `debug`, `attemptInterval`, `useAuthentication`, `useJmta`, `javamailProperties`, `sendmailHost`, `sendmailProtocol`, `sendmailMessage` and `userAuth`. The ones holding nested objects or lists cannot be
+                    expressed as a form value, so POST the configuration again to change those.
+
+                    Any write here re-marshals the whole of javamail-configuration.xml from the in-memory model and
+                    then sends a `reloadDaemonConfig` event naming `EmailNBI`, so comments and formatting in the
+                    file are lost.""",
+            operationId = "updateSendmailConfiguration")
+    @RequestBody(required = true, description = "Form-encoded property assignments, keyed by bean property name.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "object"),
+                    examples = @ExampleObject(value = "debug=true&attemptInterval=5000&useAuthentication=true")))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "At least one property was applied and the configuration was saved."),
+            @ApiResponse(responseCode = "304", description = "No key in the body matched a writable property, so nothing was changed."),
+            @ApiResponse(responseCode = "404", description = "No sendmail configuration has that name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Sendmail configuration ApiDocSendmail was not found."))),
+            @ApiResponse(responseCode = "500", description = "The configuration could not be saved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
+    public Response updateSendmailConfiguration(@Parameter(description = "Name of the sendmail-config entry.", required = true, example = "localhost") @PathParam("sendmailConfig") final String sendmailConfigName, final MultivaluedMapImpl params) {
         writeLock();
         try {
             SendmailConfig sendmailConfig = getSendmailConfiguration(sendmailConfigName);
@@ -470,7 +1014,35 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
     @PUT
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("end2ends/{end2endConfig}")
-    public Response updateEnd2endConfiguration(@PathParam("end2endConfig") final String end2endConfigName, final MultivaluedMapImpl params) {
+    @Operation(
+            summary = "Update fields on a end2end mail configuration",
+            description = """
+                    Takes a form-encoded body and applies each key to the matching writable bean property of
+                    the configuration, then saves. Keys are bean property names, not XML element or attribute
+                    names, and unrecognised keys are ignored rather than rejected.
+
+                    The writable properties are `name`, `sendmailConfigName` and `readmailConfigName`. The ones holding nested objects or lists cannot be
+                    expressed as a form value, so POST the configuration again to change those.
+
+                    Any write here re-marshals the whole of javamail-configuration.xml from the in-memory model and
+                    then sends a `reloadDaemonConfig` event naming `EmailNBI`, so comments and formatting in the
+                    file are lost.""",
+            operationId = "updateEnd2endMailConfiguration")
+    @RequestBody(required = true, description = "Form-encoded property assignments, keyed by bean property name.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "object"),
+                    examples = @ExampleObject(value = "sendmailConfigName=localhost&readmailConfigName=localhost")))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "At least one property was applied and the configuration was saved."),
+            @ApiResponse(responseCode = "304", description = "No key in the body matched a writable property, so nothing was changed."),
+            @ApiResponse(responseCode = "404", description = "No end2end mail configuration has that name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "End2End configuration ApiDocEnd2End was not found."))),
+            @ApiResponse(responseCode = "500", description = "The configuration could not be saved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
+    public Response updateEnd2endConfiguration(@Parameter(description = "Name of the end2end-mail-config entry.", required = true, example = "default") @PathParam("end2endConfig") final String end2endConfigName, final MultivaluedMapImpl params) {
         writeLock();
         try {
             End2endMailConfig end2endConfig = getEnd2EndMailConfiguration(end2endConfigName);
@@ -493,7 +1065,22 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
     @DELETE
     @Path("readmails/{readmailConfig}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    public Response removeReadmailConfig(@PathParam("readmailConfig") final String readmailConfig) {
+    @Operation(
+            summary = "Delete a readmail configuration",
+            description = """
+                    Removes the entry and saves javamail-configuration.xml. Nothing checks whether an `end2end-mail-config` or the `default-read-config-name` attribute still points at it.
+
+                    Any write here re-marshals the whole of javamail-configuration.xml from the in-memory model and
+                    then sends a `reloadDaemonConfig` event naming `EmailNBI`, so comments and formatting in the
+                    file are lost.""",
+            operationId = "removeReadmailConfiguration")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The configuration was removed and the reload event sent."),
+            @ApiResponse(responseCode = "404", description = "No readmail configuration has that name. Bodiless."),
+            @ApiResponse(responseCode = "500", description = "The configuration could not be saved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
+    public Response removeReadmailConfig(@Parameter(description = "Name of the readmail-config entry.", required = true, example = "localhost") @PathParam("readmailConfig") final String readmailConfig) {
         if (m_javamailConfigurationDao.removeReadMailConfig(readmailConfig)) {
             return saveConfiguration();
         }
@@ -509,7 +1096,22 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
     @DELETE
     @Path("sendmails/{sendmailConfig}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    public Response removeSendmailConfig(@PathParam("sendmailConfig") final String sendmailConfig) {
+    @Operation(
+            summary = "Delete a sendmail configuration",
+            description = """
+                    Removes the entry and saves javamail-configuration.xml. Nothing checks whether an `end2end-mail-config`, the `default-send-config-name` attribute or an Email northbounder destination still points at it.
+
+                    Any write here re-marshals the whole of javamail-configuration.xml from the in-memory model and
+                    then sends a `reloadDaemonConfig` event naming `EmailNBI`, so comments and formatting in the
+                    file are lost.""",
+            operationId = "removeSendmailConfiguration")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The configuration was removed and the reload event sent."),
+            @ApiResponse(responseCode = "404", description = "No sendmail configuration has that name. Bodiless."),
+            @ApiResponse(responseCode = "500", description = "The configuration could not be saved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
+    public Response removeSendmailConfig(@Parameter(description = "Name of the sendmail-config entry.", required = true, example = "localhost") @PathParam("sendmailConfig") final String sendmailConfig) {
         if (m_javamailConfigurationDao.removeSendMailConfig(sendmailConfig)) {
             return saveConfiguration();
         }
@@ -525,7 +1127,22 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
     @DELETE
     @Path("end2ends/{end2endConfig}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    public Response removeEnd2endConfig(@PathParam("end2endConfig") final String end2endConfig) {
+    @Operation(
+            summary = "Delete a end2end mail configuration",
+            description = """
+                    Removes the entry and saves javamail-configuration.xml.
+
+                    Any write here re-marshals the whole of javamail-configuration.xml from the in-memory model and
+                    then sends a `reloadDaemonConfig` event naming `EmailNBI`, so comments and formatting in the
+                    file are lost.""",
+            operationId = "removeEnd2endMailConfiguration")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The configuration was removed and the reload event sent."),
+            @ApiResponse(responseCode = "404", description = "No end2end mail configuration has that name. Bodiless."),
+            @ApiResponse(responseCode = "500", description = "The configuration could not be saved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
+    public Response removeEnd2endConfig(@Parameter(description = "Name of the end2end-mail-config entry.", required = true, example = "default") @PathParam("end2endConfig") final String end2endConfig) {
         if (m_javamailConfigurationDao.removeEnd2endConfig(end2endConfig)) {
             return saveConfiguration();
         }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/JavamailConfigurationResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/JavamailConfigurationResource.java
@@ -626,9 +626,7 @@ public class JavamailConfigurationResource extends OnmsRestService implements In
             summary = "Get one end2end mail configuration",
             description = """
                     Returns the named `end2end-mail-config`. Unlike the readmail and sendmail lookups there is
-                    no `default` special case, so `default` here means an entry actually named `default`.
-
-                    Neither name is validated against the configurations that exist.""",
+                    no `default` special case, so `default` here means an entry actually named `default`.""",
             operationId = "getEnd2endMailConfiguration")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "The end2end mail configuration.",

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/JmxDataCollectionConfigResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/JmxDataCollectionConfigResource.java
@@ -36,6 +36,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 @Component("jmxDataCollectionConfigResource")
 public class JmxDataCollectionConfigResource implements InitializingBean {
@@ -56,6 +62,65 @@ public class JmxDataCollectionConfigResource implements InitializingBean {
 
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get the JMX data collection configuration",
+            description = """
+                    Returns jmx-datacollection-config.xml as the JMX collection DAO holds it, with every
+                    `import-mbeans` include already resolved into the owning collection. The response is
+                    large: the shipped default is on the order of 100 kB of JSON.
+
+                    `rrdRepository` is the absolute path on the OpenNMS server, so it varies per
+                    installation. Each `jmx-collection` carries its own `rrd` step and RRA definitions.""",
+            operationId = "getJmxDataCollectionConfig")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The current JMX data collection configuration. The example is abbreviated to a single collection, MBean and attribute.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = JmxDatacollectionConfig.class),
+                                    examples = @ExampleObject(value = """
+                                            {
+                                              "rrdRepository": "/opt/opennms/share/rrd/snmp/",
+                                              "jmx-collection": [
+                                                {
+                                                  "name": "jmx-kafka",
+                                                  "rrd": {
+                                                    "step": 300,
+                                                    "rra": [
+                                                      "RRA:AVERAGE:0.5:1:2016",
+                                                      "RRA:AVERAGE:0.5:12:1488",
+                                                      "RRA:AVERAGE:0.5:288:366",
+                                                      "RRA:MAX:0.5:288:366",
+                                                      "RRA:MIN:0.5:288:366"
+                                                    ]
+                                                  },
+                                                  "mbeans": [
+                                                    {
+                                                      "name": "JVM Memory",
+                                                      "objectname": "java.lang:type=OperatingSystem",
+                                                      "keyfield": null,
+                                                      "exclude": null,
+                                                      "key-alias": null,
+                                                      "resource-type": null,
+                                                      "attrib": [
+                                                        {
+                                                          "name": "FreePhysicalMemorySize",
+                                                          "alias": "FreeMemory",
+                                                          "type": "gauge",
+                                                          "maxval": null,
+                                                          "minval": null
+                                                        }
+                                                      ],
+                                                      "comp-attrib": []
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = JmxDatacollectionConfig.class))
+                    }),
+            @ApiResponse(responseCode = "404", description = "The JMX data collection DAO holds no configuration. Bodiless.")
+    })
     public Response getJmxDataCollectionConfig() throws ConfigurationResourceException {
         LOG.debug("getJmxDataCollectionConfigurationForLocation()");
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/JmxDataCollectionConfigResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/JmxDataCollectionConfigResource.java
@@ -66,11 +66,11 @@ public class JmxDataCollectionConfigResource implements InitializingBean {
             summary = "Get the JMX data collection configuration",
             description = """
                     Returns jmx-datacollection-config.xml as the JMX collection DAO holds it, with every
-                    `import-mbeans` include already resolved into the owning collection. The response is
-                    large: the shipped default is on the order of 100 kB of JSON.
+                    `import-mbeans` include already resolved into the owning collection. The shipped default
+                    serializes to roughly 100 kB of JSON.
 
-                    `rrdRepository` is the absolute path on the OpenNMS server, so it varies per
-                    installation. Each `jmx-collection` carries its own `rrd` step and RRA definitions.""",
+                    `rrdRepository` is an absolute path on the OpenNMS server. Each `jmx-collection` carries
+                    its own `rrd` step and RRA definitions.""",
             operationId = "getJmxDataCollectionConfig")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "The current JMX data collection configuration. The example is abbreviated to a single collection, MBean and attribute.",

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/SnmpConfigurationResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/SnmpConfigurationResource.java
@@ -57,8 +57,8 @@ public class SnmpConfigurationResource {
                     and per-range `definition` entries, and the named `profiles` if any are configured.
 
                     Community strings, authentication and privacy passphrases are returned in the clear,
-                    exactly as they are stored. On an installation that keeps SNMP configuration in the
-                    database rather than in the file, the response reflects the database contents.
+                    exactly as they are stored. The resource reads `etc/snmp-config.xml` directly, so on an
+                    installation that keeps SNMP configuration in the database the response can be stale.
 
                     Unset defaults come back as JSON nulls and are omitted entirely from the XML form.""",
             operationId = "getSnmpConfiguration")
@@ -72,15 +72,15 @@ public class SnmpConfigurationResource {
                                               "definition": [],
                                               "profiles": null,
                                               "version": "v2c",
-                                              "readCommunity": "public",
-                                              "writeCommunity": null,
+                                              "read-community": "public",
+                                              "write-community": null,
                                               "timeout": 1800,
                                               "retry": 1,
                                               "port": null,
-                                              "maxVarsPerPdu": null,
-                                              "maxRepetitions": null,
-                                              "securityLevel": null,
-                                              "securityName": null
+                                              "max-vars-per-pdu": null,
+                                              "max-repetitions": null,
+                                              "security-level": null,
+                                              "security-name": null
                                             }""")),
                             @Content(mediaType = MediaType.APPLICATION_XML,
                                     schema = @Schema(implementation = SnmpConfig.class),

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/SnmpConfigurationResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/SnmpConfigurationResource.java
@@ -33,6 +33,12 @@ import org.opennms.netmgt.config.snmp.SnmpConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 @Component("snmpConfigurationResource")
 public class SnmpConfigurationResource {
@@ -44,6 +50,46 @@ public class SnmpConfigurationResource {
     
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get the SNMP agent configuration",
+            description = """
+                    Returns the whole of snmp-config.xml: the top-level defaults followed by the per-address
+                    and per-range `definition` entries, and the named `profiles` if any are configured.
+
+                    Community strings, authentication and privacy passphrases are returned in the clear,
+                    exactly as they are stored. On an installation that keeps SNMP configuration in the
+                    database rather than in the file, the response reflects the database contents.
+
+                    Unset defaults come back as JSON nulls and are omitted entirely from the XML form.""",
+            operationId = "getSnmpConfiguration")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The current SNMP configuration.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = SnmpConfig.class),
+                                    examples = @ExampleObject(value = """
+                                            {
+                                              "definition": [],
+                                              "profiles": null,
+                                              "version": "v2c",
+                                              "readCommunity": "public",
+                                              "writeCommunity": null,
+                                              "timeout": 1800,
+                                              "retry": 1,
+                                              "port": null,
+                                              "maxVarsPerPdu": null,
+                                              "maxRepetitions": null,
+                                              "securityLevel": null,
+                                              "securityName": null
+                                            }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = SnmpConfig.class),
+                                    examples = @ExampleObject(value = """
+                                            <?xml version="1.0" encoding="UTF-8"?>
+                                            <snmp-config xmlns="http://xmlns.opennms.org/xsd/config/snmp"
+                                                         version="v2c" read-community="public" timeout="1800" retry="1"/>"""))
+                    })
+    })
     public Response getSnmpConfiguration() throws ConfigurationResourceException {
         return Response.ok(m_snmpConfigResource.get()).build();
     }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/SnmpTrapNorthbounderConfigurationResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/SnmpTrapNorthbounderConfigurationResource.java
@@ -59,6 +59,14 @@ import org.springframework.beans.PropertyAccessorFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 /**
  * The Class SnmpTrapNorthbounderConfigurationResource.
@@ -156,6 +164,52 @@ public class SnmpTrapNorthbounderConfigurationResource extends OnmsRestService i
      */
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get the SNMP trap northbounder configuration",
+            description = """
+                    Returns the whole of snmptrap-northbounder-configuration.xml. Each `snmp-trap-sink` holds
+                    its inline `mapping-group` entries plus an `import-mappings` list of paths to mapping groups
+                    kept in separate files under the configuration directory.
+
+                    The SNMP credentials are taken at send time from snmp-config.xml for the sink's
+                    `ip-address`; only `port` and `version` are overridable on the sink, and the version has to
+                    agree with what snmp-config.xml declares for that address.
+
+                    `version` and `varbind[].type` are JAXB enums whose `@XmlEnumValue` spelling differs from the
+                    constant name, and only XML honours the `@XmlEnumValue`. In XML write `v2c` and `Int32`; in
+                    JSON write the constant names `V2c` and `TYPE_SNMP_INT32`. Getting that the wrong way round
+                    produces a 500. The versions are `V1`, `V2c`, `V3`, `V2_INFORM` and `V3_INFORM`
+                    (`v1`, `v2c`, `v3`, `v2-inform`, `v3-inform` in XML); the varbind types are
+                    `TYPE_SNMP_OCTET_STRING`, `TYPE_SNMP_INT32`, `TYPE_SNMP_NULL`,
+                    `TYPE_SNMP_OBJECT_IDENTIFIER`, `TYPE_SNMP_IPADDRESS`, `TYPE_SNMP_TIMETICKS`,
+                    `TYPE_SNMP_COUNTER32`, `TYPE_SNMP_GAUGE32`, `TYPE_SNMP_OPAQUE` and `TYPE_SNMP_COUNTER64`
+                    (`OctetString`, `Int32`, and so on in XML).""",
+            operationId = "getSnmpTrapNorthbounderConfiguration")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The current SNMP trap northbounder configuration. The example has the mapping groups elided.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = SnmpTrapNorthbounderConfig.class),
+                                    examples = @ExampleObject(value = """
+                                            {
+                                              "enabled": false,
+                                              "nagles-delay": 1000,
+                                              "batch-size": 100,
+                                              "queue-size": 300000,
+                                              "snmp-trap-sink": [
+                                                {
+                                                  "name": "localTest1",
+                                                  "ip-address": "127.0.0.1",
+                                                  "version": "V2c",
+                                                  "mapping-group": [],
+                                                  "import-mappings": []
+                                                }
+                                              ]
+                                            }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = SnmpTrapNorthbounderConfig.class))
+                    })
+    })
     public Response getConfiguration() {
         return Response.ok(m_snmpTrapNorthbounderConfigDao.getConfig()).build();
     }
@@ -167,6 +221,57 @@ public class SnmpTrapNorthbounderConfigurationResource extends OnmsRestService i
      * @return the response
      */
     @POST
+    @Operation(
+            summary = "Replace the SNMP trap northbounder configuration",
+            description = """
+                    Marshals the request body straight over snmptrap-northbounder-configuration.xml, then sends
+                    a `reloadDaemonConfig` event for `SnmpTrapNBI`. The whole file is replaced, so anything
+                    absent from the body is dropped, including comments. Mapping-group files referenced through
+                    `import-mappings` are left on disk but become orphaned if the body drops the reference.
+
+                    The handler declares no `@Consumes`, so the media type is whatever the JAXB and Jackson
+                    providers accept for the body type. A body that fails to parse surfaces as a 500 rather
+                    than a 400: the null check that would produce the 400 is unreachable through those
+                    providers.
+
+                    `version` and `varbind[].type` are JAXB enums whose `@XmlEnumValue` spelling differs from the
+                    constant name, and only XML honours the `@XmlEnumValue`. In XML write `v2c` and `Int32`; in
+                    JSON write the constant names `V2c` and `TYPE_SNMP_INT32`. Getting that the wrong way round
+                    produces a 500. The versions are `V1`, `V2c`, `V3`, `V2_INFORM` and `V3_INFORM`
+                    (`v1`, `v2c`, `v3`, `v2-inform`, `v3-inform` in XML); the varbind types are
+                    `TYPE_SNMP_OCTET_STRING`, `TYPE_SNMP_INT32`, `TYPE_SNMP_NULL`,
+                    `TYPE_SNMP_OBJECT_IDENTIFIER`, `TYPE_SNMP_IPADDRESS`, `TYPE_SNMP_TIMETICKS`,
+                    `TYPE_SNMP_COUNTER32`, `TYPE_SNMP_GAUGE32`, `TYPE_SNMP_OPAQUE` and `TYPE_SNMP_COUNTER64`
+                    (`OctetString`, `Int32`, and so on in XML).""",
+            operationId = "setSnmpTrapNorthbounderConfiguration")
+    @RequestBody(required = true, description = "The complete replacement configuration.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = SnmpTrapNorthbounderConfig.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                              "enabled": false,
+                                              "nagles-delay": 1000,
+                                              "batch-size": 100,
+                                              "queue-size": 300000,
+                                              "snmp-trap-sink": [
+                                                {
+                                                  "name": "localTest1",
+                                                  "ip-address": "127.0.0.1",
+                                                  "version": "V2c",
+                                                  "mapping-group": [],
+                                                  "import-mappings": []
+                                                }
+                                              ]
+                                            }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = SnmpTrapNorthbounderConfig.class))
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The file was written and the reload event sent."),
+            @ApiResponse(responseCode = "500", description = "The body could not be parsed, or the file could not be written.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
     public Response setConfiguration(final SnmpTrapNorthbounderConfig config) {
         writeLock();
         try {
@@ -194,6 +299,21 @@ public class SnmpTrapNorthbounderConfigurationResource extends OnmsRestService i
     @GET
     @Path("status")
     @Produces(MediaType.TEXT_PLAIN)
+    @Operation(
+            summary = "Get whether the SNMP trap northbounder is enabled",
+            description = """
+                    Returns the `enabled` flag from snmptrap-northbounder-configuration.xml as the literal text
+                    `true` or `false`. An absent flag reads back as `false`.
+
+                    This operation produces text/plain only, so a request sent with
+                    `Accept: application/json` is rejected with a 406.""",
+            operationId = "getSnmpTrapNorthbounderStatus")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The current enabled flag.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "boolean"),
+                            examples = @ExampleObject(value = "false")))
+    })
     public Response getStatus() {
         return Response.ok(m_snmpTrapNorthbounderConfigDao.getConfig().isEnabled()).build();
     }
@@ -208,7 +328,22 @@ public class SnmpTrapNorthbounderConfigurationResource extends OnmsRestService i
     @PUT
     @Path("status")
     @Produces(MediaType.TEXT_PLAIN)
-    public Response getStatus(@QueryParam("enabled") final Boolean enabled) throws WebApplicationException {
+    @Operation(
+            summary = "Enable or disable the SNMP trap northbounder",
+            description = """
+                    Sets the `enabled` flag, rewrites snmptrap-northbounder-configuration.xml and sends a
+                    `reloadDaemonConfig` event for `SnmpTrapNBI`. Comments and formatting in the file are lost,
+                    because the whole file is re-marshalled from the in-memory model.
+
+                    Omitting `enabled` clears the flag rather than leaving it alone, which then reads back as
+                    `false`. Despite the text/plain declaration the success response has no body.""",
+            operationId = "setSnmpTrapNorthbounderStatus")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The flag was written and the reload event sent."),
+            @ApiResponse(responseCode = "500", description = "The configuration could not be saved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
+    public Response getStatus(@Parameter(description = "New value for the enabled flag. Omitting it clears the flag, which reads back as false.", example = "true") @QueryParam("enabled") final Boolean enabled) throws WebApplicationException {
         writeLock();
         try {
             m_snmpTrapNorthbounderConfigDao.getConfig().setEnabled(enabled);
@@ -226,6 +361,36 @@ public class SnmpTrapNorthbounderConfigurationResource extends OnmsRestService i
     @GET
     @Path("trapsinks")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "List the SNMP trap sink names",
+            description = """
+                    Returns only the trap sink names, not the sinks themselves. Fetch a single sink to see its
+                    mappings.
+
+                    `count` and `totalCount` are always equal here: the listing is not paged and `offset` is
+                    always 0.""",
+            operationId = "getSnmpTrapSinks")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The configured trap sink names.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = SnmpTrapSinkList.class),
+                                    examples = @ExampleObject(value = """
+                                            {
+                                              "totalCount": 1,
+                                              "count": 1,
+                                              "offset": 0,
+                                              "trap-sink": ["localTest1"]
+                                            }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = SnmpTrapSinkList.class),
+                                    examples = @ExampleObject(value = """
+                                            <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                                            <trap-sinks count="1" offset="0" totalCount="1">
+                                              <trap-sink>localTest1</trap-sink>
+                                            </trap-sinks>"""))
+                    })
+    })
     public Response getSnmpTrapSinks() {
         SnmpTrapSinkList trapSinks = new SnmpTrapSinkList(m_snmpTrapNorthbounderConfigDao.getConfig().getSnmpTrapSinks());
         return Response.ok(trapSinks).build();
@@ -240,7 +405,94 @@ public class SnmpTrapNorthbounderConfigurationResource extends OnmsRestService i
     @GET
     @Path("trapsinks/{trapsinkName}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    public SnmpTrapSink getSnmpTrapSink(@PathParam("trapsinkName") final String trapSinkName) {
+    @Operation(
+            summary = "Get one SNMP trap sink",
+            description = """
+                    Returns the sink with its inline mapping groups. `import-mappings` lists the paths of
+                    mapping groups held in separate files; their contents are not inlined here.
+
+                    `version` and `varbind[].type` are JAXB enums whose `@XmlEnumValue` spelling differs from the
+                    constant name, and only XML honours the `@XmlEnumValue`. In XML write `v2c` and `Int32`; in
+                    JSON write the constant names `V2c` and `TYPE_SNMP_INT32`. Getting that the wrong way round
+                    produces a 500. The versions are `V1`, `V2c`, `V3`, `V2_INFORM` and `V3_INFORM`
+                    (`v1`, `v2c`, `v3`, `v2-inform`, `v3-inform` in XML); the varbind types are
+                    `TYPE_SNMP_OCTET_STRING`, `TYPE_SNMP_INT32`, `TYPE_SNMP_NULL`,
+                    `TYPE_SNMP_OBJECT_IDENTIFIER`, `TYPE_SNMP_IPADDRESS`, `TYPE_SNMP_TIMETICKS`,
+                    `TYPE_SNMP_COUNTER32`, `TYPE_SNMP_GAUGE32`, `TYPE_SNMP_OPAQUE` and `TYPE_SNMP_COUNTER64`
+                    (`OctetString`, `Int32`, and so on in XML).
+
+                    `mapping-group[].rule`, `mapping[].rule`, `varbind[].value` and `varbind[].instance` are SpEL
+                    expressions evaluated against the `NorthboundAlarm` being forwarded, so `parameters['x']`
+                    and `eventParametersCollection[0].value` reach the alarm's event parameters. Nothing
+                    validates the expressions at write time.""",
+            operationId = "getSnmpTrapSink")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The trap sink.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = SnmpTrapSink.class),
+                                    examples = @ExampleObject(value = """
+                                            {
+                                              "name": "ApiDocTrapSink",
+                                              "ip-address": "127.0.0.1",
+                                              "port": 1162,
+                                              "version": "V2c",
+                                              "community": "public",
+                                              "mapping-group": [
+                                                {
+                                                  "name": "ApiDoc Mappings",
+                                                  "rule": "foreignSource matches '^ApiDoc.*'",
+                                                  "mapping": [
+                                                    {
+                                                      "name": "apidoctrap",
+                                                      "rule": "uei == 'uei.opennms.org/trap/apiDoc'",
+                                                      "enterprise-oid": ".1.3.6.1.4.1.5813.99.1",
+                                                      "specific": 1,
+                                                      "varbind": [
+                                                        {
+                                                          "oid": ".1.3.6.1.4.1.5813.99.1.1",
+                                                          "type": "TYPE_SNMP_OCTET_STRING",
+                                                          "value": "parameters['alarmMessage']",
+                                                          "max": 48
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ],
+                                              "import-mappings": []
+                                            }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = SnmpTrapSink.class),
+                                    examples = @ExampleObject(value = """
+                                            <snmp-trap-sink>
+                                              <name>ApiDocTrapSink</name>
+                                              <ip-address>127.0.0.1</ip-address>
+                                              <port>1162</port>
+                                              <version>v2c</version>
+                                              <community>public</community>
+                                              <mapping-group name="ApiDoc Mappings">
+                                                <rule>foreignSource matches '^ApiDoc.*'</rule>
+                                                <mapping name="apidoctrap">
+                                                  <rule>uei == 'uei.opennms.org/trap/apiDoc'</rule>
+                                                  <enterprise-oid>.1.3.6.1.4.1.5813.99.1</enterprise-oid>
+                                                  <specific>1</specific>
+                                                  <varbind>
+                                                    <oid>.1.3.6.1.4.1.5813.99.1.1</oid>
+                                                    <type>OctetString</type>
+                                                    <value>parameters['alarmMessage']</value>
+                                                    <max>48</max>
+                                                  </varbind>
+                                                </mapping>
+                                              </mapping-group>
+                                            </snmp-trap-sink>"""))
+                    }),
+            @ApiResponse(responseCode = "404", description = "No trap sink has that name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "SNMP Trap sink ApiDocTrapSink was not found.")))
+    })
+    public SnmpTrapSink getSnmpTrapSink(@Parameter(description = "Name of the trap sink.", required = true, example = "localTest1") @PathParam("trapsinkName") final String trapSinkName) {
         SnmpTrapSink trapSink = m_snmpTrapNorthbounderConfigDao.getConfig().getSnmpTrapSink(trapSinkName);
         if (trapSink == null) {
             throw getException(Status.NOT_FOUND, "SNMP Trap sink {} was not found.", trapSinkName);
@@ -257,7 +509,42 @@ public class SnmpTrapNorthbounderConfigurationResource extends OnmsRestService i
     @GET
     @Path("trapsinks/{trapsinkName}/import-mappings")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    public Response getImportMappings(@PathParam("trapsinkName") final String trapSinkName) {
+    @Operation(
+            summary = "List a trap sink's imported mapping-group files",
+            description = """
+                    Returns the `import-mappings` entries of the sink: the relative paths, under the OpenNMS
+                    configuration directory, of the files holding the sink's external mapping groups. The
+                    mapping group named `X` lives in `snmptrap-northbounder-mappings.d/X.xml`.
+
+                    Unlike the other list endpoints here, `count` and `totalCount` come back as null when the
+                    list is empty.""",
+            operationId = "getSnmpTrapSinkImportMappings")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The imported mapping-group file paths.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = ImportMappings.class),
+                                    examples = @ExampleObject(value = """
+                                            {
+                                              "totalCount": 1,
+                                              "count": 1,
+                                              "offset": 0,
+                                              "import-mapping": ["snmptrap-northbounder-mappings.d/ApiDocMappings.xml"]
+                                            }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = ImportMappings.class),
+                                    examples = @ExampleObject(value = """
+                                            <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                                            <import-mappings count="1" offset="0" totalCount="1">
+                                              <import-mapping>snmptrap-northbounder-mappings.d/ApiDocMappings.xml</import-mapping>
+                                            </import-mappings>"""))
+                    }),
+            @ApiResponse(responseCode = "404", description = "No trap sink has that name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "SNMP Trap sink ApiDocTrapSink was not found.")))
+    })
+    public Response getImportMappings(@Parameter(description = "Name of the trap sink.", required = true, example = "localTest1") @PathParam("trapsinkName") final String trapSinkName) {
         SnmpTrapSink trapSink = getSnmpTrapSink(trapSinkName);
         return Response.ok(new ImportMappings(trapSink.getImportMappings())).build();
 
@@ -273,6 +560,96 @@ public class SnmpTrapNorthbounderConfigurationResource extends OnmsRestService i
     @POST
     @Path("trapsinks")
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Add or replace an SNMP trap sink",
+            description = """
+                    Adds the sink to snmptrap-northbounder-configuration.xml, rewriting the whole file and
+                    sending a `reloadDaemonConfig` event for `SnmpTrapNBI`. A sink with the same `name` is
+                    replaced outright, which is the only way to change its inline mapping groups: the PUT
+                    reaches the scalar fields only.
+
+                    `version` and `varbind[].type` are JAXB enums whose `@XmlEnumValue` spelling differs from the
+                    constant name, and only XML honours the `@XmlEnumValue`. In XML write `v2c` and `Int32`; in
+                    JSON write the constant names `V2c` and `TYPE_SNMP_INT32`. Getting that the wrong way round
+                    produces a 500. The versions are `V1`, `V2c`, `V3`, `V2_INFORM` and `V3_INFORM`
+                    (`v1`, `v2c`, `v3`, `v2-inform`, `v3-inform` in XML); the varbind types are
+                    `TYPE_SNMP_OCTET_STRING`, `TYPE_SNMP_INT32`, `TYPE_SNMP_NULL`,
+                    `TYPE_SNMP_OBJECT_IDENTIFIER`, `TYPE_SNMP_IPADDRESS`, `TYPE_SNMP_TIMETICKS`,
+                    `TYPE_SNMP_COUNTER32`, `TYPE_SNMP_GAUGE32`, `TYPE_SNMP_OPAQUE` and `TYPE_SNMP_COUNTER64`
+                    (`OctetString`, `Int32`, and so on in XML).
+
+                    `mapping-group[].rule`, `mapping[].rule`, `varbind[].value` and `varbind[].instance` are SpEL
+                    expressions evaluated against the `NorthboundAlarm` being forwarded, so `parameters['x']`
+                    and `eventParametersCollection[0].value` reach the alarm's event parameters. Nothing
+                    validates the expressions at write time.
+
+                    An empty or unparseable body surfaces as a 500 rather than the documented 400.""",
+            operationId = "setSnmpTrapSink")
+    @RequestBody(required = true, description = "The trap sink to add or replace.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = SnmpTrapSink.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                              "name": "ApiDocTrapSink",
+                                              "ip-address": "127.0.0.1",
+                                              "port": 1162,
+                                              "version": "V2c",
+                                              "community": "public",
+                                              "mapping-group": [
+                                                {
+                                                  "name": "ApiDoc Mappings",
+                                                  "rule": "foreignSource matches '^ApiDoc.*'",
+                                                  "mapping": [
+                                                    {
+                                                      "name": "apidoctrap",
+                                                      "rule": "uei == 'uei.opennms.org/trap/apiDoc'",
+                                                      "enterprise-oid": ".1.3.6.1.4.1.5813.99.1",
+                                                      "specific": 1,
+                                                      "varbind": [
+                                                        {
+                                                          "oid": ".1.3.6.1.4.1.5813.99.1.1",
+                                                          "type": "TYPE_SNMP_OCTET_STRING",
+                                                          "value": "parameters['alarmMessage']",
+                                                          "max": 48
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ],
+                                              "import-mappings": []
+                                            }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = SnmpTrapSink.class),
+                            examples = @ExampleObject(value = """
+                                    <snmp-trap-sink>
+                                              <name>ApiDocTrapSink</name>
+                                              <ip-address>127.0.0.1</ip-address>
+                                              <port>1162</port>
+                                              <version>v2c</version>
+                                              <community>public</community>
+                                              <mapping-group name="ApiDoc Mappings">
+                                                <rule>foreignSource matches '^ApiDoc.*'</rule>
+                                                <mapping name="apidoctrap">
+                                                  <rule>uei == 'uei.opennms.org/trap/apiDoc'</rule>
+                                                  <enterprise-oid>.1.3.6.1.4.1.5813.99.1</enterprise-oid>
+                                                  <specific>1</specific>
+                                                  <varbind>
+                                                    <oid>.1.3.6.1.4.1.5813.99.1.1</oid>
+                                                    <type>OctetString</type>
+                                                    <value>parameters['alarmMessage']</value>
+                                                    <max>48</max>
+                                                  </varbind>
+                                                </mapping>
+                                              </mapping-group>
+                                            </snmp-trap-sink>"""))
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The trap sink was stored and the reload event sent."),
+            @ApiResponse(responseCode = "500", description = "The body could not be parsed, or the configuration could not be saved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
     public Response setSnmpTrapSink(final SnmpTrapSink snmpTrapSink) {
         writeLock();
         try {
@@ -297,7 +674,81 @@ public class SnmpTrapNorthbounderConfigurationResource extends OnmsRestService i
     @POST
     @Path("trapsinks/{trapsinkName}/import-mappings")
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    public Response setImportMapping(@PathParam("trapsinkName") final String trapSinkName, final SnmpTrapMappingGroup mappingGroup) {
+    @Operation(
+            summary = "Add or replace an imported mapping group on a trap sink",
+            description = """
+                    Writes the mapping group to `snmptrap-northbounder-mappings.d/<name>.xml` under the
+                    configuration directory, adds that path to the sink's `import-mappings` if it is not there
+                    already, then rewrites snmptrap-northbounder-configuration.xml and sends a
+                    `reloadDaemonConfig` event for `SnmpTrapNBI`. The file name is derived from the group's
+                    `name`, not from anything in the URL, and an existing file of that name is overwritten.
+
+                    `version` and `varbind[].type` are JAXB enums whose `@XmlEnumValue` spelling differs from the
+                    constant name, and only XML honours the `@XmlEnumValue`. In XML write `v2c` and `Int32`; in
+                    JSON write the constant names `V2c` and `TYPE_SNMP_INT32`. Getting that the wrong way round
+                    produces a 500. The versions are `V1`, `V2c`, `V3`, `V2_INFORM` and `V3_INFORM`
+                    (`v1`, `v2c`, `v3`, `v2-inform`, `v3-inform` in XML); the varbind types are
+                    `TYPE_SNMP_OCTET_STRING`, `TYPE_SNMP_INT32`, `TYPE_SNMP_NULL`,
+                    `TYPE_SNMP_OBJECT_IDENTIFIER`, `TYPE_SNMP_IPADDRESS`, `TYPE_SNMP_TIMETICKS`,
+                    `TYPE_SNMP_COUNTER32`, `TYPE_SNMP_GAUGE32`, `TYPE_SNMP_OPAQUE` and `TYPE_SNMP_COUNTER64`
+                    (`OctetString`, `Int32`, and so on in XML).
+
+                    `mapping-group[].rule`, `mapping[].rule`, `varbind[].value` and `varbind[].instance` are SpEL
+                    expressions evaluated against the `NorthboundAlarm` being forwarded, so `parameters['x']`
+                    and `eventParametersCollection[0].value` reach the alarm's event parameters. Nothing
+                    validates the expressions at write time.""",
+            operationId = "setSnmpTrapSinkImportMapping")
+    @RequestBody(required = true, description = "The mapping group to store. Its `name` sets the file name.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = SnmpTrapMappingGroup.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                              "name": "ApiDocMappings",
+                                              "rule": "foreignSource matches '^ApiDoc.*'",
+                                              "mapping": [
+                                                {
+                                                  "name": "apidocimported",
+                                                  "rule": "uei == 'uei.opennms.org/trap/apiDocImported'",
+                                                  "enterprise-oid": ".1.3.6.1.4.1.5813.99.2",
+                                                  "specific": 2,
+                                                  "varbind": [
+                                                    {
+                                                      "oid": ".1.3.6.1.4.1.5813.99.2.1",
+                                                      "type": "TYPE_SNMP_INT32",
+                                                      "value": "count"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = SnmpTrapMappingGroup.class),
+                            examples = @ExampleObject(value = """
+                                    <mapping-group name="ApiDocMappings">
+                                              <rule>foreignSource matches '^ApiDoc.*'</rule>
+                                              <mapping name="apidocimported">
+                                                <rule>uei == 'uei.opennms.org/trap/apiDocImported'</rule>
+                                                <enterprise-oid>.1.3.6.1.4.1.5813.99.2</enterprise-oid>
+                                                <specific>2</specific>
+                                                <varbind>
+                                                  <oid>.1.3.6.1.4.1.5813.99.2.1</oid>
+                                                  <type>Int32</type>
+                                                  <value>count</value>
+                                                </varbind>
+                                              </mapping>
+                                            </mapping-group>"""))
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The mapping group file was written and the reload event sent."),
+            @ApiResponse(responseCode = "404", description = "No trap sink has that name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "SNMP Trap sink ApiDocTrapSink was not found."))),
+            @ApiResponse(responseCode = "500", description = "The body could not be parsed, the mapping file could not be written, or the configuration could not be saved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
+    public Response setImportMapping(@Parameter(description = "Name of the trap sink.", required = true, example = "localTest1") @PathParam("trapsinkName") final String trapSinkName, final SnmpTrapMappingGroup mappingGroup) {
         writeLock();
         try {
             SnmpTrapSink trapSink = getSnmpTrapSink(trapSinkName);
@@ -323,7 +774,35 @@ public class SnmpTrapNorthbounderConfigurationResource extends OnmsRestService i
     @PUT
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("trapsinks/{trapsinkName}")
-    public Response updateSnmpTrapSink(@PathParam("trapsinkName") final String trapSinkName, final MultivaluedMapImpl params) {
+    @Operation(
+            summary = "Update fields on an SNMP trap sink",
+            description = """
+                    Takes a form-encoded body and applies each key to the matching writable bean property of
+                    the sink, then rewrites the file and sends a `reloadDaemonConfig` event for `SnmpTrapNBI`.
+                    Keys are bean property names, not XML element names, and unrecognised keys are ignored
+                    rather than rejected.
+
+                    The writable properties are `name`, `ipAddress`, `port`, `v1AgentIpAddress`, `version`,
+                    `community`, `mappings` and `importMappings`. `firstOccurrenceOnly` has a getter but no
+                    setter, so a key of that name is accepted and silently ignored. `version` takes the
+                    constant name, for example `V2c`. The collection properties cannot be expressed as a form
+                    value, so POST the sink again to change its mapping groups.""",
+            operationId = "updateSnmpTrapSink")
+    @RequestBody(required = true, description = "Form-encoded property assignments, keyed by bean property name.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "object"),
+                    examples = @ExampleObject(value = "port=1163&community=public&version=V2c")))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "At least one property was applied and the configuration was saved."),
+            @ApiResponse(responseCode = "304", description = "No key in the body matched a writable property, so nothing was changed."),
+            @ApiResponse(responseCode = "404", description = "No trap sink has that name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "SNMP Trap sink ApiDocTrapSink was not found."))),
+            @ApiResponse(responseCode = "500", description = "The configuration could not be saved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
+    public Response updateSnmpTrapSink(@Parameter(description = "Name of the trap sink.", required = true, example = "localTest1") @PathParam("trapsinkName") final String trapSinkName, final MultivaluedMapImpl params) {
         writeLock();
         try {
             boolean modified = false;
@@ -358,7 +837,32 @@ public class SnmpTrapNorthbounderConfigurationResource extends OnmsRestService i
     @PUT
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("trapsinks/{trapsinkName}/import-mappings/{mappingName}")
-    public Response updateImportMapping(@PathParam("trapsinkName") final String trapSinkName, @PathParam("mappingName") final String mappingName, final MultivaluedMapImpl params) {
+    @Operation(
+            summary = "Update fields on an imported mapping group",
+            description = """
+                    Reads `snmptrap-northbounder-mappings.d/{mappingName}.xml`, applies each form key to the
+                    matching writable bean property of the mapping group, writes the file back and sends a
+                    `reloadDaemonConfig` event for `SnmpTrapNBI`.
+
+                    The writable properties are `name` and `rule`, plus `mappings`, which a form value cannot
+                    express. Renaming through `name` writes a new file rather than moving the old one, so POST
+                    the mapping group again if you need to rename it.""",
+            operationId = "updateSnmpTrapSinkImportMapping")
+    @RequestBody(required = true, description = "Form-encoded property assignments, keyed by bean property name.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "object"),
+                    examples = @ExampleObject(value = "rule=foreignSource matches '^ApiDocUpdated.*'")))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "At least one property was applied and the mapping file was rewritten."),
+            @ApiResponse(responseCode = "304", description = "No key in the body matched a writable property, so nothing was changed."),
+            @ApiResponse(responseCode = "404", description = "The sink has no imported mapping group of that name. Bodiless. A 404 with a plain-text body instead means the trap sink itself was not found.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "SNMP Trap sink ApiDocTrapSink was not found."))),
+            @ApiResponse(responseCode = "500", description = "The mapping file could not be read or written, or the configuration could not be saved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
+    public Response updateImportMapping(@Parameter(description = "Name of the trap sink.", required = true, example = "localTest1") @PathParam("trapsinkName") final String trapSinkName, @Parameter(description = "Name of the mapping group, without the .xml extension. The file is snmptrap-northbounder-mappings.d/<name>.xml.", required = true, example = "ApiDocMappings") @PathParam("mappingName") final String mappingName, final MultivaluedMapImpl params) {
         writeLock();
         try {
             SnmpTrapSink trapSink = getSnmpTrapSink(trapSinkName);
@@ -406,7 +910,28 @@ public class SnmpTrapNorthbounderConfigurationResource extends OnmsRestService i
     @DELETE
     @Path("trapsinks/{trapsinkName}/import-mappings/{mappingName}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    public Response removeImportMapping(@PathParam("trapsinkName") final String trapSinkName, @PathParam("mappingName") final String mappingName) {
+    @Operation(
+            summary = "Delete an imported mapping group from a trap sink",
+            description = """
+                    Drops the path from the sink's `import-mappings`, deletes
+                    `snmptrap-northbounder-mappings.d/{mappingName}.xml`, then rewrites the configuration and
+                    sends a `reloadDaemonConfig` event for `SnmpTrapNBI`.
+
+                    A mapping name that is not in the list yields 304, not 404. So does a name that is in the
+                    list but whose file is already gone, in which case the list entry is still removed from
+                    the in-memory model but the configuration is not written.""",
+            operationId = "removeSnmpTrapSinkImportMapping")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The mapping file was deleted and the reload event sent."),
+            @ApiResponse(responseCode = "304", description = "The sink has no imported mapping group of that name, so nothing was deleted."),
+            @ApiResponse(responseCode = "404", description = "No trap sink has that name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "SNMP Trap sink ApiDocTrapSink was not found."))),
+            @ApiResponse(responseCode = "500", description = "The configuration could not be saved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
+    public Response removeImportMapping(@Parameter(description = "Name of the trap sink.", required = true, example = "localTest1") @PathParam("trapsinkName") final String trapSinkName, @Parameter(description = "Name of the mapping group, without the .xml extension. The file is snmptrap-northbounder-mappings.d/<name>.xml.", required = true, example = "ApiDocMappings") @PathParam("mappingName") final String mappingName) {
         SnmpTrapSink trapSink = getSnmpTrapSink(trapSinkName);
         if (trapSink.removeImportMapping(mappingName)) {
             return saveConfiguration();
@@ -423,7 +948,20 @@ public class SnmpTrapNorthbounderConfigurationResource extends OnmsRestService i
     @DELETE
     @Path("trapsinks/{trapsinkName}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    public Response removeSnmpTrapSink(@PathParam("trapsinkName") final String trapSinkName) {
+    @Operation(
+            summary = "Delete an SNMP trap sink",
+            description = """
+                    Removes the sink, rewrites snmptrap-northbounder-configuration.xml and sends a
+                    `reloadDaemonConfig` event for `SnmpTrapNBI`. Any mapping-group files the sink imported are
+                    left on disk.""",
+            operationId = "removeSnmpTrapSink")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The trap sink was removed and the reload event sent."),
+            @ApiResponse(responseCode = "404", description = "No trap sink has that name. Bodiless."),
+            @ApiResponse(responseCode = "500", description = "The configuration could not be saved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
+    public Response removeSnmpTrapSink(@Parameter(description = "Name of the trap sink.", required = true, example = "localTest1") @PathParam("trapsinkName") final String trapSinkName) {
         if (m_snmpTrapNorthbounderConfigDao.getConfig().removeSnmpTrapSink(trapSinkName)) {
             return saveConfiguration();
         }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/SnmpTrapNorthbounderConfigurationResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/SnmpTrapNorthbounderConfigurationResource.java
@@ -175,10 +175,9 @@ public class SnmpTrapNorthbounderConfigurationResource extends OnmsRestService i
                     `ip-address`; only `port` and `version` are overridable on the sink, and the version has to
                     agree with what snmp-config.xml declares for that address.
 
-                    `version` and `varbind[].type` are JAXB enums whose `@XmlEnumValue` spelling differs from the
-                    constant name, and only XML honours the `@XmlEnumValue`. In XML write `v2c` and `Int32`; in
-                    JSON write the constant names `V2c` and `TYPE_SNMP_INT32`. Getting that the wrong way round
-                    produces a 500. The versions are `V1`, `V2c`, `V3`, `V2_INFORM` and `V3_INFORM`
+                    `version` and `varbind[].type` are JAXB enums; only XML honours their `@XmlEnumValue`
+                    spelling. XML spells them `v2c` and `Int32`, JSON the constant names `V2c` and
+                    `TYPE_SNMP_INT32`; the wrong spelling for the media type produces a 500. The versions are `V1`, `V2c`, `V3`, `V2_INFORM` and `V3_INFORM`
                     (`v1`, `v2c`, `v3`, `v2-inform`, `v3-inform` in XML); the varbind types are
                     `TYPE_SNMP_OCTET_STRING`, `TYPE_SNMP_INT32`, `TYPE_SNMP_NULL`,
                     `TYPE_SNMP_OBJECT_IDENTIFIER`, `TYPE_SNMP_IPADDRESS`, `TYPE_SNMP_TIMETICKS`,
@@ -234,10 +233,9 @@ public class SnmpTrapNorthbounderConfigurationResource extends OnmsRestService i
                     than a 400: the null check that would produce the 400 is unreachable through those
                     providers.
 
-                    `version` and `varbind[].type` are JAXB enums whose `@XmlEnumValue` spelling differs from the
-                    constant name, and only XML honours the `@XmlEnumValue`. In XML write `v2c` and `Int32`; in
-                    JSON write the constant names `V2c` and `TYPE_SNMP_INT32`. Getting that the wrong way round
-                    produces a 500. The versions are `V1`, `V2c`, `V3`, `V2_INFORM` and `V3_INFORM`
+                    `version` and `varbind[].type` are JAXB enums; only XML honours their `@XmlEnumValue`
+                    spelling. XML spells them `v2c` and `Int32`, JSON the constant names `V2c` and
+                    `TYPE_SNMP_INT32`; the wrong spelling for the media type produces a 500. The versions are `V1`, `V2c`, `V3`, `V2_INFORM` and `V3_INFORM`
                     (`v1`, `v2c`, `v3`, `v2-inform`, `v3-inform` in XML); the varbind types are
                     `TYPE_SNMP_OCTET_STRING`, `TYPE_SNMP_INT32`, `TYPE_SNMP_NULL`,
                     `TYPE_SNMP_OBJECT_IDENTIFIER`, `TYPE_SNMP_IPADDRESS`, `TYPE_SNMP_TIMETICKS`,
@@ -364,8 +362,7 @@ public class SnmpTrapNorthbounderConfigurationResource extends OnmsRestService i
     @Operation(
             summary = "List the SNMP trap sink names",
             description = """
-                    Returns only the trap sink names, not the sinks themselves. Fetch a single sink to see its
-                    mappings.
+                    Returns only the trap sink names, not the sinks themselves.
 
                     `count` and `totalCount` are always equal here: the listing is not paged and `offset` is
                     always 0.""",
@@ -411,10 +408,9 @@ public class SnmpTrapNorthbounderConfigurationResource extends OnmsRestService i
                     Returns the sink with its inline mapping groups. `import-mappings` lists the paths of
                     mapping groups held in separate files; their contents are not inlined here.
 
-                    `version` and `varbind[].type` are JAXB enums whose `@XmlEnumValue` spelling differs from the
-                    constant name, and only XML honours the `@XmlEnumValue`. In XML write `v2c` and `Int32`; in
-                    JSON write the constant names `V2c` and `TYPE_SNMP_INT32`. Getting that the wrong way round
-                    produces a 500. The versions are `V1`, `V2c`, `V3`, `V2_INFORM` and `V3_INFORM`
+                    `version` and `varbind[].type` are JAXB enums; only XML honours their `@XmlEnumValue`
+                    spelling. XML spells them `v2c` and `Int32`, JSON the constant names `V2c` and
+                    `TYPE_SNMP_INT32`; the wrong spelling for the media type produces a 500. The versions are `V1`, `V2c`, `V3`, `V2_INFORM` and `V3_INFORM`
                     (`v1`, `v2c`, `v3`, `v2-inform`, `v3-inform` in XML); the varbind types are
                     `TYPE_SNMP_OCTET_STRING`, `TYPE_SNMP_INT32`, `TYPE_SNMP_NULL`,
                     `TYPE_SNMP_OBJECT_IDENTIFIER`, `TYPE_SNMP_IPADDRESS`, `TYPE_SNMP_TIMETICKS`,
@@ -516,8 +512,7 @@ public class SnmpTrapNorthbounderConfigurationResource extends OnmsRestService i
                     configuration directory, of the files holding the sink's external mapping groups. The
                     mapping group named `X` lives in `snmptrap-northbounder-mappings.d/X.xml`.
 
-                    Unlike the other list endpoints here, `count` and `totalCount` come back as null when the
-                    list is empty.""",
+                    `count` and `totalCount` come back as null when the list is empty.""",
             operationId = "getSnmpTrapSinkImportMappings")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "The imported mapping-group file paths.",
@@ -568,10 +563,9 @@ public class SnmpTrapNorthbounderConfigurationResource extends OnmsRestService i
                     replaced outright, which is the only way to change its inline mapping groups: the PUT
                     reaches the scalar fields only.
 
-                    `version` and `varbind[].type` are JAXB enums whose `@XmlEnumValue` spelling differs from the
-                    constant name, and only XML honours the `@XmlEnumValue`. In XML write `v2c` and `Int32`; in
-                    JSON write the constant names `V2c` and `TYPE_SNMP_INT32`. Getting that the wrong way round
-                    produces a 500. The versions are `V1`, `V2c`, `V3`, `V2_INFORM` and `V3_INFORM`
+                    `version` and `varbind[].type` are JAXB enums; only XML honours their `@XmlEnumValue`
+                    spelling. XML spells them `v2c` and `Int32`, JSON the constant names `V2c` and
+                    `TYPE_SNMP_INT32`; the wrong spelling for the media type produces a 500. The versions are `V1`, `V2c`, `V3`, `V2_INFORM` and `V3_INFORM`
                     (`v1`, `v2c`, `v3`, `v2-inform`, `v3-inform` in XML); the varbind types are
                     `TYPE_SNMP_OCTET_STRING`, `TYPE_SNMP_INT32`, `TYPE_SNMP_NULL`,
                     `TYPE_SNMP_OBJECT_IDENTIFIER`, `TYPE_SNMP_IPADDRESS`, `TYPE_SNMP_TIMETICKS`,
@@ -683,10 +677,9 @@ public class SnmpTrapNorthbounderConfigurationResource extends OnmsRestService i
                     `reloadDaemonConfig` event for `SnmpTrapNBI`. The file name is derived from the group's
                     `name`, not from anything in the URL, and an existing file of that name is overwritten.
 
-                    `version` and `varbind[].type` are JAXB enums whose `@XmlEnumValue` spelling differs from the
-                    constant name, and only XML honours the `@XmlEnumValue`. In XML write `v2c` and `Int32`; in
-                    JSON write the constant names `V2c` and `TYPE_SNMP_INT32`. Getting that the wrong way round
-                    produces a 500. The versions are `V1`, `V2c`, `V3`, `V2_INFORM` and `V3_INFORM`
+                    `version` and `varbind[].type` are JAXB enums; only XML honours their `@XmlEnumValue`
+                    spelling. XML spells them `v2c` and `Int32`, JSON the constant names `V2c` and
+                    `TYPE_SNMP_INT32`; the wrong spelling for the media type produces a 500. The versions are `V1`, `V2c`, `V3`, `V2_INFORM` and `V3_INFORM`
                     (`v1`, `v2c`, `v3`, `v2-inform`, `v3-inform` in XML); the varbind types are
                     `TYPE_SNMP_OCTET_STRING`, `TYPE_SNMP_INT32`, `TYPE_SNMP_NULL`,
                     `TYPE_SNMP_OBJECT_IDENTIFIER`, `TYPE_SNMP_IPADDRESS`, `TYPE_SNMP_TIMETICKS`,
@@ -784,9 +777,8 @@ public class SnmpTrapNorthbounderConfigurationResource extends OnmsRestService i
 
                     The writable properties are `name`, `ipAddress`, `port`, `v1AgentIpAddress`, `version`,
                     `community`, `mappings` and `importMappings`. `firstOccurrenceOnly` has a getter but no
-                    setter, so a key of that name is accepted and silently ignored. `version` takes the
-                    constant name, for example `V2c`. The collection properties cannot be expressed as a form
-                    value, so POST the sink again to change its mapping groups.""",
+                    setter, so a key of that name is accepted and ignored. `version` takes the constant name,
+                    for example `V2c`. The collection properties cannot be expressed as a form value.""",
             operationId = "updateSnmpTrapSink")
     @RequestBody(required = true, description = "Form-encoded property assignments, keyed by bean property name.",
             content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
@@ -845,8 +837,7 @@ public class SnmpTrapNorthbounderConfigurationResource extends OnmsRestService i
                     `reloadDaemonConfig` event for `SnmpTrapNBI`.
 
                     The writable properties are `name` and `rule`, plus `mappings`, which a form value cannot
-                    express. Renaming through `name` writes a new file rather than moving the old one, so POST
-                    the mapping group again if you need to rename it.""",
+                    express. Renaming through `name` writes a new file rather than moving the old one.""",
             operationId = "updateSnmpTrapSinkImportMapping")
     @RequestBody(required = true, description = "Form-encoded property assignments, keyed by bean property name.",
             content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/SyslogNorthbounderConfigurationResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/SyslogNorthbounderConfigurationResource.java
@@ -58,6 +58,14 @@ import org.springframework.beans.PropertyAccessorFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 /**
  * The Class SyslogNorthbounderConfigurationResource.
@@ -123,6 +131,68 @@ public class SyslogNorthbounderConfigurationResource extends OnmsRestService imp
      */
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get the Syslog northbounder configuration",
+            description = """
+                    Returns the whole of syslog-northbounder-configuration.xml: the queue settings, the
+                    top-level `message-format` template, the optional `uei` allow list and one entry per
+                    destination.
+
+                    `ip-protocol` and `facility` are JAXB enums declared without `@XmlEnumValue`, so they carry the
+                    same constant spelling in JSON and XML: `UDP`/`TCP` and the usual syslog facility names in
+                    upper case.""",
+            operationId = "getSyslogNorthbounderConfiguration")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The current Syslog northbounder configuration.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = SyslogNorthbounderConfig.class),
+                                    examples = @ExampleObject(value = """
+                                            {
+                                              "enabled": false,
+                                              "nagles-delay": 1000,
+                                              "batch-size": 100,
+                                              "queue-size": 300000,
+                                              "message-format": "ALARM ID:${alarmId} NODE:${nodeLabel}; ${logMsg}",
+                                              "destination": [
+                                                {
+                                                  "destination-name": "localTest",
+                                                  "host": "127.0.0.1",
+                                                  "port": 514,
+                                                  "ip-protocol": "UDP",
+                                                  "facility": "LOCAL0",
+                                                  "max-message-length": 1024,
+                                                  "send-local-name": true,
+                                                  "send-local-time": true,
+                                                  "truncate-message": false,
+                                                  "filter": []
+                                                }
+                                              ]
+                                            }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = SyslogNorthbounderConfig.class),
+                                    examples = @ExampleObject(value = """
+                                            <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                                            <syslog-northbounder-config>
+                                              <enabled>false</enabled>
+                                              <nagles-delay>1000</nagles-delay>
+                                              <batch-size>100</batch-size>
+                                              <queue-size>300000</queue-size>
+                                              <message-format>ALARM ID:${alarmId} NODE:${nodeLabel}; ${logMsg}</message-format>
+                                              <destination>
+                                                <destination-name>localTest</destination-name>
+                                                <host>127.0.0.1</host>
+                                                <port>514</port>
+                                                <ip-protocol>UDP</ip-protocol>
+                                                <facility>LOCAL0</facility>
+                                                <max-message-length>1024</max-message-length>
+                                                <send-local-name>true</send-local-name>
+                                                <send-local-time>true</send-local-time>
+                                                <truncate-message>false</truncate-message>
+                                              </destination>
+                                            </syslog-northbounder-config>"""))
+                    })
+    })
     public Response getConfiguration() {
         return Response.ok(m_syslogNorthbounderConfigDao.getConfig()).build();
     }
@@ -134,6 +204,72 @@ public class SyslogNorthbounderConfigurationResource extends OnmsRestService imp
      * @return the response
      */
     @POST
+    @Operation(
+            summary = "Replace the Syslog northbounder configuration",
+            description = """
+                    Marshals the request body straight over syslog-northbounder-configuration.xml, then sends a
+                    `reloadDaemonConfig` event for `SyslogNBI`. The whole file is replaced, so anything absent
+                    from the body is dropped, including comments. There is no merge and no dry run.
+
+                    The handler declares no `@Consumes`, so the media type is whatever the JAXB and Jackson
+                    providers accept for the body type. A body that fails to parse surfaces as a 500 rather
+                    than a 400: the null check that would produce the 400 is unreachable through those
+                    providers.""",
+            operationId = "setSyslogNorthbounderConfiguration")
+    @RequestBody(required = true, description = "The complete replacement configuration.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = SyslogNorthbounderConfig.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                              "enabled": false,
+                                              "nagles-delay": 1000,
+                                              "batch-size": 100,
+                                              "queue-size": 300000,
+                                              "message-format": "ALARM ID:${alarmId} NODE:${nodeLabel}; ${logMsg}",
+                                              "destination": [
+                                                {
+                                                  "destination-name": "localTest",
+                                                  "host": "127.0.0.1",
+                                                  "port": 514,
+                                                  "ip-protocol": "UDP",
+                                                  "facility": "LOCAL0",
+                                                  "max-message-length": 1024,
+                                                  "send-local-name": true,
+                                                  "send-local-time": true,
+                                                  "truncate-message": false,
+                                                  "filter": []
+                                                }
+                                              ]
+                                            }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = SyslogNorthbounderConfig.class),
+                            examples = @ExampleObject(value = """
+                                    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                                            <syslog-northbounder-config>
+                                              <enabled>false</enabled>
+                                              <nagles-delay>1000</nagles-delay>
+                                              <batch-size>100</batch-size>
+                                              <queue-size>300000</queue-size>
+                                              <message-format>ALARM ID:${alarmId} NODE:${nodeLabel}; ${logMsg}</message-format>
+                                              <destination>
+                                                <destination-name>localTest</destination-name>
+                                                <host>127.0.0.1</host>
+                                                <port>514</port>
+                                                <ip-protocol>UDP</ip-protocol>
+                                                <facility>LOCAL0</facility>
+                                                <max-message-length>1024</max-message-length>
+                                                <send-local-name>true</send-local-name>
+                                                <send-local-time>true</send-local-time>
+                                                <truncate-message>false</truncate-message>
+                                              </destination>
+                                            </syslog-northbounder-config>"""))
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The file was written and the reload event sent."),
+            @ApiResponse(responseCode = "500", description = "The body could not be parsed, or the file could not be written.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
     public Response setConfiguration(final SyslogNorthbounderConfig config) {
         writeLock();
         try {
@@ -161,6 +297,21 @@ public class SyslogNorthbounderConfigurationResource extends OnmsRestService imp
     @GET
     @Path("status")
     @Produces(MediaType.TEXT_PLAIN)
+    @Operation(
+            summary = "Get whether the Syslog northbounder is enabled",
+            description = """
+                    Returns the `enabled` flag from syslog-northbounder-configuration.xml as the literal text
+                    `true` or `false`. An absent flag reads back as `false`.
+
+                    This operation produces text/plain only, so a request sent with
+                    `Accept: application/json` is rejected with a 406.""",
+            operationId = "getSyslogNorthbounderStatus")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The current enabled flag.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "boolean"),
+                            examples = @ExampleObject(value = "false")))
+    })
     public Response getStatus() {
         return Response.ok(m_syslogNorthbounderConfigDao.getConfig().isEnabled()).build();
     }
@@ -175,7 +326,22 @@ public class SyslogNorthbounderConfigurationResource extends OnmsRestService imp
     @PUT
     @Path("status")
     @Produces(MediaType.TEXT_PLAIN)
-    public Response getStatus(@QueryParam("enabled") final Boolean enabled) throws WebApplicationException {
+    @Operation(
+            summary = "Enable or disable the Syslog northbounder",
+            description = """
+                    Sets the `enabled` flag, rewrites syslog-northbounder-configuration.xml and sends a
+                    `reloadDaemonConfig` event for `SyslogNBI`. Comments and formatting in the file are lost,
+                    because the whole file is re-marshalled from the in-memory model.
+
+                    Omitting `enabled` clears the flag rather than leaving it alone, which then reads back as
+                    `false`. Despite the text/plain declaration the success response has no body.""",
+            operationId = "setSyslogNorthbounderStatus")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The flag was written and the reload event sent."),
+            @ApiResponse(responseCode = "500", description = "The configuration could not be saved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
+    public Response getStatus(@Parameter(description = "New value for the enabled flag. Omitting it clears the flag, which reads back as false.", example = "true") @QueryParam("enabled") final Boolean enabled) throws WebApplicationException {
         writeLock();
         try {
             m_syslogNorthbounderConfigDao.getConfig().setEnabled(enabled);
@@ -193,6 +359,36 @@ public class SyslogNorthbounderConfigurationResource extends OnmsRestService imp
     @GET
     @Path("destinations")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "List the Syslog northbounder destination names",
+            description = """
+                    Returns only the destination names, not the destinations themselves. Fetch a single
+                    destination to see its settings.
+
+                    `count` and `totalCount` are always equal here: the listing is not paged and `offset` is
+                    always 0.""",
+            operationId = "getSyslogDestinations")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The configured destination names.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = SyslogDestinationList.class),
+                                    examples = @ExampleObject(value = """
+                                            {
+                                              "totalCount": 1,
+                                              "count": 1,
+                                              "offset": 0,
+                                              "destination": ["localTest"]
+                                            }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = SyslogDestinationList.class),
+                                    examples = @ExampleObject(value = """
+                                            <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                                            <syslog-destinations count="1" offset="0" totalCount="1">
+                                              <destination>localTest</destination>
+                                            </syslog-destinations>"""))
+                    })
+    })
     public Response getEmailDestinations() {
         SyslogDestinationList destinations = new SyslogDestinationList(m_syslogNorthbounderConfigDao.getConfig().getDestinations());
         return Response.ok(destinations).build();
@@ -207,7 +403,55 @@ public class SyslogNorthbounderConfigurationResource extends OnmsRestService imp
     @GET
     @Path("destinations/{destinationName}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    public SyslogDestination getSyslogDestination(@PathParam("destinationName") final String destinationName) {
+    @Operation(
+            summary = "Get one Syslog northbounder destination",
+            description = """
+                    Returns the destination, including any per-destination `filter` entries.
+
+                    `ip-protocol` and `facility` are JAXB enums declared without `@XmlEnumValue`, so they carry the
+                    same constant spelling in JSON and XML: `UDP`/`TCP` and the usual syslog facility names in
+                    upper case.""",
+            operationId = "getSyslogDestination")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The destination.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = SyslogDestination.class),
+                                    examples = @ExampleObject(value = """
+                                            {
+                                              "destination-name": "ApiDocSyslogDest",
+                                              "host": "127.0.0.1",
+                                              "port": 5140,
+                                              "ip-protocol": "UDP",
+                                              "facility": "LOCAL1",
+                                              "max-message-length": 1024,
+                                              "send-local-name": true,
+                                              "send-local-time": true,
+                                              "truncate-message": false,
+                                              "first-occurrence-only": false
+                                            }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = SyslogDestination.class),
+                                    examples = @ExampleObject(value = """
+                                            <syslog-destination>
+                                              <destination-name>ApiDocSyslogDest</destination-name>
+                                              <host>127.0.0.1</host>
+                                              <port>5140</port>
+                                              <ip-protocol>UDP</ip-protocol>
+                                              <facility>LOCAL1</facility>
+                                              <max-message-length>1024</max-message-length>
+                                              <send-local-name>true</send-local-name>
+                                              <send-local-time>true</send-local-time>
+                                              <truncate-message>false</truncate-message>
+                                              <first-occurrence-only>false</first-occurrence-only>
+                                            </syslog-destination>"""))
+                    }),
+            @ApiResponse(responseCode = "404", description = "No destination has that name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Syslog destination ApiDocSyslogDest was not found.")))
+    })
+    public SyslogDestination getSyslogDestination(@Parameter(description = "Value of the destination-name element for the destination.", required = true, example = "localTest") @PathParam("destinationName") final String destinationName) {
         SyslogDestination destination = m_syslogNorthbounderConfigDao.getConfig().getSyslogDestination(destinationName);
         if (destination == null) {
             throw getException(Status.NOT_FOUND, "Syslog destination {} was not found.", destinationName);
@@ -225,6 +469,58 @@ public class SyslogNorthbounderConfigurationResource extends OnmsRestService imp
     @POST
     @Path("destinations")
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Add or replace a Syslog northbounder destination",
+            description = """
+                    Adds the destination to syslog-northbounder-configuration.xml, rewriting the whole file and
+                    sending a `reloadDaemonConfig` event for `SyslogNBI`. A destination with the same
+                    `destination-name` is replaced outright, which is the only way to change `facility` or the
+                    filter list: neither is reachable through the PUT.
+
+                    `ip-protocol` and `facility` are JAXB enums declared without `@XmlEnumValue`, so they carry the
+                    same constant spelling in JSON and XML: `UDP`/`TCP` and the usual syslog facility names in
+                    upper case.
+
+                    An empty or unparseable body surfaces as a 500 rather than the documented 400.""",
+            operationId = "setSyslogDestination")
+    @RequestBody(required = true, description = "The destination to add or replace.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = SyslogDestination.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                              "destination-name": "ApiDocSyslogDest",
+                                              "host": "127.0.0.1",
+                                              "port": 5140,
+                                              "ip-protocol": "UDP",
+                                              "facility": "LOCAL1",
+                                              "max-message-length": 1024,
+                                              "send-local-name": true,
+                                              "send-local-time": true,
+                                              "truncate-message": false,
+                                              "first-occurrence-only": false
+                                            }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = SyslogDestination.class),
+                            examples = @ExampleObject(value = """
+                                    <syslog-destination>
+                                              <destination-name>ApiDocSyslogDest</destination-name>
+                                              <host>127.0.0.1</host>
+                                              <port>5140</port>
+                                              <ip-protocol>UDP</ip-protocol>
+                                              <facility>LOCAL1</facility>
+                                              <max-message-length>1024</max-message-length>
+                                              <send-local-name>true</send-local-name>
+                                              <send-local-time>true</send-local-time>
+                                              <truncate-message>false</truncate-message>
+                                              <first-occurrence-only>false</first-occurrence-only>
+                                            </syslog-destination>"""))
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The destination was stored and the reload event sent."),
+            @ApiResponse(responseCode = "500", description = "The body could not be parsed, or the configuration could not be saved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
     public Response setSyslogDestination(final SyslogDestination destination) {
         writeLock();
         try {
@@ -249,7 +545,35 @@ public class SyslogNorthbounderConfigurationResource extends OnmsRestService imp
     @PUT
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("destinations/{destinationName}")
-    public Response updateSyslogDestination(@PathParam("destinationName") final String destinationName, final MultivaluedMapImpl params) {
+    @Operation(
+            summary = "Update fields on a Syslog northbounder destination",
+            description = """
+                    Takes a form-encoded body and applies each key to the matching writable bean property of
+                    the destination, then rewrites the file and sends a `reloadDaemonConfig` event for
+                    `SyslogNBI`. Keys are bean property names, not XML element names, and unrecognised keys
+                    are ignored rather than rejected.
+
+                    The writable properties are `name` (which is the `destination-name` element), `host`,
+                    `port`, `protocol` (the `ip-protocol` element), `charSet`, `maxMessageLength`,
+                    `sendLocalName`, `sendLocalTime`, `truncateMessage` and `firstOccurrenceOnly`. `facility`
+                    has a getter but no setter, so a `facility` key is accepted and silently ignored; POST the
+                    destination again to change it.""",
+            operationId = "updateSyslogDestination")
+    @RequestBody(required = true, description = "Form-encoded property assignments, keyed by bean property name.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "object"),
+                    examples = @ExampleObject(value = "port=5141&protocol=TCP&maxMessageLength=2048")))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "At least one property was applied and the configuration was saved."),
+            @ApiResponse(responseCode = "304", description = "No key in the body matched a writable property, so nothing was changed."),
+            @ApiResponse(responseCode = "404", description = "No destination has that name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Syslog destination ApiDocSyslogDest was not found."))),
+            @ApiResponse(responseCode = "500", description = "The configuration could not be saved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
+    public Response updateSyslogDestination(@Parameter(description = "Value of the destination-name element for the destination.", required = true, example = "localTest") @PathParam("destinationName") final String destinationName, final MultivaluedMapImpl params) {
         writeLock();
         try {
             boolean modified = false;
@@ -282,7 +606,19 @@ public class SyslogNorthbounderConfigurationResource extends OnmsRestService imp
     @DELETE
     @Path("destinations/{destinationName}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
-    public Response removeSyslogDestination(@PathParam("destinationName") final String destinationName) {
+    @Operation(
+            summary = "Delete a Syslog northbounder destination",
+            description = """
+                    Removes the destination, rewrites syslog-northbounder-configuration.xml and sends a
+                    `reloadDaemonConfig` event for `SyslogNBI`.""",
+            operationId = "removeSyslogDestination")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The destination was removed and the reload event sent."),
+            @ApiResponse(responseCode = "404", description = "No destination has that name. Bodiless."),
+            @ApiResponse(responseCode = "500", description = "The configuration could not be saved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
+    public Response removeSyslogDestination(@Parameter(description = "Value of the destination-name element for the destination.", required = true, example = "localTest") @PathParam("destinationName") final String destinationName) {
         if (m_syslogNorthbounderConfigDao.getConfig().removeSyslogDestination(destinationName)) {
             return saveConfiguration();
         }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/SyslogNorthbounderConfigurationResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/SyslogNorthbounderConfigurationResource.java
@@ -209,7 +209,7 @@ public class SyslogNorthbounderConfigurationResource extends OnmsRestService imp
             description = """
                     Marshals the request body straight over syslog-northbounder-configuration.xml, then sends a
                     `reloadDaemonConfig` event for `SyslogNBI`. The whole file is replaced, so anything absent
-                    from the body is dropped, including comments. There is no merge and no dry run.
+                    from the body is dropped, including comments.
 
                     The handler declares no `@Consumes`, so the media type is whatever the JAXB and Jackson
                     providers accept for the body type. A body that fails to parse surfaces as a 500 rather
@@ -362,8 +362,7 @@ public class SyslogNorthbounderConfigurationResource extends OnmsRestService imp
     @Operation(
             summary = "List the Syslog northbounder destination names",
             description = """
-                    Returns only the destination names, not the destinations themselves. Fetch a single
-                    destination to see its settings.
+                    Returns only the destination names, not the destinations themselves.
 
                     `count` and `totalCount` are always equal here: the listing is not paged and `offset` is
                     always 0.""",
@@ -556,8 +555,7 @@ public class SyslogNorthbounderConfigurationResource extends OnmsRestService imp
                     The writable properties are `name` (which is the `destination-name` element), `host`,
                     `port`, `protocol` (the `ip-protocol` element), `charSet`, `maxMessageLength`,
                     `sendLocalName`, `sendLocalTime`, `truncateMessage` and `firstOccurrenceOnly`. `facility`
-                    has a getter but no setter, so a `facility` key is accepted and silently ignored; POST the
-                    destination again to change it.""",
+                    has a getter but no setter, so a `facility` key is accepted and ignored.""",
             operationId = "updateSyslogDestination")
     @RequestBody(required = true, description = "Form-encoded property assignments, keyed by bean property name.",
             content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/TicketerConfig.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/TicketerConfig.java
@@ -31,7 +31,7 @@ public class TicketerConfig {
     @Schema(description = "Class name of the ticketer plugin in use. Null when the ticketer is disabled.", example = "org.opennms.netmgt.ticketer.jira.JiraTicketerPlugin")
     private String plugin;
 
-    @Schema(description = "Whether the trouble ticketer is enabled, from opennms.ticketer.plugin in opennms.properties.", example = "false")
+    @Schema(description = "Whether the trouble ticketer is enabled, from opennms.alarmTroubleTicketEnabled in opennms.properties.", example = "false")
     private boolean enabled;
 
     public void setPlugin(String plugin) {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/TrapdConfigurationResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/TrapdConfigurationResource.java
@@ -33,6 +33,12 @@ import org.opennms.netmgt.config.TrapdConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 @Component("trapdConfigurationResource")
 public class TrapdConfigurationResource {
@@ -45,6 +51,42 @@ public class TrapdConfigurationResource {
     
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get the trapd configuration",
+            description = """
+                    Returns the contents of trapd-configuration.xml, including the SNMPv3 users trapd will
+                    accept traps from. `threads` and `queue-size` describe the ingress pipeline; a `threads`
+                    value of 0 means trapd sizes the pool from the available processor count.""",
+            operationId = "getTrapdConfiguration")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The current trapd configuration.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = TrapdConfig.class),
+                                    examples = @ExampleObject(value = """
+                                            {
+                                              "threads": 0,
+                                              "snmp-trap-address": "*",
+                                              "snmp-trap-port": 10162,
+                                              "new-suspect-on-trap": false,
+                                              "include-raw-message": false,
+                                              "queue-size": 10000,
+                                              "batch-size": 1000,
+                                              "batch-interval": 500,
+                                              "snmpv3-user": [],
+                                              "use-address-from-varbind": null
+                                            }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = TrapdConfig.class),
+                                    examples = @ExampleObject(value = """
+                                            <?xml version="1.0" encoding="UTF-8"?>
+                                            <trapd-configuration xmlns="http://xmlns.opennms.org/xsd/config/trapd"
+                                                                 snmp-trap-address="*" snmp-trap-port="10162"
+                                                                 new-suspect-on-trap="false" include-raw-message="false"
+                                                                 threads="0" queue-size="10000" batch-size="1000"
+                                                                 batch-interval="500"/>"""))
+                    })
+    })
     public Response getTrapdConfiguration() throws ConfigurationResourceException {
         return Response.ok(m_trapdConfigResource.get()).build();
     }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/TrapdConfigurationResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/TrapdConfigurationResource.java
@@ -55,8 +55,8 @@ public class TrapdConfigurationResource {
             summary = "Get the trapd configuration",
             description = """
                     Returns the contents of trapd-configuration.xml, including the SNMPv3 users trapd will
-                    accept traps from. `threads` and `queue-size` describe the ingress pipeline; a `threads`
-                    value of 0 means trapd sizes the pool from the available processor count.""",
+                    accept traps from. A `threads` value of 0 means trapd sizes the pool from the available
+                    processor count.""",
             operationId = "getTrapdConfiguration")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "The current trapd configuration.",

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/TrapdConfigurationResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/TrapdConfigurationResource.java
@@ -36,7 +36,6 @@ import org.springframework.stereotype.Component;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
@@ -49,6 +48,9 @@ public class TrapdConfigurationResource {
     @Resource(name="trapd-configuration.xml")
     ConfigurationResource<TrapdConfig> m_trapdConfigResource;
     
+    // Documented by example only: the response is the JAXB TrapdConfiguration, which swagger-core
+    // cannot introspect (Jackson sees conflicting array and List setters for snmpv3User). The v1
+    // response carries the XSD attribute names, so the v2 TrapdConfigDto does not describe it either.
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Operation(
@@ -62,7 +64,6 @@ public class TrapdConfigurationResource {
             @ApiResponse(responseCode = "200", description = "The current trapd configuration.",
                     content = {
                             @Content(mediaType = MediaType.APPLICATION_JSON,
-                                    schema = @Schema(implementation = org.opennms.netmgt.config.trapd.TrapdConfiguration.class),
                                     examples = @ExampleObject(value = """
                                             {
                                               "threads": 0,
@@ -77,7 +78,6 @@ public class TrapdConfigurationResource {
                                               "use-address-from-varbind": null
                                             }""")),
                             @Content(mediaType = MediaType.APPLICATION_XML,
-                                    schema = @Schema(implementation = org.opennms.netmgt.config.trapd.TrapdConfiguration.class),
                                     examples = @ExampleObject(value = """
                                             <?xml version="1.0" encoding="UTF-8"?>
                                             <trapd-configuration xmlns="http://xmlns.opennms.org/xsd/config/trapd"

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/TrapdConfigurationResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/TrapdConfigurationResource.java
@@ -57,12 +57,12 @@ public class TrapdConfigurationResource {
                     Returns the contents of trapd-configuration.xml, including the SNMPv3 users trapd will
                     accept traps from. A `threads` value of 0 means trapd sizes the pool from the available
                     processor count.""",
-            operationId = "getTrapdConfiguration")
+            operationId = "getTrapdConfigurationV1")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "The current trapd configuration.",
                     content = {
                             @Content(mediaType = MediaType.APPLICATION_JSON,
-                                    schema = @Schema(implementation = TrapdConfig.class),
+                                    schema = @Schema(implementation = org.opennms.netmgt.config.trapd.TrapdConfiguration.class),
                                     examples = @ExampleObject(value = """
                                             {
                                               "threads": 0,
@@ -77,7 +77,7 @@ public class TrapdConfigurationResource {
                                               "use-address-from-varbind": null
                                             }""")),
                             @Content(mediaType = MediaType.APPLICATION_XML,
-                                    schema = @Schema(implementation = TrapdConfig.class),
+                                    schema = @Schema(implementation = org.opennms.netmgt.config.trapd.TrapdConfiguration.class),
                                     examples = @ExampleObject(value = """
                                             <?xml version="1.0" encoding="UTF-8"?>
                                             <trapd-configuration xmlns="http://xmlns.opennms.org/xsd/config/trapd"

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/model/AckOnlyForm.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/model/AckOnlyForm.java
@@ -19,34 +19,19 @@
  * language governing permissions and limitations under the
  * License.
  */
-package org.opennms.web.rest.v1.config;
+
+package org.opennms.web.rest.v1.model;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "TicketerConfig", description = "State of the trouble ticketer integration.")
-public class TicketerConfig {
-    /**
-     * The plugin currently in use. If enabled is false, this should be null.
-     */
-    @Schema(description = "Class name of the ticketer plugin in use. Null when the ticketer is disabled.", example = "org.opennms.netmgt.ticketer.jira.JiraTicketerPlugin")
-    private String plugin;
+/** Describes the form body the single-event and single-notification acknowledge handlers read; it is not bound as a type. */
+@Schema(name = "V1AckOnlyForm",
+        description = "Form-encoded body carrying only an acknowledge flag.")
+public class AckOnlyForm {
 
-    @Schema(description = "Whether the trouble ticketer is enabled, from opennms.ticketer.plugin in opennms.properties.", example = "false")
-    private boolean enabled;
-
-    public void setPlugin(String plugin) {
-        this.plugin = plugin;
-    }
-
-    public String getPlugin() {
-        return plugin;
-    }
-
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
-    }
-
-    public boolean isEnabled() {
-        return enabled;
-    }
+    @Schema(description = "`true` records the acknowledgement as the authenticated user, `false` removes it. "
+            + "Any other value parses as `false`. The single-resource operations reject a body without it with a "
+            + "400; the collection operations default it to `false`.",
+            example = "true")
+    public Boolean ack;
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/model/AcknowledgmentForm.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/model/AcknowledgmentForm.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+
+package org.opennms.web.rest.v1.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/** Describes the form body the acknowledge handler reads out of a MultivaluedMap; it is not bound as a type. */
+@Schema(name = "V1AcknowledgmentForm",
+        description = "Form-encoded body for creating an acknowledgement. Exactly one of `alarmId` and `notifId` "
+                + "has to be present.")
+public class AcknowledgmentForm {
+
+    @Schema(description = "Id of the alarm to act on. Mutually exclusive with `notifId`.", example = "4547")
+    public String alarmId;
+
+    @Schema(description = "Id of the notification to act on. Mutually exclusive with `alarmId`.", example = "2615")
+    public String notifId;
+
+    @Schema(description = "Action to record. Defaults to `ack` when absent.",
+            example = "ack", allowableValues = {"ack", "unack", "clear", "esc"})
+    public String action;
+
+    @Schema(description = "User the acknowledgement is recorded against. Defaults to the authenticated user. "
+            + "A non-admin caller may only name themselves.",
+            example = "admin")
+    public String ackUser;
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/model/AlarmAckForm.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/model/AlarmAckForm.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+
+package org.opennms.web.rest.v1.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/** Describes the form body the alarm update handlers read out of a MultivaluedMap; it is not bound as a type. */
+@Schema(name = "V1AlarmUpdateForm",
+        description = """
+                Form-encoded body for the alarm update handlers. `ack`, `escalate` and `clear` are mutually
+                exclusive: they are tested in that order and only the first one present is acted on. Any field
+                not listed here is treated as an alarm filter, so on the collection handler `id`, `severity`,
+                `node.id` and the other `OnmsAlarm` property names select which alarms are updated.""")
+public class AlarmAckForm {
+
+    @Schema(description = "`true` acknowledges, `false` unacknowledges. Takes precedence over `escalate` and `clear`.",
+            example = "true")
+    public Boolean ack;
+
+    @Schema(description = "`true` raises the alarm severity one step. Only consulted when `ack` is absent.",
+            example = "true")
+    public Boolean escalate;
+
+    @Schema(description = "`true` sets the alarm severity to Cleared. Only consulted when `ack` and `escalate` are absent.",
+            example = "true")
+    public Boolean clear;
+
+    @Schema(description = "User the acknowledgement is recorded against. Defaults to the authenticated user. "
+            + "A non-admin caller may only name themselves.",
+            example = "admin")
+    public String ackUser;
+
+    @Schema(description = "Trouble ticket id to store on the alarm. Only honoured by the single-alarm handler, "
+            + "and only when non-blank.",
+            example = "TT-4711")
+    public String ticketId;
+
+    @Schema(description = "Trouble ticket state to store on the alarm. Only honoured by the single-alarm handler. "
+            + "A value outside the enumeration is ignored rather than reported.",
+            example = "OPEN",
+            allowableValues = {"OPEN", "CREATE_PENDING", "CREATE_FAILED", "UPDATE_PENDING", "UPDATE_FAILED",
+                    "CLOSED", "CLOSE_PENDING", "CLOSE_FAILED", "RESOLVED", "RESOLVE_PENDING", "RESOLVE_FAILED",
+                    "CANCELLED", "CANCEL_PENDING", "CANCEL_FAILED"})
+    public String ticketState;
+
+    @Schema(description = "Collection handler only: restricts the update to the alarm with this id. "
+            + "`alarmId` is accepted as a synonym, but supplying both is a 400.",
+            example = "4547")
+    public Integer id;
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/model/AvailabilityDataResponse.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/model/AvailabilityDataResponse.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v1.model;
+
+import java.util.List;
+
+import org.opennms.web.category.Category;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Documentation-only description of the body returned by {@code GET /availability}. The handler
+ * returns a package-private JAXB type whose properties swagger cannot introspect.
+ */
+@Schema(name = "AvailabilityData", description = "Category groups as defined by categories.xml, each holding its categories.")
+public class AvailabilityDataResponse {
+
+    @Schema(description = "One entry per category group in categories.xml.", required = true)
+    private List<AvailabilitySection> section;
+
+    public List<AvailabilitySection> getSection() {
+        return section;
+    }
+
+    @Schema(name = "AvailabilitySection", description = "A named group of categories.")
+    public static class AvailabilitySection {
+
+        @Schema(description = "Group name from categories.xml.", example = "Categories", required = true)
+        private String name;
+
+        @Schema(description = "Categories in this group, wrapped in the usual count/offset envelope.", required = true)
+        private AvailabilityCategoryList categories;
+
+        public String getName() {
+            return name;
+        }
+
+        public AvailabilityCategoryList getCategories() {
+            return categories;
+        }
+    }
+
+    @Schema(name = "AvailabilityCategoryList", description = "Envelope around the category list.")
+    public static class AvailabilityCategoryList {
+
+        @Schema(description = "Number of categories in the group.", example = "8")
+        private Integer totalCount;
+
+        @Schema(description = "Number of categories in this response.", example = "8")
+        private Integer count;
+
+        @Schema(description = "Always 0; this list is not paged.", example = "0")
+        private Integer offset;
+
+        @Schema(description = "The categories. `last-updated` is emitted as epoch milliseconds, not as a date-time string.")
+        private List<Category> category;
+
+        public Integer getTotalCount() {
+            return totalCount;
+        }
+
+        public Integer getCount() {
+            return count;
+        }
+
+        public Integer getOffset() {
+            return offset;
+        }
+
+        public List<Category> getCategory() {
+            return category;
+        }
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/model/GroupUpdateForm.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/model/GroupUpdateForm.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+
+package org.opennms.web.rest.v1.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/** Describes the form body the group update handler reads out of a MultivaluedMap; it is not bound as a type. */
+@Schema(name = "V1GroupUpdateForm",
+        description = """
+                Form-encoded body for updating a group. Field names are the `OnmsGroup` bean property names. Keys
+                that are not writable properties are skipped, and a request in which nothing was written comes back
+                as 304.""")
+public class GroupUpdateForm {
+
+    @Schema(description = "Group comments.", example = "Second-line network operations")
+    public String comments;
+
+    @Schema(description = "Member user name. Stored as a single list element, which replaces the whole member "
+            + "list, so a comma-separated string becomes one malformed entry. The "
+            + "`/groups/{groupName}/users/{userName}` endpoints are the additive way to change membership.",
+            example = "admin")
+    public String users;
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/model/GroupUpdateForm.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/model/GroupUpdateForm.java
@@ -36,8 +36,7 @@ public class GroupUpdateForm {
     public String comments;
 
     @Schema(description = "Member user name. Stored as a single list element, which replaces the whole member "
-            + "list, so a comma-separated string becomes one malformed entry. The "
-            + "`/groups/{groupName}/users/{userName}` endpoints are the additive way to change membership.",
+            + "list, so a comma-separated string becomes one element containing the commas.",
             example = "admin")
     public String users;
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/model/UserUpdateForm.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/model/UserUpdateForm.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+
+package org.opennms.web.rest.v1.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/** Describes the form body the user update handler reads out of a MultivaluedMap; it is not bound as a type. */
+@Schema(name = "V1UserUpdateForm",
+        description = """
+                Form-encoded body for updating a user. Field names are the `OnmsUser` bean property names, not the
+                XML element names the read endpoints emit, so `fullName` and `comments` are the keys, not
+                `full-name` and `user-comments`. Keys that are not writable properties are skipped, and a request in
+                which nothing was written comes back as 304.""")
+public class UserUpdateForm {
+
+    @Schema(description = "Display name.", example = "Jane Roe")
+    public String fullName;
+
+    @Schema(description = "Free-text comments stored as `user-comments`.", example = "On call for the NOC")
+    public String comments;
+
+    @Schema(description = "Email contact address.", example = "jane.roe@example.org")
+    public String email;
+
+    @Schema(description = "New password. Stored verbatim unless `hashPassword` is `true`.", example = "s3cret")
+    public String password;
+
+    @Schema(description = "`true` hashes and salts `password` before storing it. Only consulted when `password` "
+            + "is also present in the same request.",
+            example = "true")
+    public Boolean hashPassword;
+
+    @Schema(description = "Duty schedule entry. The value is stored as a single list element, so a "
+            + "comma-separated string becomes one malformed entry rather than several.",
+            example = "MoTuWeThFr800-1700")
+    public String dutySchedule;
+
+    @Schema(description = "Security role. Stored as a single list element, which replaces the whole role list. "
+            + "The `/users/{userCriteria}/roles/{roleName}` endpoints are the additive way to change roles.",
+            example = "ROLE_USER")
+    public String roles;
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/model/UserUpdateForm.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/model/UserUpdateForm.java
@@ -51,12 +51,11 @@ public class UserUpdateForm {
     public Boolean hashPassword;
 
     @Schema(description = "Duty schedule entry. The value is stored as a single list element, so a "
-            + "comma-separated string becomes one malformed entry rather than several.",
+            + "comma-separated string becomes one element containing the commas rather than several entries.",
             example = "MoTuWeThFr800-1700")
     public String dutySchedule;
 
-    @Schema(description = "Security role. Stored as a single list element, which replaces the whole role list. "
-            + "The `/users/{userCriteria}/roles/{roleName}` endpoints are the additive way to change roles.",
+    @Schema(description = "Security role. Stored as a single list element, which replaces the whole role list.",
             example = "ROLE_USER")
     public String roles;
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/model/WhoamiResponse.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/model/WhoamiResponse.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v1.model;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Documentation-only description of the body returned by {@code GET /whoami}. The handler serialises
+ * an ad-hoc JSON object rather than returning this type.
+ */
+@Schema(name = "WhoamiResponse", description = "Identity and granted roles of the authenticated principal.")
+public class WhoamiResponse {
+
+    @Schema(description = "Login name of the authenticated principal.", example = "admin", required = true)
+    private String id;
+
+    @Schema(description = "Spring Security roles the principal holds, out of the roles OpenNMS knows about.",
+            example = "[\"ROLE_USER\",\"ROLE_ADMIN\"]", required = true)
+    private List<String> roles;
+
+    @Schema(description = "True when the principal is defined in users.xml. False for principals supplied by an external "
+            + "authentication source, in which case `email` and `fullName` are absent.",
+            example = "true", required = true)
+    private boolean internal;
+
+    @Schema(description = "Email address from users.xml. Omitted when empty or when the user is not internal.",
+            example = "admin@example.org")
+    private String email;
+
+    @Schema(description = "Full name from users.xml. Omitted when empty or when the user is not internal.",
+            example = "Administrator")
+    private String fullName;
+
+    public String getId() {
+        return id;
+    }
+
+    public List<String> getRoles() {
+        return roles;
+    }
+
+    public boolean isInternal() {
+        return internal;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getFullName() {
+        return fullName;
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AbstractDaoRestServiceWithDTO.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AbstractDaoRestServiceWithDTO.java
@@ -94,6 +94,11 @@ import org.springframework.orm.hibernate5.HibernateCallback;
 import org.springframework.orm.hibernate5.HibernateTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import com.google.common.base.Strings;
 import com.googlecode.concurentlocks.ReadWriteUpdateLock;
 import com.googlecode.concurentlocks.ReentrantReadWriteUpdateLock;
@@ -130,6 +135,71 @@ public abstract class AbstractDaoRestServiceWithDTO<T,D,Q,K extends Serializable
     private final Lock m_writeLock = m_globalLock.writeLock();
 
     protected static final int DEFAULT_LIMIT = 10;
+
+    /*
+     * Reference text for the query layer every V2 collection endpoint inherits. Held as
+     * constants because annotation members must be compile-time constants, and the same
+     * wording has to appear on each of the four collection operations.
+     */
+
+    protected static final String DOC_SEARCH = """
+            FIQL search expression restricting the result set. Property names are the `id` values \
+            listed by this endpoint's `properties` operation; nested properties are reached with a \
+            dot, for example `node.label`.
+
+            Operators are `==` (equal), `!=` (not equal), `=gt=`, `=ge=`, `=lt=` and `=le=`. \
+            String comparisons accept `*` as a wildcard, so `name==Review*` matches by prefix. \
+            Terms are combined with `;` for AND and `,` for OR. Timestamps are written as \
+            ISO-8601, for example `2026-08-01T00:00:00.000-0400`, even though they are returned \
+            as epoch milliseconds in JSON.
+
+            An expression that cannot be parsed, or that names a property the underlying query \
+            cannot resolve, is answered with 500 and a `text/plain` message.""";
+
+    protected static final String DOC_LIMIT = """
+            Maximum number of entities to return. Defaults to 10, and `0` means no limit. The same \
+            limit bounds how many matching entities the collection-level PUT and DELETE act on, so \
+            those operations touch at most ten entities unless a larger limit is given. A \
+            non-numeric value is answered with 500.""";
+
+    protected static final String DOC_OFFSET = """
+            Number of matching entities to skip before the first one returned. Defaults to 0.""";
+
+    protected static final String DOC_ORDER_BY = """
+            Property to sort by, named as in the `properties` operation. It replaces the \
+            endpoint's default ordering rather than adding to it. A name the query cannot resolve \
+            is answered with 500.""";
+
+    protected static final String DOC_ORDER = """
+            Sort direction. Read only when `orderBy` is also given: `desc` (case-insensitive) \
+            sorts descending, and any other value, including an absent one, sorts ascending.""";
+
+    protected static final String DOC_SEARCH_ERROR = """
+            The search expression could not be parsed, or it named a property the underlying query \
+            could not resolve. The body is a `text/plain` message.""";
+
+    protected static final String DOC_COUNT_ERROR = """
+            The search expression could not be parsed or resolved, or an `offset` was given (the \
+            count query rejects it). The body is a `text/plain` message.""";
+
+    protected static final String DOC_NOT_IMPLEMENTED = """
+            Not supported by this endpoint. The shared implementation answers 501 with no body.""";
+
+    protected static final String DOC_POST_WITH_ID = """
+            Creating an entity under a caller-chosen identifier is not supported. Every request to \
+            this path is answered with 404 and no body, whether or not the identifier exists. Use \
+            the collection-level POST instead where the endpoint supports creation.""";
+
+    protected static final String DOC_NO_MATCH = """
+            No entity matched the query, so nothing was changed. The response has no body.""";
+
+    protected static final String DOC_FORM_BODY = """
+            Form parameters naming the properties to set. Names are normalised by lower-casing and \
+            then upper-casing the letter after each `-` or `_`, so `link-label` and `link_label` \
+            both reach the `linkLabel` property while the camel-case spelling `linkLabel` does \
+            not. Names that do not resolve to a writable property, and the protected names `id`, \
+            `dbId`, `nodeId`, `authorizedGroups`, `foreignSource`, `foreignId` and `type`, are \
+            ignored without an error.""";
 
     protected abstract OnmsDao<T,K> getDao();
     protected abstract Class<T> getDaoClass();
@@ -244,6 +314,18 @@ public abstract class AbstractDaoRestServiceWithDTO<T,D,Q,K extends Serializable
 
     @GET
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
+    @Parameters({
+            @Parameter(name = "_s", in = ParameterIn.QUERY, description = DOC_SEARCH,
+                    schema = @Schema(type = "string")),
+            @Parameter(name = "limit", in = ParameterIn.QUERY, description = DOC_LIMIT,
+                    schema = @Schema(type = "integer", format = "int32", defaultValue = "10"), example = "10"),
+            @Parameter(name = "offset", in = ParameterIn.QUERY, description = DOC_OFFSET,
+                    schema = @Schema(type = "integer", format = "int32", defaultValue = "0"), example = "0"),
+            @Parameter(name = "orderBy", in = ParameterIn.QUERY, description = DOC_ORDER_BY,
+                    schema = @Schema(type = "string"), example = "id"),
+            @Parameter(name = "order", in = ParameterIn.QUERY, description = DOC_ORDER,
+                    schema = @Schema(type = "string", allowableValues = {"asc", "desc"}), example = "asc")
+    })
     public Response get(@Context final UriInfo uriInfo, @Context final SearchContext searchContext) {
         Criteria crit = getCriteria(uriInfo, searchContext);
         final List<T> coll = getDao().findMatching(crit);
@@ -275,6 +357,10 @@ public abstract class AbstractDaoRestServiceWithDTO<T,D,Q,K extends Serializable
     @GET
     @Path("count")
     @Produces({MediaType.TEXT_PLAIN})
+    @Parameters({
+            @Parameter(name = "_s", in = ParameterIn.QUERY, description = DOC_SEARCH,
+                    schema = @Schema(type = "string"))
+    })
     public Response getCount(@Context final UriInfo uriInfo, @Context final SearchContext searchContext) {
         return Response.ok(String.valueOf(getDao().countMatching(getCriteria(uriInfo, searchContext)))).build();
     }
@@ -282,7 +368,10 @@ public abstract class AbstractDaoRestServiceWithDTO<T,D,Q,K extends Serializable
     @GET
     @Path("properties")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-    public Response getProperties(@QueryParam("q") final String query) {
+    public Response getProperties(
+            @Parameter(description = "Case-insensitive substring matched against the property `name`. "
+                    + "Omit it to list every property.", example = "label")
+            @QueryParam("q") final String query) {
         Set<SearchProperty> props = getQueryProperties();
         if (props != null && props.size() > 0) {
             return Response.ok(new SearchPropertyCollection(props.stream().filter(s -> {
@@ -356,7 +445,18 @@ public abstract class AbstractDaoRestServiceWithDTO<T,D,Q,K extends Serializable
     @GET
     @Path("properties/{propertyId}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-    public Response getPropertyValues(@PathParam("propertyId") final String propertyId, @QueryParam("q") final String query, @QueryParam("limit") final Integer limit) {
+    public Response getPropertyValues(
+            @Parameter(description = "The `id` of one of the properties listed by the `properties` operation.",
+                    required = true, example = "id")
+            @PathParam("propertyId") final String propertyId,
+            @Parameter(description = "Substring the returned values must contain. For a property with a fixed "
+                    + "value list the match is case-sensitive; otherwise it is applied case-insensitively in SQL.",
+                    example = "127.")
+            @QueryParam("q") final String query,
+            @Parameter(description = "Maximum number of distinct values to return. Applied only to properties "
+                    + "whose values are read from the database, not to those with a fixed value list.",
+                    example = "25")
+            @QueryParam("limit") final Integer limit) {
         Set<SearchProperty> props = getQueryProperties();
         // Find the property with the matching ID
         Optional<SearchProperty> prop = props.stream().filter(p -> p.getId().equals(propertyId)).findAny();
@@ -457,6 +557,18 @@ public abstract class AbstractDaoRestServiceWithDTO<T,D,Q,K extends Serializable
 
     @PUT
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Parameters({
+            @Parameter(name = "_s", in = ParameterIn.QUERY, description = DOC_SEARCH,
+                    schema = @Schema(type = "string")),
+            @Parameter(name = "limit", in = ParameterIn.QUERY, description = DOC_LIMIT,
+                    schema = @Schema(type = "integer", format = "int32", defaultValue = "10"), example = "10"),
+            @Parameter(name = "offset", in = ParameterIn.QUERY, description = DOC_OFFSET,
+                    schema = @Schema(type = "integer", format = "int32", defaultValue = "0"), example = "0"),
+            @Parameter(name = "orderBy", in = ParameterIn.QUERY, description = DOC_ORDER_BY,
+                    schema = @Schema(type = "string"), example = "id"),
+            @Parameter(name = "order", in = ParameterIn.QUERY, description = DOC_ORDER,
+                    schema = @Schema(type = "string", allowableValues = {"asc", "desc"}), example = "asc")
+    })
     public Response updateMany(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo, @Context final SearchContext searchContext, final MultivaluedMapImpl params) {
         writeLock();
         try {
@@ -515,6 +627,18 @@ public abstract class AbstractDaoRestServiceWithDTO<T,D,Q,K extends Serializable
     }
 
     @DELETE
+    @Parameters({
+            @Parameter(name = "_s", in = ParameterIn.QUERY, description = DOC_SEARCH,
+                    schema = @Schema(type = "string")),
+            @Parameter(name = "limit", in = ParameterIn.QUERY, description = DOC_LIMIT,
+                    schema = @Schema(type = "integer", format = "int32", defaultValue = "10"), example = "10"),
+            @Parameter(name = "offset", in = ParameterIn.QUERY, description = DOC_OFFSET,
+                    schema = @Schema(type = "integer", format = "int32", defaultValue = "0"), example = "0"),
+            @Parameter(name = "orderBy", in = ParameterIn.QUERY, description = DOC_ORDER_BY,
+                    schema = @Schema(type = "string"), example = "id"),
+            @Parameter(name = "order", in = ParameterIn.QUERY, description = DOC_ORDER,
+                    schema = @Schema(type = "string", allowableValues = {"asc", "desc"}), example = "asc")
+    })
     public Response deleteMany(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo, @Context final SearchContext searchContext) {
         writeLock();
         try {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AbstractDaoRestServiceWithDTO.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AbstractDaoRestServiceWithDTO.java
@@ -158,8 +158,7 @@ public abstract class AbstractDaoRestServiceWithDTO<T,D,Q,K extends Serializable
 
     protected static final String DOC_LIMIT = """
             Maximum number of entities to return. Defaults to 10, and `0` means no limit. The same \
-            limit bounds how many matching entities the collection-level PUT and DELETE act on, so \
-            those operations touch at most ten entities unless a larger limit is given. A \
+            limit bounds how many matching entities the collection-level PUT and DELETE act on. A \
             non-numeric value is answered with 500.""";
 
     protected static final String DOC_OFFSET = """
@@ -183,12 +182,11 @@ public abstract class AbstractDaoRestServiceWithDTO<T,D,Q,K extends Serializable
             count query rejects it). The body is a `text/plain` message.""";
 
     protected static final String DOC_NOT_IMPLEMENTED = """
-            Not supported by this endpoint. The shared implementation answers 501 with no body.""";
+            Not supported by this endpoint: answered with 501 and no body.""";
 
     protected static final String DOC_POST_WITH_ID = """
-            Creating an entity under a caller-chosen identifier is not supported. Every request to \
-            this path is answered with 404 and no body, whether or not the identifier exists. Use \
-            the collection-level POST instead where the endpoint supports creation.""";
+            Every request to this path is answered with 404 and no body, whether or not the \
+            identifier exists.""";
 
     protected static final String DOC_NO_MATCH = """
             No entity matched the query, so nothing was changed. The response has no body.""";

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AlarmRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AlarmRestService.java
@@ -359,7 +359,7 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
             description = """
         Return the number of alarms matching `_s` as a plain-text integer. The response is
         `text/plain` only, so a request that asks solely for `application/json` is answered with 404.
-        `limit` and `offset` are ignored here: the count covers the whole match.
+        `limit` is ignored here, but a non-zero `offset` reaches the count query and fails with 500.
 
         Example query: `_s=alarm.severity==MINOR`.""",
             operationId = "getAlarmCount")
@@ -467,7 +467,7 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
                     description = "Unprefixed property id from `GET /alarms/properties`.", example = "severity")
             @PathParam("propertyId") final String propertyId,
             @Parameter(in = ParameterIn.QUERY, name = "q",
-                    description = "Case-sensitive substring the value must contain.", example = "nodeLost")
+                    description = "Substring the value must contain. Database-backed properties match case-insensitively; only fixed value lists are case-sensitive.", example = "nodeLost")
             @QueryParam("q") final String query,
             @Parameter(in = ParameterIn.QUERY, name = "limit",
                     description = "Maximum number of values returned. Applies only to values read from the database.",
@@ -600,7 +600,10 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
             @ApiResponse(responseCode = "404", description = "No alarm matched `_s`. No body is returned."),
             @ApiResponse(responseCode = "500", description = "`_s` named a property the entity does not have.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "could not resolve property: bogusprop of: org.opennms.netmgt.model.OnmsAlarm")))
+                            examples = @ExampleObject(value = "could not resolve property: bogusprop of: org.opennms.netmgt.model.OnmsAlarm"))),
+            @ApiResponse(responseCode = "403", description = "The caller holds `ROLE_READONLY`, or named somebody other than themselves in `ackUser` without holding `ROLE_ADMIN` or `ROLE_DELEGATE`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User 'operator', is not allowed to perform updates to alarms as user 'admin'")))
     })
     @Override
     public Response updateMany(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo,
@@ -663,7 +666,7 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
             @ApiResponse(responseCode = "204", description = "The alarm was updated. No body is returned."),
             @ApiResponse(responseCode = "403", description = "The caller may not act on behalf of the `ackUser` named.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "User 'operator' cannot act on behalf of user 'admin'"))),
+                            examples = @ExampleObject(value = "User 'operator', is not allowed to perform updates to alarms as user 'admin'"))),
             @ApiResponse(responseCode = "404", description = "No alarm has that id. No body is returned.")
     })
     @Override
@@ -736,7 +739,7 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
                             examples = @ExampleObject(value = "Body cannot be null."))),
             @ApiResponse(responseCode = "403", description = "The caller may not act on behalf of the `user` named.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "User operator cannot act on behalf of user admin"))),
+                            examples = @ExampleObject(value = "User 'operator', is not allowed to perform updates to alarms as user 'admin'"))),
             @ApiResponse(responseCode = "404", description = "No alarm has that id.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Alarm not found.")))
@@ -775,7 +778,7 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
                             examples = @ExampleObject(value = "Body cannot be null."))),
             @ApiResponse(responseCode = "403", description = "The caller may not act on behalf of the `user` named.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "User operator cannot act on behalf of user admin"))),
+                            examples = @ExampleObject(value = "User 'operator', is not allowed to perform updates to alarms as user 'admin'"))),
             @ApiResponse(responseCode = "404", description = "No alarm has that id.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Alarm not found.")))
@@ -806,7 +809,7 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
             @ApiResponse(responseCode = "204", description = "The sticky memo is gone, whether or not one was set. No body is returned."),
             @ApiResponse(responseCode = "403", description = "The authenticated user may not edit alarms.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "User operator cannot act on behalf of user admin"))),
+                            examples = @ExampleObject(value = "User 'operator', is not allowed to perform updates to alarms as user 'admin'"))),
             @ApiResponse(responseCode = "404", description = "No alarm has that id.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Alarm not found.")))
@@ -834,7 +837,7 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
             @ApiResponse(responseCode = "204", description = "The journal note is gone, whether or not one was set. No body is returned."),
             @ApiResponse(responseCode = "403", description = "The authenticated user may not edit alarms.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "User operator cannot act on behalf of user admin"))),
+                            examples = @ExampleObject(value = "User 'operator', is not allowed to perform updates to alarms as user 'admin'"))),
             @ApiResponse(responseCode = "404", description = "No alarm has that id.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Alarm not found.")))
@@ -869,7 +872,7 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
             @ApiResponse(responseCode = "202", description = "The request was handed to the ticketer plugin. No body is returned."),
             @ApiResponse(responseCode = "403", description = "The authenticated user may not edit alarms.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "User operator cannot act on behalf of user admin"))),
+                            examples = @ExampleObject(value = "User 'operator', is not allowed to perform updates to alarms as user 'admin'"))),
             @ApiResponse(responseCode = "501", description = "The ticketer plugin is disabled.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "AlarmTroubleTicketer is not enabled. Cannot perform operation")))
@@ -908,7 +911,7 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
             @ApiResponse(responseCode = "202", description = "The request was handed to the ticketer plugin. No body is returned."),
             @ApiResponse(responseCode = "403", description = "The authenticated user may not edit alarms.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "User operator cannot act on behalf of user admin"))),
+                            examples = @ExampleObject(value = "User 'operator', is not allowed to perform updates to alarms as user 'admin'"))),
             @ApiResponse(responseCode = "501", description = "The ticketer plugin is disabled.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "AlarmTroubleTicketer is not enabled. Cannot perform operation")))
@@ -944,7 +947,7 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
             @ApiResponse(responseCode = "202", description = "The request was handed to the ticketer plugin. No body is returned."),
             @ApiResponse(responseCode = "403", description = "The authenticated user may not edit alarms.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "User operator cannot act on behalf of user admin"))),
+                            examples = @ExampleObject(value = "User 'operator', is not allowed to perform updates to alarms as user 'admin'"))),
             @ApiResponse(responseCode = "501", description = "The ticketer plugin is disabled.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "AlarmTroubleTicketer is not enabled. Cannot perform operation")))

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AlarmRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AlarmRestService.java
@@ -30,10 +30,13 @@ import java.util.concurrent.Callable;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -41,7 +44,18 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.apache.cxf.jaxrs.ext.search.SearchContext;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.cxf.jaxrs.ext.search.SearchBean;
@@ -69,7 +83,11 @@ import org.opennms.web.rest.support.IpLikeCriteriaBehavior;
 import org.opennms.web.rest.support.MultivaluedMapImpl;
 import org.opennms.web.rest.support.SearchProperties;
 import org.opennms.web.rest.support.SearchProperty;
+import org.opennms.web.rest.support.SearchPropertyCollection;
 import org.opennms.web.rest.support.SecurityHelper;
+import org.opennms.web.rest.support.StringCollection;
+import org.opennms.web.rest.v2.model.AlarmMemoRequest;
+import org.opennms.web.rest.v2.model.AlarmPropertyUpdateRequest;
 import org.opennms.web.svclayer.TroubleTicketProxy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -83,7 +101,23 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @Path("alarms")
 @Transactional
-@Tag(name = "Alarms", description = "Alarms API")
+@Tag(name = "Alarms", description = """
+        Alarms API.
+
+        An alarm is the deduplicated form of one or more events that share a reduction key. Alarms are
+        not created through this API: they are raised by alarmd when an event whose event configuration
+        carries `alarm-data` is processed. What this API offers is querying, acknowledgement and
+        severity changes, sticky and journal notes, and trouble ticket actions.
+
+        Timestamps are rendered differently per representation: JSON carries epoch milliseconds
+        (`1787685470949`), XML carries an ISO-8601 string with offset
+        (`2026-08-25T15:17:50.949-04:00`). The generated schema shows the XML form for both.
+
+        Collection reads accept a CXF FIQL expression in `_s` together with `limit`, `offset`,
+        `orderBy` and `order`. The default page size is 10 and the default sort is `lastEventTime`
+        descending. Property names usable in `_s` and `orderBy` are listed by
+        `GET /alarms/properties`; naming a property the entity does not have fails with 500 rather
+        than 400.""")
 public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,AlarmDTO,SearchBean,Integer,Integer> {
 
     @Autowired
@@ -244,10 +278,480 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
         return Response.noContent().build();
     }
 
+
+    @GET
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "List alarms",
+            description = """
+        Return a page of alarms. `application/atom+xml` yields the same document as
+        `application/xml`, not an Atom feed. `relatedAlarms` is present only on alarms that are
+        situations.
+
+        Example query: `_s=alarm.severity==MINOR&orderBy=lastEventTime&order=desc`.""",
+            operationId = "getAlarms")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "A page of alarms.",
+                    headers = @Header(name = "Content-Range", description = "Range of rows returned and the total, as `items <from>-<to>/<total>`.",
+                            schema = @Schema(type = "string", example = "items 0-1/16")),
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = AlarmCollectionDTO.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 2,
+                      "count": 1,
+                      "offset": 0,
+                      "alarm": [
+                        {
+                          "id": 4241,
+                          "uei": "uei.opennms.org/perspective/nodes/nodeLostService",
+                          "location": "Default",
+                          "nodeId": 2,
+                          "nodeLabel": "loopback-001",
+                          "ipAddress": "127.0.0.1",
+                          "serviceType": { "id": 3, "name": "SNMP" },
+                          "reductionKey": "uei.opennms.org/perspective/nodes/nodeLostService:Default:2:127.0.0.1:SNMP",
+                          "type": 1,
+                          "count": 2,
+                          "severity": "MINOR",
+                          "firstEventTime": 1787684981802,
+                          "lastEventTime": 1787685470949,
+                          "description": "<p>A SNMP outage was identified on interface 127.0.0.1.</p>",
+                          "logMessage": "SNMP outage identified on interface 127.0.0.1.",
+                          "x733ProbableCause": 0,
+                          "affectedNodeCount": 1
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = AlarmCollectionDTO.class),
+                                    examples = @ExampleObject(value = """
+                    <alarms count="1" offset="0" totalCount="2">
+                      <alarm id="4241" type="1" count="2" severity="MINOR">
+                        <uei>uei.opennms.org/perspective/nodes/nodeLostService</uei>
+                        <location>Default</location>
+                        <nodeId>2</nodeId>
+                        <nodeLabel>loopback-001</nodeLabel>
+                        <ipAddress>127.0.0.1</ipAddress>
+                        <serviceType id="3"><name>SNMP</name></serviceType>
+                        <reductionKey>uei.opennms.org/perspective/nodes/nodeLostService:Default:2:127.0.0.1:SNMP</reductionKey>
+                        <firstEventTime>2026-08-25T15:09:41.802-04:00</firstEventTime>
+                        <lastEventTime>2026-08-25T15:17:50.949-04:00</lastEventTime>
+                        <x733ProbableCause>0</x733ProbableCause>
+                        <affectedNodeCount>1</affectedNodeCount>
+                      </alarm>
+                    </alarms>"""))
+                    }),
+            @ApiResponse(responseCode = "204", description = "No alarm matched. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "`_s` or `orderBy` named a property the entity does not have.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "could not resolve property: bogusprop of: org.opennms.netmgt.model.OnmsAlarm")))
+    })
+    @Override
+    public Response get(@Context final UriInfo uriInfo, @Context final SearchContext searchContext) {
+        return super.get(uriInfo, searchContext);
+    }
+
+    @GET
+    @Path("count")
+    @Produces({MediaType.TEXT_PLAIN})
+    @Operation(
+            summary = "Count alarms",
+            description = """
+        Return the number of alarms matching `_s` as a plain-text integer. The response is
+        `text/plain` only, so a request that asks solely for `application/json` is answered with 404.
+        `limit` and `offset` are ignored here: the count covers the whole match.
+
+        Example query: `_s=alarm.severity==MINOR`.""",
+            operationId = "getAlarmCount")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The number of matching alarms.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "2"))),
+            @ApiResponse(responseCode = "404", description = "The request did not accept `text/plain`. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "`_s` named a property the entity does not have.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "could not resolve property: bogusprop of: org.opennms.netmgt.model.OnmsAlarm")))
+    })
+    @Override
+    public Response getCount(@Context final UriInfo uriInfo, @Context final SearchContext searchContext) {
+        return super.getCount(uriInfo, searchContext);
+    }
+
+    @GET
+    @Path("properties")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Operation(
+            summary = "List the properties alarms can be queried on",
+            description = """
+        Return the property names accepted by `_s` and `orderBy`, with their type and whether they
+        support `iplike`. Properties whose value set is fixed carry a `values` map of code to label.
+        `q` filters the list by a case-insensitive substring of the name; a `q` that matches nothing
+        yields 200 with an empty list, not 204.""",
+            operationId = "getAlarmProperties")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The matching query properties.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = SearchPropertyCollection.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 2,
+                      "count": 2,
+                      "offset": 0,
+                      "searchProperty": [
+                        {
+                          "id": "severity",
+                          "name": "Severity",
+                          "type": "INTEGER",
+                          "orderBy": true,
+                          "iplike": false,
+                          "values": { "1": "Indeterminate", "2": "Cleared", "3": "Normal" }
+                        },
+                        {
+                          "id": "alarm.severity",
+                          "name": "Alarm: Severity",
+                          "type": "INTEGER",
+                          "orderBy": true,
+                          "iplike": false
+                        }
+                      ]
+                    }""")))
+    })
+    @Override
+    public Response getProperties(@Parameter(in = ParameterIn.QUERY, name = "q",
+            description = "Case-insensitive substring of the property name.", example = "severity")
+                                  @QueryParam("q") final String query) {
+        return super.getProperties(query);
+    }
+
+    @GET
+    @Path("properties/{propertyId}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Operation(
+            summary = "List the values a query property takes",
+            description = """
+        Return the distinct values of one query property, either from its fixed value set or from a
+        `select distinct` over the alarm table. The element type follows the property type: strings for
+        `STRING` and `IP_ADDRESS`, numbers for `INTEGER`, `LONG` and `FLOAT`, and epoch milliseconds in
+        JSON for `TIMESTAMP`. `propertyId` is the unprefixed id from `GET /alarms/properties`, so
+        `severity` rather than `alarm.severity`.""",
+            operationId = "getAlarmPropertyValues")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The distinct values of the property.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = StringCollection.class),
+                            examples = {
+                                    @ExampleObject(name = "string property", value = """
+                    {
+                      "totalCount": 2,
+                      "count": 2,
+                      "offset": 0,
+                      "value": [
+                        "uei.opennms.org/nodes/dataCollectionFailed",
+                        "uei.opennms.org/perspective/nodes/nodeLostService"
+                      ]
+                    }"""),
+                                    @ExampleObject(name = "timestamp property", value = """
+                    {
+                      "totalCount": 2,
+                      "count": 2,
+                      "offset": 0,
+                      "value": [1787685468093, 1787685470949]
+                    }""")
+                            })),
+            @ApiResponse(responseCode = "204", description = "The property has a type with no value listing, such as BOOLEAN. No body is returned."),
+            @ApiResponse(responseCode = "404", description = "No query property has that id. No body is returned.")
+    })
+    @Override
+    public Response getPropertyValues(
+            @Parameter(in = ParameterIn.PATH, name = "propertyId", required = true,
+                    description = "Unprefixed property id from `GET /alarms/properties`.", example = "severity")
+            @PathParam("propertyId") final String propertyId,
+            @Parameter(in = ParameterIn.QUERY, name = "q",
+                    description = "Case-sensitive substring the value must contain.", example = "nodeLost")
+            @QueryParam("q") final String query,
+            @Parameter(in = ParameterIn.QUERY, name = "limit",
+                    description = "Maximum number of values returned. Applies only to values read from the database.",
+                    example = "25")
+            @QueryParam("limit") final Integer limit) {
+        return super.getPropertyValues(propertyId, query, limit);
+    }
+
+    @GET
+    @Path("{id}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get one alarm",
+            description = """
+        Return a single alarm by its database id. `relatedAlarms` is present only when the alarm is a
+        situation.
+
+        A situation is itself an alarm, so `/situations/{id}` resolves the same way and this operation
+        also serves that path. Neither path restricts the lookup, so a situation id works here and an
+        ordinary alarm id works there.""",
+            operationId = "getAlarmById")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The alarm.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = AlarmDTO.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "id": 4241,
+                      "uei": "uei.opennms.org/perspective/nodes/nodeLostService",
+                      "location": "Default",
+                      "nodeId": 2,
+                      "nodeLabel": "loopback-001",
+                      "ipAddress": "127.0.0.1",
+                      "serviceType": { "id": 3, "name": "SNMP" },
+                      "reductionKey": "uei.opennms.org/perspective/nodes/nodeLostService:Default:2:127.0.0.1:SNMP",
+                      "type": 1,
+                      "count": 2,
+                      "severity": "MINOR",
+                      "firstEventTime": 1787684981802,
+                      "lastEventTime": 1787685470949,
+                      "x733ProbableCause": 0,
+                      "affectedNodeCount": 1
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = AlarmDTO.class),
+                                    examples = @ExampleObject(value = """
+                    <alarm id="4241" type="1" count="2" severity="MINOR">
+                      <uei>uei.opennms.org/perspective/nodes/nodeLostService</uei>
+                      <reductionKey>uei.opennms.org/perspective/nodes/nodeLostService:Default:2:127.0.0.1:SNMP</reductionKey>
+                      <lastEventTime>2026-08-25T15:17:50.949-04:00</lastEventTime>
+                    </alarm>"""))
+                    }),
+            @ApiResponse(responseCode = "404", description = "No alarm has that id. No body is returned.")
+    })
+    @Override
+    public Response get(@Context final UriInfo uriInfo,
+                        @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                                description = "Alarm database id.", example = "4241")
+                        @PathParam("id") final Integer id) {
+        return super.get(uriInfo, id);
+    }
+
+    @POST
+    @Path("{id}")
+    @Operation(
+            summary = "Rejected: alarms cannot be created at a chosen id",
+            description = "Always answers 404. Alarms are raised by alarmd from events, not created through this API.",
+            operationId = "createAlarmWithId",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                    description = "Alarm database id. The value is not read: every request to this path is answered with 404.",
+                    example = "4241"))
+    @ApiResponses(@ApiResponse(responseCode = "404", description = "Always. No body is returned."))
+    @Override
+    public Response createSpecific() {
+        return super.createSpecific();
+    }
+
+    @POST
+    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Operation(
+            summary = "Not implemented: create an alarm",
+            description = """
+        Creating an alarm from a document is not implemented and answers 501. To raise an alarm,
+        publish an event whose event configuration carries `alarm-data`; to correlate existing alarms
+        into a situation, use `POST /situations/create`. This operation also serves `POST /situations`,
+        which behaves identically.
+
+        The body is still deserialised and mapped before the 501 is produced, so a body that omits
+        `relatedAlarms` fails earlier with 500: the entity setter dereferences the missing collection.
+        Sending `"relatedAlarms": []` reaches the 501.""",
+            operationId = "createAlarm")
+    @RequestBody(description = "Alarm document. Include `relatedAlarms` to avoid the 500 described above.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = AlarmDTO.class),
+                            examples = @ExampleObject(value = "{ \"relatedAlarms\": [] }")),
+                    @Content(mediaType = MediaType.APPLICATION_XML, schema = @Schema(implementation = AlarmDTO.class),
+                            examples = @ExampleObject(value = "<alarm><relatedAlarms/></alarm>"))
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "500", description = "The body omitted `relatedAlarms`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot invoke \"java.util.Set.forEach(java.util.function.Consumer)\" because \"alarms\" is null"))),
+            @ApiResponse(responseCode = "501", description = "Create is not implemented. No body is returned.")
+    })
+    @Override
+    public Response create(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo, final AlarmDTO object) {
+        return super.create(securityContext, uriInfo, object);
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Operation(
+            summary = "Update properties of several alarms",
+            description = """
+        Apply the form parameters to every alarm matching `_s`. The default `limit` of 10 applies to
+        the selection, so a call without an explicit `limit` touches at most 10 alarms. Acknowledgement
+        changes go through the acknowledgement DAO, which writes an `acks` row per alarm and updates
+        the alarm in place.
+
+        The whole batch runs in one transaction and stops at the first alarm whose update fails, so a
+        4xx or 5xx leaves earlier alarms already changed.
+
+        Example query: `_s=alarm.id==4241`.""",
+            operationId = "updateAlarms")
+    @RequestBody(required = true, description = "Alarm properties to apply, form-encoded.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(implementation = AlarmPropertyUpdateRequest.class),
+                    examples = @ExampleObject(value = "ack=true")))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Every selected alarm was updated. No body is returned."),
+            @ApiResponse(responseCode = "404", description = "No alarm matched `_s`. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "`_s` named a property the entity does not have.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "could not resolve property: bogusprop of: org.opennms.netmgt.model.OnmsAlarm")))
+    })
+    @Override
+    public Response updateMany(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo,
+                               @Context final SearchContext searchContext, final MultivaluedMapImpl params) {
+        return super.updateMany(securityContext, uriInfo, searchContext, params);
+    }
+
+    @PUT
+    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Path("{id}")
+    @Operation(
+            summary = "Not implemented: replace an alarm",
+            description = """
+        Replacing an alarm from a document is not implemented and answers 501. Use the
+        form-encoded variant of `PUT /alarms/{id}` to change acknowledgement, severity or ticket
+        fields.""",
+            operationId = "replaceAlarm")
+    @RequestBody(description = "Alarm document. Not applied.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = AlarmDTO.class),
+                            examples = @ExampleObject(value = "{}")),
+                    @Content(mediaType = MediaType.APPLICATION_XML, schema = @Schema(implementation = AlarmDTO.class),
+                            examples = @ExampleObject(value = "<alarm/>"))
+            })
+    @ApiResponses(@ApiResponse(responseCode = "501", description = "Replace is not implemented. No body is returned."))
+    @Override
+    public Response update(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo,
+                           @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                                   description = "Alarm database id.", example = "4241")
+                           @PathParam("id") final Integer id, final OnmsAlarm object) {
+        return super.update(securityContext, uriInfo, id, object);
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Path("{id}")
+    @Operation(
+            summary = "Acknowledge, clear, escalate or ticket one alarm",
+            description = """
+        Apply the form parameters to one alarm. Only the parameters present are acted on, so this is
+        the endpoint for acknowledging, un-acknowledging, escalating and clearing an alarm as well as
+        for recording a trouble ticket id and state.
+
+        A `ticketState` outside the enumerated names is ignored, and a caller with ROLE_ADMIN may set
+        `ackUser` to any name, so neither case is reported as an error.
+
+        This operation also serves `PUT /situations/{id}`, where it acts on the situation alarm alone:
+        clearing or acknowledging a situation leaves its member alarms untouched. Use
+        `POST /situations/alarms/clear` to clear members. A body sent as JSON or XML rather than
+        form-encoded reaches a different handler that answers 501.""",
+            operationId = "updateAlarmProperties")
+    @RequestBody(required = true, description = "Alarm properties to apply, form-encoded.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(implementation = AlarmPropertyUpdateRequest.class),
+                    examples = {
+                            @ExampleObject(name = "acknowledge", value = "ack=true"),
+                            @ExampleObject(name = "clear", value = "clear=true"),
+                            @ExampleObject(name = "record a ticket", value = "ticketId=INC0012345&ticketState=OPEN")
+                    }))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The alarm was updated. No body is returned."),
+            @ApiResponse(responseCode = "403", description = "The caller may not act on behalf of the `ackUser` named.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User 'operator' cannot act on behalf of user 'admin'"))),
+            @ApiResponse(responseCode = "404", description = "No alarm has that id. No body is returned.")
+    })
+    @Override
+    public Response updateProperties(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo,
+                                     @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                                             description = "Alarm database id.", example = "4241")
+                                     @PathParam("id") final Integer id, final MultivaluedMapImpl params) {
+        return super.updateProperties(securityContext, uriInfo, id, params);
+    }
+
+    @DELETE
+    @Operation(
+            summary = "Not implemented: delete several alarms",
+            description = """
+        Deleting alarms is not implemented. When `_s` selects at least one alarm the handler answers
+        501 without deleting anything; when nothing matches it answers 404 instead, so the status code
+        reports whether the filter matched rather than whether anything was deleted.
+
+        Example query: `_s=alarm.id==4241`.""",
+            operationId = "deleteAlarms")
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = "No alarm matched `_s`. No body is returned."),
+            @ApiResponse(responseCode = "501", description = "Delete is not implemented. No body is returned.")
+    })
+    @Override
+    public Response deleteMany(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo,
+                               @Context final SearchContext searchContext) {
+        return super.deleteMany(securityContext, uriInfo, searchContext);
+    }
+
+    @DELETE
+    @Path("{id}")
+    @Operation(
+            summary = "Not implemented: delete one alarm",
+            description = """
+        Deleting an alarm is not implemented. An existing alarm answers 501 and an unknown id answers
+        404, so the status code reports whether the alarm exists rather than whether it was
+        deleted.
+
+        This operation also serves `DELETE /situations/{id}`. To dissolve a correlation rather than
+        remove the alarm, drop its members with `DELETE /situations/removeAlarm`.""",
+            operationId = "deleteAlarm")
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = "No alarm has that id. No body is returned."),
+            @ApiResponse(responseCode = "501", description = "Delete is not implemented. No body is returned.")
+    })
+    @Override
+    public Response delete(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo,
+                           @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                                   description = "Alarm database id.", example = "4241")
+                           @PathParam("id") final Integer id) {
+        return super.delete(securityContext, uriInfo, id);
+    }
+
     @PUT
     @Path("{id}/memo")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-    public Response updateMemo(@Context final SecurityContext securityContext, @PathParam("id") final Integer alarmId, final MultivaluedMapImpl params) {
+    @Operation(
+            summary = "Set the sticky memo on an alarm",
+            description = """
+        Replace the sticky memo, the note attached to the alarm row itself. `body` is required. When
+        `user` is omitted the authenticated user is recorded as the author.""",
+            operationId = "updateAlarmMemo")
+    @RequestBody(required = true, description = "Memo text and optional author, form-encoded.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(implementation = AlarmMemoRequest.class),
+                    examples = @ExampleObject(value = "body=Waiting+on+the+carrier.&user=admin")))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The memo was written. No body is returned."),
+            @ApiResponse(responseCode = "400", description = "`body` was absent.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Body cannot be null."))),
+            @ApiResponse(responseCode = "403", description = "The caller may not act on behalf of the `user` named.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User operator cannot act on behalf of user admin"))),
+            @ApiResponse(responseCode = "404", description = "No alarm has that id.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Alarm not found.")))
+    })
+    public Response updateMemo(@Context final SecurityContext securityContext,
+                               @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                                       description = "Alarm database id.", example = "4241")
+                               @PathParam("id") final Integer alarmId, final MultivaluedMapImpl params) {
         final String user = params.containsKey("user") ? params.getFirst("user") : securityContext.getUserPrincipal().getName();
         SecurityHelper.assertUserEditCredentials(securityContext, user);
         final String body = params.getFirst("body");
@@ -260,7 +764,33 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
     @PUT
     @Path("{id}/journal")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-    public Response updateJournal(@Context final SecurityContext securityContext, @PathParam("id") final Integer alarmId, final MultivaluedMapImpl params) {
+    @Operation(
+            summary = "Set the journal note on an alarm",
+            description = """
+        Replace the journal note, which is keyed on the reduction key rather than on the alarm row, so a
+        later alarm reduced onto the same key carries the same note. `body` is required. When `user` is
+        omitted the authenticated user is recorded as the author.""",
+            operationId = "updateAlarmJournal")
+    @RequestBody(required = true, description = "Memo text and optional author, form-encoded.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(implementation = AlarmMemoRequest.class),
+                    examples = @ExampleObject(value = "body=Carrier+ticket+INC0012345+raised.&user=admin")))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The journal note was written. No body is returned."),
+            @ApiResponse(responseCode = "400", description = "`body` was absent.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Body cannot be null."))),
+            @ApiResponse(responseCode = "403", description = "The caller may not act on behalf of the `user` named.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User operator cannot act on behalf of user admin"))),
+            @ApiResponse(responseCode = "404", description = "No alarm has that id.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Alarm not found.")))
+    })
+    public Response updateJournal(@Context final SecurityContext securityContext,
+                                  @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                                          description = "Alarm database id.", example = "4241")
+                                  @PathParam("id") final Integer alarmId, final MultivaluedMapImpl params) {
         final String user = params.containsKey("user") ? params.getFirst("user") : securityContext.getUserPrincipal().getName();
         SecurityHelper.assertUserEditCredentials(securityContext, user);
         final String body = params.getFirst("body");
@@ -273,7 +803,26 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
     @DELETE
     @Path("{id}/memo")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-    public Response removeMemo(@Context final SecurityContext securityContext, @PathParam("id") final Integer alarmId) {
+    @Operation(
+            summary = "Remove the sticky memo from an alarm",
+            description = """
+        Remove the note attached to the alarm row. Removing one that is not set is not reported as an error: the call still answers
+        204. No request body is read, although the handler declares
+        `application/x-www-form-urlencoded`.""",
+            operationId = "deleteAlarmMemo")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The sticky memo is gone, whether or not one was set. No body is returned."),
+            @ApiResponse(responseCode = "403", description = "The authenticated user may not edit alarms.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User operator cannot act on behalf of user admin"))),
+            @ApiResponse(responseCode = "404", description = "No alarm has that id.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Alarm not found.")))
+    })
+    public Response removeMemo(@Context final SecurityContext securityContext,
+                               @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                                       description = "Alarm database id.", example = "4241")
+                               @PathParam("id") final Integer alarmId) {
         SecurityHelper.assertUserEditCredentials(securityContext, securityContext.getUserPrincipal().getName());
         if (m_repository.getAlarm(alarmId) == null) throw getException(Status.NOT_FOUND, "Alarm not found.");
         m_repository.removeStickyMemo(alarmId);
@@ -283,7 +832,26 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
     @DELETE
     @Path("{id}/journal")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-    public Response removeJournal(@Context final SecurityContext securityContext, @PathParam("id") final Integer alarmId) {
+    @Operation(
+            summary = "Remove the journal note from an alarm",
+            description = """
+        Remove the note keyed on the reduction key. Removing one that is not set is not reported as an error: the call still answers
+        204. No request body is read, although the handler declares
+        `application/x-www-form-urlencoded`.""",
+            operationId = "deleteAlarmJournal")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The journal note is gone, whether or not one was set. No body is returned."),
+            @ApiResponse(responseCode = "403", description = "The authenticated user may not edit alarms.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User operator cannot act on behalf of user admin"))),
+            @ApiResponse(responseCode = "404", description = "No alarm has that id.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Alarm not found.")))
+    })
+    public Response removeJournal(@Context final SecurityContext securityContext,
+                                  @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                                          description = "Alarm database id.", example = "4241")
+                                  @PathParam("id") final Integer alarmId) {
         SecurityHelper.assertUserEditCredentials(securityContext, securityContext.getUserPrincipal().getName());
         if (m_repository.getAlarm(alarmId) == null) throw getException(Status.NOT_FOUND, "Alarm not found.");
         m_repository.removeReductionKeyMemo(alarmId);
@@ -292,7 +860,33 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
 
     @POST
     @Path("{id}/ticket/create")
-    public Response createTicket(@Context final SecurityContext securityContext, @PathParam("id") final Integer alarmId) throws Exception {
+    @Operation(
+            summary = "Create the trouble ticket for an alarm",
+            description = """
+        Ask the configured ticketer plugin to raise a ticket for the alarm. The authenticated user is passed
+        to the plugin as the `user` parameter.
+
+        The action is asynchronous: the handler hands the request to the ticketer plugin and answers
+        202 without waiting for the helpdesk system. Progress shows up in the `troubleTicket` and
+        `troubleTicketState` fields of the alarm.
+
+        The whole family is gated on `opennms.alarmTroubleTicketEnabled` being `true`. With the
+        ticketer disabled every call answers 501, including a call naming an alarm that does not
+        exist, because the gate is checked before the alarm is looked up.""",
+            operationId = "createAlarmTicket")
+    @ApiResponses({
+            @ApiResponse(responseCode = "202", description = "The request was handed to the ticketer plugin. No body is returned."),
+            @ApiResponse(responseCode = "403", description = "The authenticated user may not edit alarms.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User operator cannot act on behalf of user admin"))),
+            @ApiResponse(responseCode = "501", description = "The ticketer plugin is disabled.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "AlarmTroubleTicketer is not enabled. Cannot perform operation")))
+    })
+    public Response createTicket(@Context final SecurityContext securityContext,
+                                 @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                                         description = "Alarm database id.", example = "4241")
+                                 @PathParam("id") final Integer alarmId) throws Exception {
         SecurityHelper.assertUserEditCredentials(securityContext, securityContext.getUserPrincipal().getName());
 
         return runIfTicketerPluginIsEnabled(() -> {
@@ -305,7 +899,33 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
 
     @POST
     @Path("{id}/ticket/update")
-    public Response updateTicket(@Context final SecurityContext securityContext, @PathParam("id") final Integer alarmId) throws Exception {
+    @Operation(
+            summary = "Refresh the trouble ticket for an alarm",
+            description = """
+        Ask the configured ticketer plugin to re-read the ticket from the helpdesk system and write the
+        current state back onto the alarm.
+
+        The action is asynchronous: the handler hands the request to the ticketer plugin and answers
+        202 without waiting for the helpdesk system. Progress shows up in the `troubleTicket` and
+        `troubleTicketState` fields of the alarm.
+
+        The whole family is gated on `opennms.alarmTroubleTicketEnabled` being `true`. With the
+        ticketer disabled every call answers 501, including a call naming an alarm that does not
+        exist, because the gate is checked before the alarm is looked up.""",
+            operationId = "updateAlarmTicket")
+    @ApiResponses({
+            @ApiResponse(responseCode = "202", description = "The request was handed to the ticketer plugin. No body is returned."),
+            @ApiResponse(responseCode = "403", description = "The authenticated user may not edit alarms.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User operator cannot act on behalf of user admin"))),
+            @ApiResponse(responseCode = "501", description = "The ticketer plugin is disabled.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "AlarmTroubleTicketer is not enabled. Cannot perform operation")))
+    })
+    public Response updateTicket(@Context final SecurityContext securityContext,
+                                 @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                                         description = "Alarm database id.", example = "4241")
+                                 @PathParam("id") final Integer alarmId) throws Exception {
         SecurityHelper.assertUserEditCredentials(securityContext, securityContext.getUserPrincipal().getName());
 
         return runIfTicketerPluginIsEnabled(() -> {
@@ -316,7 +936,32 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
 
     @POST
     @Path("{id}/ticket/close")
-    public Response closeTicket(@Context final SecurityContext securityContext, @PathParam("id") final Integer alarmId) throws Exception {
+    @Operation(
+            summary = "Close the trouble ticket for an alarm",
+            description = """
+        Ask the configured ticketer plugin to close the ticket recorded on the alarm.
+
+        The action is asynchronous: the handler hands the request to the ticketer plugin and answers
+        202 without waiting for the helpdesk system. Progress shows up in the `troubleTicket` and
+        `troubleTicketState` fields of the alarm.
+
+        The whole family is gated on `opennms.alarmTroubleTicketEnabled` being `true`. With the
+        ticketer disabled every call answers 501, including a call naming an alarm that does not
+        exist, because the gate is checked before the alarm is looked up.""",
+            operationId = "closeAlarmTicket")
+    @ApiResponses({
+            @ApiResponse(responseCode = "202", description = "The request was handed to the ticketer plugin. No body is returned."),
+            @ApiResponse(responseCode = "403", description = "The authenticated user may not edit alarms.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User operator cannot act on behalf of user admin"))),
+            @ApiResponse(responseCode = "501", description = "The ticketer plugin is disabled.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "AlarmTroubleTicketer is not enabled. Cannot perform operation")))
+    })
+    public Response closeTicket(@Context final SecurityContext securityContext,
+                                @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                                        description = "Alarm database id.", example = "4241")
+                                @PathParam("id") final Integer alarmId) throws Exception {
         SecurityHelper.assertUserEditCredentials(securityContext, securityContext.getUserPrincipal().getName());
 
         return runIfTicketerPluginIsEnabled(() -> {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AlarmRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AlarmRestService.java
@@ -102,12 +102,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Path("alarms")
 @Transactional
 @Tag(name = "Alarms", description = """
-        Alarms API.
-
-        An alarm is the deduplicated form of one or more events that share a reduction key. Alarms are
-        not created through this API: they are raised by alarmd when an event whose event configuration
-        carries `alarm-data` is processed. What this API offers is querying, acknowledgement and
-        severity changes, sticky and journal notes, and trouble ticket actions.
+        Alarms API. An alarm is the deduplicated form of one or more events that share a reduction key.
+        This API queries alarms, changes acknowledgement and severity, sets sticky and journal notes and
+        drives trouble ticket actions. Alarms are raised by alarmd from events whose event configuration
+        carries `alarm-data`, not created here.
 
         Timestamps are rendered differently per representation: JSON carries epoch milliseconds
         (`1787685470949`), XML carries an ISO-8601 string with offset
@@ -537,7 +535,7 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
     @Path("{id}")
     @Operation(
             summary = "Rejected: alarms cannot be created at a chosen id",
-            description = "Always answers 404. Alarms are raised by alarmd from events, not created through this API.",
+            description = "Always answers 404.",
             operationId = "createAlarmWithId",
             parameters = @Parameter(in = ParameterIn.PATH, name = "id", required = true,
                     description = "Alarm database id. The value is not read: every request to this path is answered with 404.",
@@ -553,16 +551,14 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
     @Operation(
             summary = "Not implemented: create an alarm",
             description = """
-        Creating an alarm from a document is not implemented and answers 501. To raise an alarm,
-        publish an event whose event configuration carries `alarm-data`; to correlate existing alarms
-        into a situation, use `POST /situations/create`. This operation also serves `POST /situations`,
-        which behaves identically.
+        Creating an alarm from a document is not implemented and answers 501. This operation also
+        serves `POST /situations`, which behaves identically.
 
         The body is still deserialised and mapped before the 501 is produced, so a body that omits
         `relatedAlarms` fails earlier with 500: the entity setter dereferences the missing collection.
         Sending `"relatedAlarms": []` reaches the 501.""",
             operationId = "createAlarm")
-    @RequestBody(description = "Alarm document. Include `relatedAlarms` to avoid the 500 described above.",
+    @RequestBody(description = "Alarm document. `relatedAlarms` has to be present; without it the call answers 500.",
             content = {
                     @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = AlarmDTO.class),
                             examples = @ExampleObject(value = "{ \"relatedAlarms\": [] }")),
@@ -618,9 +614,8 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
     @Operation(
             summary = "Not implemented: replace an alarm",
             description = """
-        Replacing an alarm from a document is not implemented and answers 501. Use the
-        form-encoded variant of `PUT /alarms/{id}` to change acknowledgement, severity or ticket
-        fields.""",
+        Replacing an alarm from a document is not implemented and answers 501. The form-encoded
+        variant of `PUT /alarms/{id}` changes acknowledgement, severity and ticket fields.""",
             operationId = "replaceAlarm")
     @RequestBody(description = "Alarm document. Not applied.",
             content = {
@@ -644,16 +639,16 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
     @Operation(
             summary = "Acknowledge, clear, escalate or ticket one alarm",
             description = """
-        Apply the form parameters to one alarm. Only the parameters present are acted on, so this is
-        the endpoint for acknowledging, un-acknowledging, escalating and clearing an alarm as well as
-        for recording a trouble ticket id and state.
+        Apply the form parameters to one alarm. Only the parameters present are acted on: they cover
+        acknowledging, un-acknowledging, escalating and clearing an alarm, and recording a trouble
+        ticket id and state.
 
         A `ticketState` outside the enumerated names is ignored, and a caller with ROLE_ADMIN may set
         `ackUser` to any name, so neither case is reported as an error.
 
         This operation also serves `PUT /situations/{id}`, where it acts on the situation alarm alone:
-        clearing or acknowledging a situation leaves its member alarms untouched. Use
-        `POST /situations/alarms/clear` to clear members. A body sent as JSON or XML rather than
+        clearing or acknowledging a situation leaves its member alarms untouched.
+        `POST /situations/alarms/clear` clears members. A body sent as JSON or XML rather than
         form-encoded reaches a different handler that answers 501.""",
             operationId = "updateAlarmProperties")
     @RequestBody(required = true, description = "Alarm properties to apply, form-encoded.",
@@ -705,11 +700,9 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
             summary = "Not implemented: delete one alarm",
             description = """
         Deleting an alarm is not implemented. An existing alarm answers 501 and an unknown id answers
-        404, so the status code reports whether the alarm exists rather than whether it was
-        deleted.
+        404, so the status code reports whether the alarm exists rather than whether it was deleted.
 
-        This operation also serves `DELETE /situations/{id}`. To dissolve a correlation rather than
-        remove the alarm, drop its members with `DELETE /situations/removeAlarm`.""",
+        This operation also serves `DELETE /situations/{id}`.""",
             operationId = "deleteAlarm")
     @ApiResponses({
             @ApiResponse(responseCode = "404", description = "No alarm has that id. No body is returned."),
@@ -806,9 +799,8 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
     @Operation(
             summary = "Remove the sticky memo from an alarm",
             description = """
-        Remove the note attached to the alarm row. Removing one that is not set is not reported as an error: the call still answers
-        204. No request body is read, although the handler declares
-        `application/x-www-form-urlencoded`.""",
+        Remove the note attached to the alarm row. Removing one that is not set still answers 204. No
+        request body is read, although the handler declares `application/x-www-form-urlencoded`.""",
             operationId = "deleteAlarmMemo")
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "The sticky memo is gone, whether or not one was set. No body is returned."),
@@ -835,9 +827,8 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
     @Operation(
             summary = "Remove the journal note from an alarm",
             description = """
-        Remove the note keyed on the reduction key. Removing one that is not set is not reported as an error: the call still answers
-        204. No request body is read, although the handler declares
-        `application/x-www-form-urlencoded`.""",
+        Remove the note keyed on the reduction key. Removing one that is not set still answers 204. No
+        request body is read, although the handler declares `application/x-www-form-urlencoded`.""",
             operationId = "deleteAlarmJournal")
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "The journal note is gone, whether or not one was set. No body is returned."),
@@ -863,14 +854,14 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
     @Operation(
             summary = "Create the trouble ticket for an alarm",
             description = """
-        Ask the configured ticketer plugin to raise a ticket for the alarm. The authenticated user is passed
-        to the plugin as the `user` parameter.
+        Ask the configured ticketer plugin to raise a ticket for the alarm. The authenticated user is
+        passed to the plugin as the `user` parameter.
 
         The action is asynchronous: the handler hands the request to the ticketer plugin and answers
         202 without waiting for the helpdesk system. Progress shows up in the `troubleTicket` and
         `troubleTicketState` fields of the alarm.
 
-        The whole family is gated on `opennms.alarmTroubleTicketEnabled` being `true`. With the
+        The ticket operations are gated on `opennms.alarmTroubleTicketEnabled` being `true`. With the
         ticketer disabled every call answers 501, including a call naming an alarm that does not
         exist, because the gate is checked before the alarm is looked up.""",
             operationId = "createAlarmTicket")
@@ -909,7 +900,7 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
         202 without waiting for the helpdesk system. Progress shows up in the `troubleTicket` and
         `troubleTicketState` fields of the alarm.
 
-        The whole family is gated on `opennms.alarmTroubleTicketEnabled` being `true`. With the
+        The ticket operations are gated on `opennms.alarmTroubleTicketEnabled` being `true`. With the
         ticketer disabled every call answers 501, including a call naming an alarm that does not
         exist, because the gate is checked before the alarm is looked up.""",
             operationId = "updateAlarmTicket")
@@ -945,7 +936,7 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
         202 without waiting for the helpdesk system. Progress shows up in the `troubleTicket` and
         `troubleTicketState` fields of the alarm.
 
-        The whole family is gated on `opennms.alarmTroubleTicketEnabled` being `true`. With the
+        The ticket operations are gated on `opennms.alarmTroubleTicketEnabled` being `true`. With the
         ticketer disabled every call answers 501, including a call naming an alarm that does not
         exist, because the gate is checked before the alarm is looked up.""",
             operationId = "closeAlarmTicket")

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/ApplicationRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/ApplicationRestService.java
@@ -330,7 +330,7 @@ public class ApplicationRestService extends AbstractDaoRestService<OnmsApplicati
     }
 
     @Override
-    @Operation(summary = "Create a application",
+    @Operation(summary = "Create an application",
             description = """
                     Creates an application. The identifier is assigned by the database and returned in the `Location` header. An `applicationCreated` event is sent.""",
             operationId = "applicationsCreate")
@@ -363,7 +363,7 @@ public class ApplicationRestService extends AbstractDaoRestService<OnmsApplicati
     }
 
     @Override
-    @Operation(summary = "Rejected: create a application at a caller-chosen identifier",
+    @Operation(summary = "Rejected: create an application at a caller-chosen identifier",
             description = DOC_POST_WITH_ID,
             operationId = "applicationsCreateWithId")
     @Parameters({
@@ -446,7 +446,7 @@ public class ApplicationRestService extends AbstractDaoRestService<OnmsApplicati
     @Override
     @Operation(summary = "Delete the applications matching a query",
             description = """
-                    Deletes every application matching the query. At most `limit` entities are affected, so this touches ten entities per call unless a larger `limit` is given. An `applicationDeleted` event is sent for each one.
+                    Deletes every application matching the query. At most `limit` entities are affected, ten by default. An `applicationDeleted` event is sent for each one.
 
                     For example, `_s=name==Review*` matches every application whose name starts with `Review`.""",
             operationId = "applicationsDeleteMany")

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/ApplicationRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/ApplicationRestService.java
@@ -51,6 +51,22 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.apache.cxf.jaxrs.ext.search.SearchContext;
+import org.opennms.web.rest.support.MultivaluedMapImpl;
+import org.opennms.web.rest.support.SearchPropertyCollection;
+import org.opennms.web.rest.support.StringCollection;
 
 /**
  * Basic Web Service using REST for {@link OnmsApplication} entity
@@ -138,5 +154,328 @@ public class ApplicationRestService extends AbstractDaoRestService<OnmsApplicati
         } catch (final EventProxyException e) {
             LOG.warn("Failed to send event {}: {}", event.getUei(), e.getMessage(), e);
         }
+    }
+
+    @Override
+    @Operation(summary = "List applications",
+            description = """
+                    Applications matching the query, ordered by name unless `orderBy` says otherwise.
+
+                    The JSON and XML renderings of an application differ: JSON carries `perspectiveLocations` as full monitoring-location objects and omits the member services, while XML carries `monitoredServices/monitoredServiceId` and `perspectiveLocations/perspectiveLocationId` as identifier lists.
+
+                    `application/atom+xml` is also accepted and returns the same document as `application/xml`.
+
+                    For example, `_s=name==Review*` matches every application whose name starts with `Review`.""",
+            operationId = "applicationsList")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "One page of matching applications.",
+                    headers = @Header(name = "Content-Range", description = "`items <offset>-<last>/<totalCount>` for this page.",
+                            schema = @Schema(type = "string")),
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsApplicationList.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "totalCount": 4,
+                              "count": 1,
+                              "offset": 0,
+                              "application": [ {
+                                "id": 3,
+                                "name": "Review Analytics",
+                                "perspectiveLocations": [ {
+                                  "tags": [],
+                                  "latitude": null,
+                                  "geolocation": null,
+                                  "longitude": null,
+                                  "priority": 100,
+                                  "location-name": "Default",
+                                  "monitoring-area": "localhost"
+                                } ]
+                              } ]
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsApplicationList.class),
+                                    examples = @ExampleObject(value = """
+                            <applications xmlns:ns2="http://xmlns.opennms.org/xsd/config/monitoring-locations" count="1" offset="0" totalCount="4">
+                              <application id="3">
+                                <monitoredServices>
+                                  <monitoredServiceId>1021</monitoredServiceId>
+                                  <monitoredServiceId>1039</monitoredServiceId>
+                                </monitoredServices>
+                                <name>Review Analytics</name>
+                                <perspectiveLocations>
+                                  <perspectiveLocationId>Default</perspectiveLocationId>
+                                </perspectiveLocations>
+                              </application>
+                            </applications>"""))
+                    }),
+            @ApiResponse(responseCode = "204", description = "No application matched the query. The response has no body."),
+            @ApiResponse(responseCode = "500", description = DOC_SEARCH_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    public Response get(final UriInfo uriInfo, final SearchContext searchContext) {
+        return super.get(uriInfo, searchContext);
+    }
+
+    @Override
+    @Operation(summary = "Count applications",
+            description = """
+                    Number of applications matching the query.
+
+                    Only `text/plain` is produced. A request that sends `Accept: application/json` does not match this operation and falls through to the single-entity GET with `count` as the identifier.
+
+                    For example, `_s=name==Review*` matches every application whose name starts with `Review`.""",
+            operationId = "applicationsCount")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The number of matching applications, as a decimal string.",
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "4"))),
+            @ApiResponse(responseCode = "500", description = DOC_COUNT_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    public Response getCount(final UriInfo uriInfo, final SearchContext searchContext) {
+        return super.getCount(uriInfo, searchContext);
+    }
+
+    @Override
+    @Operation(summary = "List the queryable properties of applications",
+            description = """
+                    The properties an application query can filter and sort on.""",
+            operationId = "applicationsSearchProperties")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The properties this endpoint can search and sort on.",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = SearchPropertyCollection.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "totalCount": 1,
+                              "count": 1,
+                              "offset": 0,
+                              "searchProperty": [
+                                { "id": "name", "name": "Name", "type": "STRING", "orderBy": true, "iplike": false }
+                              ]
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = SearchPropertyCollection.class),
+                                    examples = @ExampleObject(value = """
+                            <searchProperties count="1" offset="0" totalCount="1">
+                              <searchProperty type="STRING" orderBy="true" iplike="false" id="name" name="Name"/>
+                            </searchProperties>"""))
+                    })
+    })
+    public Response getProperties(final String query) {
+        return super.getProperties(query);
+    }
+
+    @Override
+    @Operation(summary = "List the values a queryable property takes",
+            description = """
+                    Distinct values held by one application property. The `value` entries are typed after the property: numbers for `INTEGER`, `LONG` and `FLOAT`, epoch milliseconds for `TIMESTAMP`, strings otherwise.""",
+            operationId = "applicationsSearchPropertyValues")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The distinct values, typed after the property.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = StringCollection.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "totalCount": 4,
+                              "count": 4,
+                              "offset": 0,
+                              "value": [ "Review Analytics", "Review Billing", "Review Messaging", "Review Storefront" ]
+                            }"""))),
+            @ApiResponse(responseCode = "404", description = "No property with that `id` is queryable here. The response has no body.")
+    })
+    public Response getPropertyValues(final String propertyId, final String query, final Integer limit) {
+        return super.getPropertyValues(propertyId, query, limit);
+    }
+
+    @Override
+    @Operation(summary = "Get one application",
+            description = """
+                    One application by database identifier.
+
+                    `application/atom+xml` is also accepted and returns the same document as `application/xml`.""",
+            operationId = "applicationsGet")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The requested application.",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsApplication.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "id": 3,
+                              "name": "Review Analytics",
+                              "perspectiveLocations": [ {
+                                "tags": [],
+                                "latitude": null,
+                                "geolocation": null,
+                                "longitude": null,
+                                "priority": 100,
+                                "location-name": "Default",
+                                "monitoring-area": "localhost"
+                              } ]
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsApplication.class),
+                                    examples = @ExampleObject(value = """
+                            <application xmlns:ns0="http://xmlns.opennms.org/xsd/config/monitoring-locations" id="3">
+                              <name>Review Analytics</name>
+                            </application>"""))
+                    }),
+            @ApiResponse(responseCode = "404", description = """
+                    No application has that identifier, or the identifier is not an integer. The response has no body.""")
+    })
+    public Response get(final UriInfo uriInfo,
+            @Parameter(description = """
+                    Database identifier of the application.""",
+                    required = true, example = "3")
+            final Integer id) {
+        return super.get(uriInfo, id);
+    }
+
+    @Override
+    @Operation(summary = "Create a application",
+            description = """
+                    Creates an application. The identifier is assigned by the database and returned in the `Location` header. An `applicationCreated` event is sent.""",
+            operationId = "applicationsCreate")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = """
+                    The application was created. The response has no body.""",
+                    headers = @Header(name = "Location", description = "URI of the created application.",
+                            schema = @Schema(type = "string"))),
+            @ApiResponse(responseCode = "500", description = """
+                    The name is already taken. The body is a `text/plain` message naming the violated constraint.""",
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = """
+                            could not execute statement; SQL [n/a]; constraint [applications_name_idx]; nested exception is org.hibernate.exception.ConstraintViolationException: could not execute statement""")))
+    })
+    public Response create(final SecurityContext securityContext, final UriInfo uriInfo,
+            @RequestBody(description = """
+                    The application to create. Only `name` is required, and it must be unique.""",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsApplication.class),
+                                    examples = @ExampleObject(value = """
+                            { "name": "Review Reporting" }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsApplication.class),
+                                    examples = @ExampleObject(value = """
+                            <application>
+                              <name>Review Reporting</name>
+                            </application>"""))
+                    })
+            final OnmsApplication object) {
+        return super.create(securityContext, uriInfo, object);
+    }
+
+    @Override
+    @Operation(summary = "Rejected: create a application at a caller-chosen identifier",
+            description = DOC_POST_WITH_ID,
+            operationId = "applicationsCreateWithId")
+    @Parameters({
+            @Parameter(name = "id", in = ParameterIn.PATH, required = true,
+                    description = "Ignored. Any value produces the same response.",
+                    schema = @Schema(type = "string"), example = "3")
+    })
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = "Always. The response has no body.")
+    })
+    public Response createSpecific() {
+        return super.createSpecific();
+    }
+
+    @Override
+    @Operation(summary = "Update the applications matching a query",
+            description = """
+                    Not supported for applications: the endpoint answers 501 once it has found at least one match, and 404 when nothing matches.
+
+                    For example, `_s=name==Review*` matches every application whose name starts with `Review`.""",
+            operationId = "applicationsUpdateMany")
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = DOC_NO_MATCH),
+            @ApiResponse(responseCode = "500", description = DOC_SEARCH_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search"))),
+            @ApiResponse(responseCode = "501", description = DOC_NOT_IMPLEMENTED)
+    })
+    public Response updateMany(final SecurityContext securityContext, final UriInfo uriInfo, final SearchContext searchContext,
+            @RequestBody(description = DOC_FORM_BODY,
+                    content = @Content(mediaType = "application/x-www-form-urlencoded",
+                            schema = @Schema(type = "object"),
+                            examples = @ExampleObject(value = """
+                            name=Review+Reporting""")))
+            final MultivaluedMapImpl params) {
+        return super.updateMany(securityContext, uriInfo, searchContext, params);
+    }
+
+    @Override
+    @Hidden
+    public Response update(final SecurityContext securityContext, final UriInfo uriInfo, final Integer id,
+            final OnmsApplication object) {
+        return super.update(securityContext, uriInfo, id, object);
+    }
+
+    @Override
+    @Operation(summary = "Update one application",
+            description = """
+                    Not supported for applications. Both the JSON or XML replacement form and the form-parameter form answer 501.""",
+            operationId = "applicationsUpdate")
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = """
+                    No application has that identifier. The response has no body."""),
+            @ApiResponse(responseCode = "501", description = """
+                    Applications do not support update. The response has no body.""")
+    })
+    public Response updateProperties(final SecurityContext securityContext, final UriInfo uriInfo,
+            @Parameter(description = """
+                    Database identifier of the application.""",
+                    required = true, example = "3")
+            final Integer id,
+            @RequestBody(description = """
+                    Accepted but not acted on: the endpoint answers 501 for every body.""",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsApplication.class),
+                                    examples = @ExampleObject(value = """
+                            { "id": 3, "name": "Review Reporting" }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsApplication.class),
+                                    examples = @ExampleObject(value = """
+                            <application id="3"><name>Review Reporting</name></application>""")),
+                            @Content(mediaType = "application/x-www-form-urlencoded",
+                                    schema = @Schema(type = "object"),
+                                    examples = @ExampleObject(value = """
+                            name=Review+Reporting"""))
+                    })
+            final MultivaluedMapImpl params) {
+        return super.updateProperties(securityContext, uriInfo, id, params);
+    }
+
+    @Override
+    @Operation(summary = "Delete the applications matching a query",
+            description = """
+                    Deletes every application matching the query. At most `limit` entities are affected, so this touches ten entities per call unless a larger `limit` is given. An `applicationDeleted` event is sent for each one.
+
+                    For example, `_s=name==Review*` matches every application whose name starts with `Review`.""",
+            operationId = "applicationsDeleteMany")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Every matching application was deleted. The response has no body."),
+            @ApiResponse(responseCode = "404", description = DOC_NO_MATCH),
+            @ApiResponse(responseCode = "500", description = DOC_SEARCH_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    public Response deleteMany(final SecurityContext securityContext, final UriInfo uriInfo, final SearchContext searchContext) {
+        return super.deleteMany(securityContext, uriInfo, searchContext);
+    }
+
+    @Override
+    @Operation(summary = "Delete one application",
+            description = """
+                    Deletes one application by identifier. An `applicationDeleted` event is sent.""",
+            operationId = "applicationsDelete")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The application was deleted. The response has no body."),
+            @ApiResponse(responseCode = "404", description = """
+                    No application has that identifier. The response has no body.""")
+    })
+    public Response delete(final SecurityContext securityContext, final UriInfo uriInfo,
+            @Parameter(description = """
+                    Database identifier of the application.""",
+                    required = true, example = "3")
+            final Integer id) {
+        return super.delete(securityContext, uriInfo, id);
     }
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/ApplicationStatusRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/ApplicationStatusRestService.java
@@ -33,6 +33,12 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.netmgt.dao.api.ApplicationDao;
 import org.opennms.netmgt.dao.api.MonitoredServiceDao;
@@ -40,6 +46,8 @@ import org.opennms.netmgt.dao.api.OutageDao;
 import org.opennms.netmgt.dao.support.ApplicationStatusUtil;
 import org.opennms.netmgt.model.OnmsApplication;
 import org.opennms.netmgt.model.OnmsOutage;
+import org.opennms.netmgt.model.perspectivepolling.ApplicationServiceStatus;
+import org.opennms.netmgt.model.perspectivepolling.ApplicationStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -59,11 +67,65 @@ public class ApplicationStatusRestService {
     @Autowired
     private MonitoredServiceDao monitoredServiceDao;
 
+    private static final String WINDOW_NOTE = """
+            `start` and `end` are epoch milliseconds. Omitting `end` uses now; omitting `start` uses
+            `end` minus 24 hours. The window is not validated, so a `start` after `end` is accepted and
+            simply matches nothing.""";
+
     @GET
     @Path("{applicationId}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-    @Operation(summary = "Get a Status of a specified application", description = "Get a Status of a specified application", operationId = "ApplicationStatusRestServiceGetStatusByApplicationId")
-    public Response applicationStatus(@PathParam("applicationId") final Integer applicationId, @QueryParam("start") Long start, @QueryParam("end") Long end) {
+    @Operation(summary = "Get a Status of a specified application",
+            description = """
+        Perspective-poller availability for one application over a time window, aggregated overall and
+        per monitoring location. `overallStatus` and `aggregated-status` are percentages of the window
+        during which the application was up as seen from that perspective.
+
+        """ + WINDOW_NOTE + """
+
+
+        In XML, `applicationId`, `start` and `end` are attributes on `application-status`, and the
+        per-location value is the hyphenated element `aggregated-status`. The JSON keeps the hyphenated
+        spelling for `aggregated-status`.""",
+            operationId = "ApplicationStatusRestServiceGetStatusByApplicationId")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Availability for the application over the window.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = ApplicationStatus.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "applicationId": 1,
+                      "start": 1787641143996,
+                      "end": 1787727543996,
+                      "overallStatus": 100.0,
+                      "location": [
+                        {"name": "Default", "aggregated-status": 100.0}
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = ApplicationStatus.class),
+                                    examples = @ExampleObject(value = """
+                    <application-status applicationId="1" end="1787727557946" start="1787641157946">
+                      <location name="Default">
+                        <aggregated-status>100.0</aggregated-status>
+                      </location>
+                      <overallStatus>100.0</overallStatus>
+                    </application-status>"""))
+                    }),
+            @ApiResponse(responseCode = "404", description = """
+                    No application with that id. A non-numeric `applicationId` also lands here, from the
+                    parameter conversion. The body is empty either way.""")
+    })
+    public Response applicationStatus(@Parameter(description = "Numeric id of the application, as returned by `/applications`.",
+                                              required = true, example = "1")
+                                      @PathParam("applicationId") final Integer applicationId,
+                                      @Parameter(description = "Window start, epoch milliseconds. Defaults to `end` minus 24 hours.",
+                                              example = "1787641143996")
+                                      @QueryParam("start") Long start,
+                                      @Parameter(description = "Window end, epoch milliseconds. Defaults to now.",
+                                              example = "1787727543996")
+                                      @QueryParam("end") Long end) {
         if (end == null) {
             end = new Date().getTime();
         }
@@ -84,8 +146,55 @@ public class ApplicationStatusRestService {
     @GET
     @Path("{applicationId}/{monitoredServiceId}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-    @Operation(summary = "Get a Status of a specified application by monitoringServiceId", description = "Get a Status of a specified application by monitoringServiceId", operationId = "ApplicationStatusRestServiceGetStatusByMonitoringServiceId")
-    public Response applicationServiceStatus(@PathParam("applicationId") final Integer applicationId, @PathParam("monitoredServiceId") final Integer monitoredServiceId, @QueryParam("start") Long start, @QueryParam("end") Long end) {
+    @Operation(summary = "Get a Status of a specified application by monitoringServiceId",
+            description = """
+        Perspective-poller availability for one monitored service inside an application, per monitoring
+        location. Each location also reports `response-resource-id`, the resource id under which that
+        perspective's response-time data is stored.
+
+        """ + WINDOW_NOTE + """
+
+
+        `monitoredServiceId` is an `ifServiceId`, and it has to be one the application actually
+        contains: an id that is not a member fails with a 500 rather than a 404.""",
+            operationId = "ApplicationStatusRestServiceGetStatusByMonitoringServiceId")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Availability for the service over the window, per location.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = ApplicationServiceStatus.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "applicationId": 1,
+                      "monitoredServiceId": 1022,
+                      "start": 1787641157901,
+                      "end": 1787727557901,
+                      "location": [
+                        {
+                          "name": "Default",
+                          "response-resource-id": "127.0.0.4[HTTP-8080]@Default",
+                          "aggregated-status": 100.0
+                        }
+                      ]
+                    }"""))),
+            @ApiResponse(responseCode = "404", description = "No application with that id. The body is empty."),
+            @ApiResponse(responseCode = "500", description = """
+                    `monitoredServiceId` does not resolve to a service in this application, so building
+                    the per-location resource id dereferences null.""",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot invoke \"org.opennms.netmgt.model.OnmsMonitoredService.getIpAddress()\" because \"onmsMonitoredService\" is null")))
+    })
+    public Response applicationServiceStatus(@Parameter(description = "Numeric id of the application, as returned by `/applications`.",
+                                                     required = true, example = "1")
+                                             @PathParam("applicationId") final Integer applicationId,
+                                             @Parameter(description = "`ifServiceId` of a monitored service that belongs to the application.",
+                                                     required = true, example = "1022")
+                                             @PathParam("monitoredServiceId") final Integer monitoredServiceId,
+                                             @Parameter(description = "Window start, epoch milliseconds. Defaults to `end` minus 24 hours.",
+                                                     example = "1787641157901")
+                                             @QueryParam("start") Long start,
+                                             @Parameter(description = "Window end, epoch milliseconds. Defaults to now.",
+                                                     example = "1787727557901")
+                                             @QueryParam("end") Long end) {
         if (end == null) {
             end = new Date().getTime();
         }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/DiscoveryRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/DiscoveryRestService.java
@@ -86,8 +86,7 @@ public class DiscoveryRestService {
 
     private static final String URL_CONTENT = """
             Location of a newline-separated address list, as a URL. `file:` URLs read from the OpenNMS
-            host's filesystem and `http:`/`https:` URLs are fetched by the OpenNMS host, which is why
-            this operation is restricted to the provisioning and admin roles.""";
+            host's filesystem and `http:`/`https:` URLs are fetched by the OpenNMS host.""";
 
     @XmlRootElement(name = "discoveryConfiguration")
     public static class DiscoveryConfigurationDTO {
@@ -480,22 +479,19 @@ public class DiscoveryRestService {
 
         The call returns as soon as the sweep has been handed to the discovery task executor, so a 200
         means the request was accepted, not that any address answered. Addresses that respond raise
-        `newSuspect` events, which is what turns them into nodes; watch those events or the node list
-        for the outcome. There is no job id and no way to poll this operation for progress.
+        `newSuspect` events. There is no job id and no way to poll this operation for progress.
 
-        Targets come from four collections, all optional: `specifics` (single addresses), `includeRanges`
+        Targets come from five collections, all optional: `specifics` (single addresses), `includeRanges`
         and `excludeRanges` (inclusive address ranges), and `includeUrls`/`excludeUrls` (addresses read
         from a URL). Each entry may override the top-level `location`, `retries`, `timeout` and
         `foreignSource`. A body with no targets at all is accepted and sweeps nothing.
 
         Requires `ROLE_PROVISION` or `ROLE_ADMIN`, checked in the handler on top of the Spring Security
-        rule for `/api/v2/**`, because the URL forms can read local files and reach arbitrary hosts from
-        the OpenNMS server.
+        rule for `/api/v2/**`.
 
         The JSON member names are the wrapper names (`specifics`, `includeRanges`, `excludeRanges`,
         `includeUrls`, `excludeUrls`), not the Java property names. An unrecognised JSON member is
-        rejected with a 500 carrying the Jackson message, so a misspelling fails loudly rather than
-        being ignored.""",
+        rejected with a 500 carrying the Jackson message.""",
             operationId = "submitDiscoveryScan")
     @RequestBody(required = true, description = "The one-off discovery configuration to run.",
             content = {
@@ -548,10 +544,10 @@ public class DiscoveryRestService {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "The sweep was handed to the discovery task executor. No body."),
             @ApiResponse(responseCode = "403", description = """
-                    The caller holds neither `ROLE_PROVISION` nor `ROLE_ADMIN`. Two layers can produce
-                    this: a caller that fails the Spring Security rule for `/api/v2/**` never reaches
-                    the resource and gets the container's HTML error page, while a caller that passes
-                    that rule but lacks the two roles gets the plain-text message below.""",
+                    The caller holds neither `ROLE_PROVISION` nor `ROLE_ADMIN`. A caller that fails the
+                    Spring Security rule for `/api/v2/**` never reaches the resource and gets the
+                    container's HTML error page; one that passes that rule but lacks both roles gets the
+                    plain-text message below.""",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "The PROVISION or ADMIN role is required to submit a discovery scan."))),
             @ApiResponse(responseCode = "500", description = """

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/DiscoveryRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/DiscoveryRestService.java
@@ -544,10 +544,10 @@ public class DiscoveryRestService {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "The sweep was handed to the discovery task executor. No body."),
             @ApiResponse(responseCode = "403", description = """
-                    The caller holds neither `ROLE_PROVISION` nor `ROLE_ADMIN`. A caller that fails the
-                    Spring Security rule for `/api/v2/**` never reaches the resource and gets the
-                    container's HTML error page; one that passes that rule but lacks both roles gets the
-                    plain-text message below.""",
+                    The caller holds neither `ROLE_PROVISION` nor `ROLE_ADMIN`. The shipped security
+                    rules gate `POST /api/v2/discovery` on the same two roles, so in a stock deployment
+                    the container answers first with its HTML error page and the in-handler plain-text
+                    message below is unreachable; it appears only under customized security rules.""",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "The PROVISION or ADMIN role is required to submit a discovery scan."))),
             @ApiResponse(responseCode = "500", description = """

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/DiscoveryRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/DiscoveryRestService.java
@@ -36,6 +36,13 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.soa.ServiceRegistry;
 import org.opennms.netmgt.config.discovery.DiscoveryConfiguration;
@@ -65,15 +72,41 @@ public class DiscoveryRestService {
 
     private static final Logger LOG = LoggerFactory.getLogger(org.opennms.web.rest.v2.DiscoveryRestService.class);
 
+    private static final String OVERRIDE_LOCATION =
+            "Monitoring location to probe from, overriding the configuration-level `location`.";
+
+    private static final String OVERRIDE_RETRIES =
+            "ICMP retry count for this target, overriding the configuration-level `retries`.";
+
+    private static final String OVERRIDE_TIMEOUT =
+            "ICMP timeout in milliseconds for this target, overriding the configuration-level `timeout`.";
+
+    private static final String OVERRIDE_FOREIGN_SOURCE =
+            "Requisition to attribute nodes discovered from this target to, overriding the configuration-level `foreignSource`.";
+
+    private static final String URL_CONTENT = """
+            Location of a newline-separated address list, as a URL. `file:` URLs read from the OpenNMS
+            host's filesystem and `http:`/`https:` URLs are fetched by the OpenNMS host, which is why
+            this operation is restricted to the provisioning and admin roles.""";
+
     @XmlRootElement(name = "discoveryConfiguration")
     public static class DiscoveryConfigurationDTO {
 
         @XmlRootElement
         public static class SpecificDTO {
+            @Schema(description = "The single address to probe. Named `content`, not `address`.", example = "192.0.2.1")
             private String content;
+
+            @Schema(description = OVERRIDE_LOCATION, example = "Default")
             private String location;
+
+            @Schema(description = OVERRIDE_RETRIES, example = "1")
             private Integer retries;
+
+            @Schema(description = OVERRIDE_TIMEOUT, example = "2000")
             private Long timeout;
+
+            @Schema(description = OVERRIDE_FOREIGN_SOURCE, example = "Routers")
             private String foreignSource;
 
             public SpecificDTO() {
@@ -122,11 +155,22 @@ public class DiscoveryRestService {
 
         @XmlRootElement
         public static class IncludeRangeDTO {
+            @Schema(description = OVERRIDE_LOCATION, example = "Default", defaultValue = "Default")
             private String location = "Default";
+
+            @Schema(description = OVERRIDE_RETRIES, example = "1", defaultValue = "1")
             private Integer retries = 1;
+
+            @Schema(description = OVERRIDE_TIMEOUT, example = "2000", defaultValue = "2000")
             private Long timeout = 2000l;
+
+            @Schema(description = OVERRIDE_FOREIGN_SOURCE, example = "Routers")
             private String foreignSource;
+
+            @Schema(description = "First address of the range, inclusive.", example = "192.0.2.10")
             private String begin;
+
+            @Schema(description = "Last address of the range, inclusive.", example = "192.0.2.20")
             private String end;
 
             public IncludeRangeDTO() {
@@ -183,7 +227,10 @@ public class DiscoveryRestService {
 
         @XmlRootElement
         public static class ExcludeRangeDTO {
+            @Schema(description = "First address to exclude, inclusive.", example = "192.0.2.15")
             private String begin;
+
+            @Schema(description = "Last address to exclude, inclusive.", example = "192.0.2.16")
             private String end;
 
             public ExcludeRangeDTO() {
@@ -208,10 +255,19 @@ public class DiscoveryRestService {
 
         @XmlRootElement
         public static class IncludeUrlDTO {
+            @Schema(description = URL_CONTENT, example = "file:/opt/opennms/etc/discovery-include.txt")
             private String content;
+
+            @Schema(description = OVERRIDE_LOCATION, example = "Default", defaultValue = "Default")
             private String location = "Default";
+
+            @Schema(description = OVERRIDE_RETRIES, example = "1", defaultValue = "1")
             private Integer retries = 1;
+
+            @Schema(description = OVERRIDE_TIMEOUT, example = "2000", defaultValue = "2000")
             private Long timeout = 2000l;
+
+            @Schema(description = OVERRIDE_FOREIGN_SOURCE, example = "Routers")
             private String foreignSource;
 
             public IncludeUrlDTO() {
@@ -260,8 +316,13 @@ public class DiscoveryRestService {
 
         @XmlRootElement
         public static class ExcludeUrlDTO {
+            @Schema(description = URL_CONTENT, example = "file:/opt/opennms/etc/discovery-exclude.txt")
             private String content;
+
+            @Schema(description = OVERRIDE_LOCATION, example = "Default", defaultValue = "Default")
             private String location = "Default";
+
+            @Schema(description = OVERRIDE_FOREIGN_SOURCE, example = "Routers")
             private String foreignSource;
 
             public ExcludeUrlDTO() {
@@ -292,10 +353,22 @@ public class DiscoveryRestService {
             }
         }
 
+        @Schema(description = "Default monitoring location for every target that does not name its own.",
+                example = "Default", defaultValue = "Default")
         private String location = "Default";
+
+        @Schema(description = "Default ICMP retry count for targets that do not set their own.",
+                example = "1", defaultValue = "1")
         private Integer retries = 1;
+
+        @Schema(description = "Default ICMP timeout in milliseconds for targets that do not set their own.",
+                example = "2000", defaultValue = "2000")
         private Long timeout = 2000l;
+
+        @Schema(description = "Default requisition to attribute newly discovered nodes to.", example = "Routers")
         private String foreignSource;
+
+        @Schema(description = "How many addresses go into one ping sweep job.", example = "100", defaultValue = "100")
         private Integer chunkSize = 100;
 
         private List<SpecificDTO> specificDTOList = new ArrayList<>();
@@ -400,6 +473,94 @@ public class DiscoveryRestService {
 
     @POST
     @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Operation(summary = "Submit a one-off discovery scan",
+            description = """
+        Runs a ping sweep now, using the configuration in the body only. Nothing is written to
+        `discovery-configuration.xml` and the scheduled discovery configuration is untouched.
+
+        The call returns as soon as the sweep has been handed to the discovery task executor, so a 200
+        means the request was accepted, not that any address answered. Addresses that respond raise
+        `newSuspect` events, which is what turns them into nodes; watch those events or the node list
+        for the outcome. There is no job id and no way to poll this operation for progress.
+
+        Targets come from four collections, all optional: `specifics` (single addresses), `includeRanges`
+        and `excludeRanges` (inclusive address ranges), and `includeUrls`/`excludeUrls` (addresses read
+        from a URL). Each entry may override the top-level `location`, `retries`, `timeout` and
+        `foreignSource`. A body with no targets at all is accepted and sweeps nothing.
+
+        Requires `ROLE_PROVISION` or `ROLE_ADMIN`, checked in the handler on top of the Spring Security
+        rule for `/api/v2/**`, because the URL forms can read local files and reach arbitrary hosts from
+        the OpenNMS server.
+
+        The JSON member names are the wrapper names (`specifics`, `includeRanges`, `excludeRanges`,
+        `includeUrls`, `excludeUrls`), not the Java property names. An unrecognised JSON member is
+        rejected with a 500 carrying the Jackson message, so a misspelling fails loudly rather than
+        being ignored.""",
+            operationId = "submitDiscoveryScan")
+    @RequestBody(required = true, description = "The one-off discovery configuration to run.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DiscoveryConfigurationDTO.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "location": "Default",
+                      "retries": 1,
+                      "timeout": 2000,
+                      "foreignSource": "Routers",
+                      "chunkSize": 10,
+                      "specifics": [
+                        {"content": "192.0.2.1", "location": "Default", "retries": 1, "timeout": 2000}
+                      ],
+                      "includeRanges": [
+                        {"begin": "192.0.2.10", "end": "192.0.2.20", "location": "Default", "retries": 1, "timeout": 2000}
+                      ],
+                      "excludeRanges": [
+                        {"begin": "192.0.2.15", "end": "192.0.2.16"}
+                      ],
+                      "includeUrls": [],
+                      "excludeUrls": []
+                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = DiscoveryConfigurationDTO.class),
+                            examples = @ExampleObject(value = """
+                    <discoveryConfiguration>
+                      <location>Default</location>
+                      <retries>1</retries>
+                      <timeout>2000</timeout>
+                      <foreignSource>Routers</foreignSource>
+                      <chunkSize>10</chunkSize>
+                      <specifics>
+                        <specific>
+                          <content>192.0.2.1</content>
+                          <location>Default</location>
+                          <retries>1</retries>
+                          <timeout>2000</timeout>
+                        </specific>
+                      </specifics>
+                      <includeRanges>
+                        <includeRange>
+                          <begin>192.0.2.10</begin>
+                          <end>192.0.2.20</end>
+                        </includeRange>
+                      </includeRanges>
+                    </discoveryConfiguration>"""))
+            })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The sweep was handed to the discovery task executor. No body."),
+            @ApiResponse(responseCode = "403", description = """
+                    The caller holds neither `ROLE_PROVISION` nor `ROLE_ADMIN`. Two layers can produce
+                    this: a caller that fails the Spring Security rule for `/api/v2/**` never reaches
+                    the resource and gets the container's HTML error page, while a caller that passes
+                    that rule but lacks the two roles gets the plain-text message below.""",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "The PROVISION or ADMIN role is required to submit a discovery scan."))),
+            @ApiResponse(responseCode = "500", description = """
+                    Either the body could not be bound (an unrecognised JSON member reports the Jackson
+                    error) or no `DiscoveryTaskExecutor` is registered, in which case the body is
+                    empty.""",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Unrecognized field \"specificDTOList\" (Class org.opennms.web.rest.v2.DiscoveryRestService$DiscoveryConfigurationDTO), not marked as ignorable")))
+    })
     public Response scan(@Context final SecurityContext securityContext, DiscoveryConfigurationDTO discoveryConfigurationDTO) {
 
         // Discovery is a provisioning operation: its include/exclude URLs can read local files

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/EventRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/EventRestService.java
@@ -294,10 +294,7 @@ public class EventRestService extends AbstractDaoRestServiceWithDTO<OnmsEvent,Ev
                       <location>Default</location>
                     </event>"""))
                     }),
-            @ApiResponse(responseCode = "404", description = "No event has that id. No body is returned."),
-            @ApiResponse(responseCode = "500", description = "The path segment is not a number.",
-                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "object is not an instance of declaring class")))
+            @ApiResponse(responseCode = "404", description = "No event has that id, or the path segment is not a number (the parameter fails conversion before the handler runs). No body is returned.")
     })
     @Override
     public Response get(@Context final UriInfo uriInfo,
@@ -315,7 +312,7 @@ public class EventRestService extends AbstractDaoRestServiceWithDTO<OnmsEvent,Ev
             description = """
         Return the number of events matching `_s` as a plain-text integer. The response is
         `text/plain` only, so a request that asks solely for `application/json` is answered with 404.
-        `limit` and `offset` are ignored: the count covers the whole match.
+        `limit` is ignored, but a non-zero `offset` reaches the count query and fails with 500.
 
         Example query: `_s=event.eventUei==uei.opennms.org/nodes/nodeDown`.""",
             operationId = "getEventCount")
@@ -410,7 +407,7 @@ public class EventRestService extends AbstractDaoRestServiceWithDTO<OnmsEvent,Ev
                     description = "Unprefixed property id from `GET /events/properties`.", example = "eventUei")
             @PathParam("propertyId") final String propertyId,
             @Parameter(in = ParameterIn.QUERY, name = "q",
-                    description = "Case-sensitive substring the value must contain.", example = "nodeDown")
+                    description = "Substring the value must contain. Database-backed properties match case-insensitively; only fixed value lists are case-sensitive.", example = "nodeDown")
             @QueryParam("q") final String query,
             @Parameter(in = ParameterIn.QUERY, name = "limit",
                     description = "Maximum number of values returned. Applies only to values read from the database.",

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/EventRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/EventRestService.java
@@ -27,8 +27,31 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 import org.apache.cxf.jaxrs.ext.search.SearchBean;
 import org.apache.cxf.jaxrs.ext.search.SearchContext;
@@ -42,6 +65,9 @@ import org.opennms.netmgt.xml.event.Event;
 import org.opennms.web.rest.mapper.v2.EventMapper;
 import org.opennms.web.rest.model.v2.EventCollectionDTO;
 import org.opennms.web.rest.model.v2.EventDTO;
+import org.opennms.web.rest.support.MultivaluedMapImpl;
+import org.opennms.web.rest.support.SearchPropertyCollection;
+import org.opennms.web.rest.support.StringCollection;
 import org.opennms.web.rest.support.Aliases;
 import org.opennms.web.rest.support.CriteriaBehavior;
 import org.opennms.web.rest.support.CriteriaBehaviors;
@@ -159,29 +185,381 @@ public class EventRestService extends AbstractDaoRestServiceWithDTO<OnmsEvent,Ev
         return getDao().get(id);
     }
 
+    @GET
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "List events",
+            description = """
+        Return a page of events. `application/atom+xml` yields the same document as
+        `application/xml`, not an Atom feed. The event table is the largest in an OpenNMS database, so
+        a call without `_s` and without `limit` still costs a full count over it.
+
+        Example query: `_s=event.eventUei==uei.opennms.org/nodes/nodeDown&orderBy=eventTime&order=desc`.""",
+            operationId = "getEvents")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "A page of events.",
+                    headers = @Header(name = "Content-Range", description = "Range of rows returned and the total, as `items <from>-<to>/<total>`.",
+                            schema = @Schema(type = "string", example = "items 0-0/55178")),
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = EventCollectionDTO.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 55178,
+                      "count": 1,
+                      "offset": 0,
+                      "event": [
+                        {
+                          "id": 55168,
+                          "uei": "uei.opennms.org/perspective/nodes/nodeLostService",
+                          "label": "OpenNMS-defined perspective poller event: A perspective poller detected a node lost service",
+                          "time": 1787685470949,
+                          "createTime": 1787685470954,
+                          "source": "PerspectivePoller",
+                          "ipAddress": "127.0.0.1",
+                          "serviceType": { "id": 3, "name": "SNMP" },
+                          "severity": "MINOR",
+                          "log": "Y",
+                          "display": "Y",
+                          "nodeId": 2,
+                          "nodeLabel": "loopback-001",
+                          "location": "Default",
+                          "parameters": [
+                            { "name": "eventReason", "value": "SNMP poll failed", "type": "string" }
+                          ]
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = EventCollectionDTO.class),
+                                    examples = @ExampleObject(value = """
+                    <events count="1" offset="0" totalCount="55178">
+                      <event id="55168" severity="MINOR" log="Y" display="Y">
+                        <uei>uei.opennms.org/perspective/nodes/nodeLostService</uei>
+                        <time>2026-08-25T15:17:50.949-04:00</time>
+                        <source>PerspectivePoller</source>
+                        <ipAddress>127.0.0.1</ipAddress>
+                        <serviceType id="3"><name>SNMP</name></serviceType>
+                        <parameters>
+                          <parameter name="eventReason" value="SNMP poll failed" type="string"/>
+                        </parameters>
+                        <nodeId>2</nodeId>
+                        <location>Default</location>
+                      </event>
+                    </events>"""))
+                    }),
+            @ApiResponse(responseCode = "204", description = "No event matched. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "`_s` or `orderBy` named a property the entity does not have.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "could not resolve property: bogus of: org.opennms.netmgt.model.OnmsEvent")))
+    })
     @Override
-    public Response get(UriInfo uriInfo, SearchContext searchContext) {
+    public Response get(@Context final UriInfo uriInfo, @Context final SearchContext searchContext) {
         return super.get(uriInfo, searchContext);
     }
 
+    @GET
+    @Path("{id}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get one event",
+            description = "Return a single event by its database id.",
+            operationId = "getEventById")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The event.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = EventDTO.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "id": 55168,
+                      "uei": "uei.opennms.org/perspective/nodes/nodeLostService",
+                      "label": "OpenNMS-defined perspective poller event: A perspective poller detected a node lost service",
+                      "time": 1787685470949,
+                      "createTime": 1787685470954,
+                      "source": "PerspectivePoller",
+                      "severity": "MINOR",
+                      "log": "Y",
+                      "display": "Y",
+                      "nodeId": 2,
+                      "location": "Default"
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = EventDTO.class),
+                                    examples = @ExampleObject(value = """
+                    <event id="55168" severity="MINOR" log="Y" display="Y">
+                      <uei>uei.opennms.org/perspective/nodes/nodeLostService</uei>
+                      <time>2026-08-25T15:17:50.949-04:00</time>
+                      <source>PerspectivePoller</source>
+                      <nodeId>2</nodeId>
+                      <location>Default</location>
+                    </event>"""))
+                    }),
+            @ApiResponse(responseCode = "404", description = "No event has that id. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The path segment is not a number.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "object is not an instance of declaring class")))
+    })
     @Override
-    public Response get(UriInfo uriInfo, Long id) {
+    public Response get(@Context final UriInfo uriInfo,
+                        @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                                description = "Event database id.", example = "55168")
+                        @PathParam("id") final Long id) {
         return super.get(uriInfo, id);
     }
 
+    @GET
+    @Path("count")
+    @Produces({MediaType.TEXT_PLAIN})
+    @Operation(
+            summary = "Count events",
+            description = """
+        Return the number of events matching `_s` as a plain-text integer. The response is
+        `text/plain` only, so a request that asks solely for `application/json` is answered with 404.
+        `limit` and `offset` are ignored: the count covers the whole match.
+
+        Example query: `_s=event.eventUei==uei.opennms.org/nodes/nodeDown`.""",
+            operationId = "getEventCount")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The number of matching events.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "55179"))),
+            @ApiResponse(responseCode = "404", description = "The request did not accept `text/plain`. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "`_s` named a property the entity does not have.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "could not resolve property: bogus of: org.opennms.netmgt.model.OnmsEvent")))
+    })
     @Override
-    public Response getCount(UriInfo uriInfo, SearchContext searchContext) {
+    public Response getCount(@Context final UriInfo uriInfo, @Context final SearchContext searchContext) {
         return super.getCount(uriInfo, searchContext);
     }
 
+    @GET
+    @Path("properties")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Operation(
+            summary = "List the properties events can be queried on",
+            description = """
+        Return the property names accepted by `_s` and `orderBy`, with their type and whether they
+        support `iplike`. The UEI is exposed as `eventUei`, not `uei`. `q` filters the list by a
+        case-insensitive substring of the name; a `q` that matches nothing yields 200 with an empty
+        list, not 204.""",
+            operationId = "getEventProperties")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The matching query properties.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = SearchPropertyCollection.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 2,
+                      "count": 2,
+                      "offset": 0,
+                      "searchProperty": [
+                        { "id": "eventUei", "name": "UEI", "type": "STRING", "orderBy": true, "iplike": false },
+                        { "id": "alarm.uei", "name": "Alarm: UEI", "type": "STRING", "orderBy": true, "iplike": false }
+                      ]
+                    }""")))
+    })
     @Override
-    public Response getProperties(String query) {
+    public Response getProperties(@Parameter(in = ParameterIn.QUERY, name = "q",
+            description = "Case-insensitive substring of the property name.", example = "uei")
+                                  @QueryParam("q") final String query) {
         return super.getProperties(query);
     }
 
+    @GET
+    @Path("properties/{propertyId}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Operation(
+            summary = "List the values a query property takes",
+            description = """
+        Return the distinct values of one query property, either from its fixed value set or from a
+        `select distinct` over the event table. The element type follows the property type: strings for
+        `STRING` and `IP_ADDRESS`, numbers for `INTEGER`, `LONG` and `FLOAT`, and epoch milliseconds in
+        JSON for `TIMESTAMP`. `propertyId` is the unprefixed id from `GET /events/properties`, so
+        `eventUei` rather than `event.eventUei`. Without `limit` this reads every distinct value in the
+        event table.""",
+            operationId = "getEventPropertyValues")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The distinct values of the property.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = StringCollection.class),
+                            examples = {
+                                    @ExampleObject(name = "string property", value = """
+                    {
+                      "totalCount": 2,
+                      "count": 2,
+                      "offset": 0,
+                      "value": [
+                        "uei.opennms.org/internal/authentication/failure",
+                        "uei.opennms.org/internal/capsd/deleteNode"
+                      ]
+                    }"""),
+                                    @ExampleObject(name = "timestamp property", value = """
+                    {
+                      "totalCount": 2,
+                      "count": 2,
+                      "offset": 0,
+                      "value": [1786133772883, 1786133772913]
+                    }""")
+                            })),
+            @ApiResponse(responseCode = "204", description = "The property has a type with no value listing. No body is returned."),
+            @ApiResponse(responseCode = "404", description = "No query property has that id. No body is returned.")
+    })
     @Override
-    public Response getPropertyValues(String propertyId, String query, Integer limit) {
+    public Response getPropertyValues(
+            @Parameter(in = ParameterIn.PATH, name = "propertyId", required = true,
+                    description = "Unprefixed property id from `GET /events/properties`.", example = "eventUei")
+            @PathParam("propertyId") final String propertyId,
+            @Parameter(in = ParameterIn.QUERY, name = "q",
+                    description = "Case-sensitive substring the value must contain.", example = "nodeDown")
+            @QueryParam("q") final String query,
+            @Parameter(in = ParameterIn.QUERY, name = "limit",
+                    description = "Maximum number of values returned. Applies only to values read from the database.",
+                    example = "25")
+            @QueryParam("limit") final Integer limit) {
         return super.getPropertyValues(propertyId, query, limit);
+    }
+
+
+    @POST
+    @Path("{id}")
+    @Operation(
+            summary = "Broken: create an event at a chosen id",
+            description = """
+        Inherited from the generic DAO resource and not reachable in practice. This implementation is
+        proxied on its interface, so a method the interface does not declare cannot be invoked on the
+        proxy and the call fails with 500 before any of the handler runs.
+
+        Publish events with `POST /events` instead.""",
+            operationId = "createEventWithId",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                    description = "Event database id. The value is not read: the call fails before the handler runs.",
+                    example = "1"))
+    @ApiResponses(@ApiResponse(responseCode = "500", description = "Always.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                    examples = @ExampleObject(value = "object is not an instance of declaring class"))))
+    @Override
+    public Response createSpecific() {
+        return super.createSpecific();
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Operation(
+            summary = "Broken: update properties of several events",
+            description = """
+        Inherited from the generic DAO resource and not reachable in practice. This implementation is
+        proxied on its interface, so a method the interface does not declare cannot be invoked on the
+        proxy and the call fails with 500 before any of the handler runs.
+
+        Events are an immutable record; there is no supported way to change one.""",
+            operationId = "updateEvents")
+    @RequestBody(description = "Event properties, form-encoded. Never read.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "object"),
+                    examples = @ExampleObject(value = "eventSeverity=5")))
+    @ApiResponses(@ApiResponse(responseCode = "500", description = "Always.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                    examples = @ExampleObject(value = "object is not an instance of declaring class"))))
+    @Override
+    public Response updateMany(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo,
+                               @Context final SearchContext searchContext, final MultivaluedMapImpl params) {
+        return super.updateMany(securityContext, uriInfo, searchContext, params);
+    }
+
+    @PUT
+    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Path("{id}")
+    @Operation(
+            summary = "Broken: replace an event",
+            description = """
+        Inherited from the generic DAO resource and not reachable in practice. This implementation is
+        proxied on its interface, so a method the interface does not declare cannot be invoked on the
+        proxy and the call fails with 500 before any of the handler runs.
+
+        Events are an immutable record; there is no supported way to change one.""",
+            operationId = "replaceEvent")
+    @RequestBody(description = "Event document. Never read.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = EventDTO.class),
+                    examples = @ExampleObject(value = "{}")))
+    @ApiResponses(@ApiResponse(responseCode = "500", description = "Always.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                    examples = @ExampleObject(value = "object is not an instance of declaring class"))))
+    @Override
+    public Response update(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo,
+                           @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                                   description = "Event database id.", example = "55168")
+                           @PathParam("id") final Long id, final OnmsEvent object) {
+        return super.update(securityContext, uriInfo, id, object);
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Path("{id}")
+    @Operation(
+            summary = "Broken: update properties of an event",
+            description = """
+        Inherited from the generic DAO resource and not reachable in practice. This implementation is
+        proxied on its interface, so a method the interface does not declare cannot be invoked on the
+        proxy and the call fails with 500 before any of the handler runs.
+
+        Events are an immutable record; there is no supported way to change one.""",
+            operationId = "updateEventProperties")
+    @RequestBody(description = "Event properties, form-encoded. Never read.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "object"),
+                    examples = @ExampleObject(value = "eventSeverity=5")))
+    @ApiResponses(@ApiResponse(responseCode = "500", description = "Always.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                    examples = @ExampleObject(value = "object is not an instance of declaring class"))))
+    @Override
+    public Response updateProperties(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo,
+                                     @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                                             description = "Event database id.", example = "55168")
+                                     @PathParam("id") final Long id, final MultivaluedMapImpl params) {
+        return super.updateProperties(securityContext, uriInfo, id, params);
+    }
+
+    @DELETE
+    @Operation(
+            summary = "Broken: delete several events",
+            description = """
+        Inherited from the generic DAO resource and not reachable in practice. This implementation is
+        proxied on its interface, so a method the interface does not declare cannot be invoked on the
+        proxy and the call fails with 500 before any of the handler runs.
+
+        Event retention is handled by vacuumd, not through this API.""",
+            operationId = "deleteEvents")
+    @ApiResponses(@ApiResponse(responseCode = "500", description = "Always.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                    examples = @ExampleObject(value = "object is not an instance of declaring class"))))
+    @Override
+    public Response deleteMany(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo,
+                               @Context final SearchContext searchContext) {
+        return super.deleteMany(securityContext, uriInfo, searchContext);
+    }
+
+    @DELETE
+    @Path("{id}")
+    @Operation(
+            summary = "Broken: delete one event",
+            description = """
+        Inherited from the generic DAO resource and not reachable in practice. This implementation is
+        proxied on its interface, so a method the interface does not declare cannot be invoked on the
+        proxy and the call fails with 500 before any of the handler runs.
+
+        Event retention is handled by vacuumd, not through this API.""",
+            operationId = "deleteEvent")
+    @ApiResponses(@ApiResponse(responseCode = "500", description = "Always.",
+            content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                    examples = @ExampleObject(value = "object is not an instance of declaring class"))))
+    @Override
+    public Response delete(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo,
+                           @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                                   description = "Event database id.", example = "55168")
+                           @PathParam("id") final Long id) {
+        return super.delete(securityContext, uriInfo, id);
     }
 
     /**

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/EventRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/EventRestService.java
@@ -191,8 +191,7 @@ public class EventRestService extends AbstractDaoRestServiceWithDTO<OnmsEvent,Ev
             summary = "List events",
             description = """
         Return a page of events. `application/atom+xml` yields the same document as
-        `application/xml`, not an Atom feed. The event table is the largest in an OpenNMS database, so
-        a call without `_s` and without `limit` still costs a full count over it.
+        `application/xml`, not an Atom feed.
 
         Example query: `_s=event.eventUei==uei.opennms.org/nodes/nodeDown&orderBy=eventTime&order=desc`.""",
             operationId = "getEvents")
@@ -377,8 +376,7 @@ public class EventRestService extends AbstractDaoRestServiceWithDTO<OnmsEvent,Ev
         `select distinct` over the event table. The element type follows the property type: strings for
         `STRING` and `IP_ADDRESS`, numbers for `INTEGER`, `LONG` and `FLOAT`, and epoch milliseconds in
         JSON for `TIMESTAMP`. `propertyId` is the unprefixed id from `GET /events/properties`, so
-        `eventUei` rather than `event.eventUei`. Without `limit` this reads every distinct value in the
-        event table.""",
+        `eventUei` rather than `event.eventUei`.""",
             operationId = "getEventPropertyValues")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "The distinct values of the property.",
@@ -427,11 +425,8 @@ public class EventRestService extends AbstractDaoRestServiceWithDTO<OnmsEvent,Ev
     @Operation(
             summary = "Broken: create an event at a chosen id",
             description = """
-        Inherited from the generic DAO resource and not reachable in practice. This implementation is
-        proxied on its interface, so a method the interface does not declare cannot be invoked on the
-        proxy and the call fails with 500 before any of the handler runs.
-
-        Publish events with `POST /events` instead.""",
+        Inherited from the generic DAO resource. This implementation is proxied on its interface, which
+        does not declare this method, so the call answers 500 before the handler runs.""",
             operationId = "createEventWithId",
             parameters = @Parameter(in = ParameterIn.PATH, name = "id", required = true,
                     description = "Event database id. The value is not read: the call fails before the handler runs.",
@@ -449,11 +444,8 @@ public class EventRestService extends AbstractDaoRestServiceWithDTO<OnmsEvent,Ev
     @Operation(
             summary = "Broken: update properties of several events",
             description = """
-        Inherited from the generic DAO resource and not reachable in practice. This implementation is
-        proxied on its interface, so a method the interface does not declare cannot be invoked on the
-        proxy and the call fails with 500 before any of the handler runs.
-
-        Events are an immutable record; there is no supported way to change one.""",
+        Inherited from the generic DAO resource. This implementation is proxied on its interface, which
+        does not declare this method, so the call answers 500 before the handler runs.""",
             operationId = "updateEvents")
     @RequestBody(description = "Event properties, form-encoded. Never read.",
             content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
@@ -474,11 +466,8 @@ public class EventRestService extends AbstractDaoRestServiceWithDTO<OnmsEvent,Ev
     @Operation(
             summary = "Broken: replace an event",
             description = """
-        Inherited from the generic DAO resource and not reachable in practice. This implementation is
-        proxied on its interface, so a method the interface does not declare cannot be invoked on the
-        proxy and the call fails with 500 before any of the handler runs.
-
-        Events are an immutable record; there is no supported way to change one.""",
+        Inherited from the generic DAO resource. This implementation is proxied on its interface, which
+        does not declare this method, so the call answers 500 before the handler runs.""",
             operationId = "replaceEvent")
     @RequestBody(description = "Event document. Never read.",
             content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = EventDTO.class),
@@ -500,11 +489,8 @@ public class EventRestService extends AbstractDaoRestServiceWithDTO<OnmsEvent,Ev
     @Operation(
             summary = "Broken: update properties of an event",
             description = """
-        Inherited from the generic DAO resource and not reachable in practice. This implementation is
-        proxied on its interface, so a method the interface does not declare cannot be invoked on the
-        proxy and the call fails with 500 before any of the handler runs.
-
-        Events are an immutable record; there is no supported way to change one.""",
+        Inherited from the generic DAO resource. This implementation is proxied on its interface, which
+        does not declare this method, so the call answers 500 before the handler runs.""",
             operationId = "updateEventProperties")
     @RequestBody(description = "Event properties, form-encoded. Never read.",
             content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
@@ -525,11 +511,8 @@ public class EventRestService extends AbstractDaoRestServiceWithDTO<OnmsEvent,Ev
     @Operation(
             summary = "Broken: delete several events",
             description = """
-        Inherited from the generic DAO resource and not reachable in practice. This implementation is
-        proxied on its interface, so a method the interface does not declare cannot be invoked on the
-        proxy and the call fails with 500 before any of the handler runs.
-
-        Event retention is handled by vacuumd, not through this API.""",
+        Inherited from the generic DAO resource. This implementation is proxied on its interface, which
+        does not declare this method, so the call answers 500 before the handler runs.""",
             operationId = "deleteEvents")
     @ApiResponses(@ApiResponse(responseCode = "500", description = "Always.",
             content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
@@ -545,11 +528,8 @@ public class EventRestService extends AbstractDaoRestServiceWithDTO<OnmsEvent,Ev
     @Operation(
             summary = "Broken: delete one event",
             description = """
-        Inherited from the generic DAO resource and not reachable in practice. This implementation is
-        proxied on its interface, so a method the interface does not declare cannot be invoked on the
-        proxy and the call fails with 500 before any of the handler runs.
-
-        Event retention is handled by vacuumd, not through this API.""",
+        Inherited from the generic DAO resource. This implementation is proxied on its interface, which
+        does not declare this method, so the call answers 500 before the handler runs.""",
             operationId = "deleteEvent")
     @ApiResponses(@ApiResponse(responseCode = "500", description = "Always.",
             content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/IfServiceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/IfServiceRestService.java
@@ -393,7 +393,7 @@ public class IfServiceRestService extends AbstractDaoRestServiceWithDTO<OnmsMoni
     @Override
     @Operation(summary = "Get one monitored service",
             description = """
-                    Not implemented. This endpoint has no single-entity lookup, so every identifier is answered with 501 and no body. Read a single service through `/nodes/{nodeCriteria}/ipinterfaces/{ipAddress}/services/{service}` or filter the collection with `_s=id==1017`.""",
+                    This endpoint has no single-entity lookup, so every identifier is answered with 501 and no body.""",
             operationId = "ifServicesGet")
     @ApiResponses({
             @ApiResponse(responseCode = "501", description = """
@@ -410,9 +410,7 @@ public class IfServiceRestService extends AbstractDaoRestServiceWithDTO<OnmsMoni
     @Override
     @Operation(summary = "Create a monitored service",
             description = """
-                    Not supported here: add services under `/nodes/{nodeCriteria}/ipinterfaces/{ipAddress}/services` or let capsd detect them.
-
-                    The body is mapped to an entity before the 501 is raised, and that mapping reads `serviceType.id`, so a body without a `serviceType` fails with 500 instead.""",
+                    Answered with 501. The body is mapped to an entity before the 501 is raised, and that mapping reads `serviceType.id`, so a body without a `serviceType` fails with 500 instead.""",
             operationId = "ifServicesCreate")
     @ApiResponses({
             @ApiResponse(responseCode = "500", description = """
@@ -456,7 +454,7 @@ public class IfServiceRestService extends AbstractDaoRestServiceWithDTO<OnmsMoni
     @Override
     @Operation(summary = "Update the monitored services matching a query",
             description = """
-                    Sets named properties on every monitored service matching the query, which is how services are moved in and out of maintenance mode. Setting `status=F` forces a service unmanaged and `status=A` returns it to managed. Application membership changes send `applicationChanged` events. At most `limit` entities are affected, so this touches ten entities per call unless a larger `limit` is given.
+                    Sets named properties on every monitored service matching the query. Setting `status=F` forces a service unmanaged and `status=A` returns it to managed. Application membership changes send `applicationChanged` events. At most `limit` entities are affected, ten by default.
 
                     A service whose status did not actually change is skipped rather than reported, so the operation answers 204 whether or not anything changed.
 
@@ -490,7 +488,7 @@ public class IfServiceRestService extends AbstractDaoRestServiceWithDTO<OnmsMoni
     @Override
     @Operation(summary = "Update one monitored service",
             description = """
-                    Not reachable. The form-parameter handler looks the service up first and that lookup is not implemented, and the JSON or XML replacement handler is not implemented either, so both answer 501. Use the collection-level PUT with an `_s` expression instead.""",
+                    Both the JSON or XML replacement form and the form-parameter form answer 501.""",
             operationId = "ifServicesUpdate")
     @ApiResponses({
             @ApiResponse(responseCode = "501", description = """
@@ -540,7 +538,7 @@ public class IfServiceRestService extends AbstractDaoRestServiceWithDTO<OnmsMoni
     @Override
     @Operation(summary = "Delete one monitored service",
             description = """
-                    Not implemented: the lookup this needs is not implemented for monitored services.""",
+                    Answered with 501 for every identifier.""",
             operationId = "ifServicesDelete")
     @ApiResponses({
             @ApiResponse(responseCode = "501", description = """

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/IfServiceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/IfServiceRestService.java
@@ -57,6 +57,22 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.google.common.collect.Sets;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.apache.cxf.jaxrs.ext.search.SearchContext;
+import org.opennms.web.rest.support.SearchPropertyCollection;
+import org.opennms.web.rest.support.StringCollection;
 
 /**
  * Basic Web Service using REST for {@link OnmsMonitoredService} entity.
@@ -70,6 +86,7 @@ import com.google.common.collect.Sets;
 @Component
 @Path("ifservices")
 @Transactional
+@Tag(name = "IfServices", description = "Monitored Services API")
 public class IfServiceRestService extends AbstractDaoRestServiceWithDTO<OnmsMonitoredService,MonitoredServiceDTO,SearchBean,Integer,String> {
     @Autowired
     private MonitoredServiceDao m_dao;
@@ -217,5 +234,323 @@ public class IfServiceRestService extends AbstractDaoRestServiceWithDTO<OnmsMoni
     @Override
     protected OnmsMonitoredService doGet(UriInfo uriInfo, String serviceName) {
         throw new WebApplicationException(Response.status(Status.NOT_IMPLEMENTED).build());
+    }
+
+    @Override
+    @Operation(summary = "List monitored services",
+            description = """
+                    Monitored services matching the query, by ascending identifier unless `orderBy` says otherwise. The query joins the IP interface, the service type, the node and its asset record and location, and the SNMP interface, so properties of all of those are searchable.
+
+                    The returned entity is a projection of the monitored service rather than the stored row: it carries the service type, status, last-good and last-fail times and the owning interface and node, and omits the applications and metadata.
+
+                    Timestamps are epoch milliseconds in JSON and ISO-8601 with a UTC offset in XML.
+
+                    `application/atom+xml` is also accepted and returns the same document as `application/xml`.
+
+                    For example, `_s=status==A` or `_s=node.label==loopback-001`.""",
+            operationId = "ifServicesList")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "One page of matching monitored services.",
+                    headers = @Header(name = "Content-Range", description = "`items <offset>-<last>/<totalCount>` for this page.",
+                            schema = @Schema(type = "string")),
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = MonitoredServiceCollectionDTO.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "totalCount": 262,
+                              "count": 1,
+                              "offset": 0,
+                              "service": [ {
+                                "id": 1017,
+                                "status": "A",
+                                "statusLong": "Managed",
+                                "down": false,
+                                "serviceType": { "id": 2, "name": "HTTP-8080" },
+                                "lastGood": 1787727384331,
+                                "lastFail": 1787685424834,
+                                "ipInterfaceId": 2,
+                                "ipAddress": "127.0.0.1",
+                                "nodeId": 2,
+                                "nodeLabel": "loopback-001"
+                              } ]
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = MonitoredServiceCollectionDTO.class),
+                                    examples = @ExampleObject(value = """
+                            <services count="1" offset="0" totalCount="262">
+                              <service id="1017">
+                                <down>false</down>
+                                <status>A</status>
+                                <serviceType id="2"><name>HTTP-8080</name></serviceType>
+                                <lastFail>2026-08-25T15:17:04.834-04:00</lastFail>
+                                <lastGood>2026-08-26T03:11:24.562-04:00</lastGood>
+                                <statusLong>Managed</statusLong>
+                                <ipInterfaceId>2</ipInterfaceId>
+                                <ipAddress>127.0.0.1</ipAddress>
+                                <nodeId>2</nodeId>
+                                <nodeLabel>loopback-001</nodeLabel>
+                              </service>
+                            </services>"""))
+                    }),
+            @ApiResponse(responseCode = "204", description = "No monitored service matched the query. The response has no body."),
+            @ApiResponse(responseCode = "500", description = DOC_SEARCH_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    public Response get(final UriInfo uriInfo, final SearchContext searchContext) {
+        return super.get(uriInfo, searchContext);
+    }
+
+    @Override
+    @Operation(summary = "Count monitored services",
+            description = """
+                    Number of monitored services matching the query.
+
+                    Only `text/plain` is produced. A request that sends `Accept: application/json` does not match this operation and falls through to the single-entity GET with `count` as the identifier.
+
+                    For example, `_s=status==A` or `_s=node.label==loopback-001`.""",
+            operationId = "ifServicesCount")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The number of matching monitored services, as a decimal string.",
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "262"))),
+            @ApiResponse(responseCode = "500", description = DOC_COUNT_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    public Response getCount(final UriInfo uriInfo, final SearchContext searchContext) {
+        return super.getCount(uriInfo, searchContext);
+    }
+
+    @Override
+    @Operation(summary = "List the queryable properties of monitored services",
+            description = """
+                    The properties a monitored-service query can filter and sort on, including the joined interface, node and asset properties. Properties with a fixed value set, such as `status`, carry that set as a `values` map.""",
+            operationId = "ifServicesSearchProperties")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The properties this endpoint can search and sort on.",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = SearchPropertyCollection.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "totalCount": 1,
+                              "count": 1,
+                              "offset": 0,
+                              "searchProperty": [ {
+                                "id": "status",
+                                "name": "Management Status",
+                                "type": "STRING",
+                                "orderBy": true,
+                                "iplike": false,
+                                "values": {
+                                  "A": "Managed",
+                                  "R": "Rescan to Resume",
+                                  "S": "Rescan to Suspend",
+                                  "D": "Deleted",
+                                  "U": "Unmanaged",
+                                  "F": "Forced Unmanaged",
+                                  "X": "Remotely Monitored",
+                                  "N": "Not Monitored"
+                                }
+                              } ]
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = SearchPropertyCollection.class),
+                                    examples = @ExampleObject(value = """
+                            <searchProperties count="1" offset="0" totalCount="1">
+                              <searchProperty type="STRING" orderBy="true" iplike="false" id="status" name="Management Status">
+                                <values>
+                                  <entry><key>A</key><value>Managed</value></entry>
+                                  <entry><key>U</key><value>Unmanaged</value></entry>
+                                </values>
+                              </searchProperty>
+                            </searchProperties>"""))
+                    })
+    })
+    public Response getProperties(final String query) {
+        return super.getProperties(query);
+    }
+
+    @Override
+    @Operation(summary = "List the values a queryable property takes",
+            description = """
+                    Distinct values held by one monitored-service property. Properties with a fixed value set return it directly, so `status` returns the eight management-status codes; other properties are read from the database and honour `limit`.""",
+            operationId = "ifServicesSearchPropertyValues")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The distinct values, typed after the property.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = StringCollection.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "totalCount": 8,
+                              "count": 8,
+                              "offset": 0,
+                              "value": [ "A", "R", "S", "D", "U", "F", "X", "N" ]
+                            }"""))),
+            @ApiResponse(responseCode = "404", description = "No property with that `id` is queryable here. The response has no body.")
+    })
+    public Response getPropertyValues(final String propertyId, final String query, final Integer limit) {
+        return super.getPropertyValues(propertyId, query, limit);
+    }
+
+    @Override
+    @Operation(summary = "Get one monitored service",
+            description = """
+                    Not implemented. This endpoint has no single-entity lookup, so every identifier is answered with 501 and no body. Read a single service through `/nodes/{nodeCriteria}/ipinterfaces/{ipAddress}/services/{service}` or filter the collection with `_s=id==1017`.""",
+            operationId = "ifServicesGet")
+    @ApiResponses({
+            @ApiResponse(responseCode = "501", description = """
+                    Always. The response has no body.""")
+    })
+    public Response get(final UriInfo uriInfo,
+            @Parameter(description = """
+                    Unused: this endpoint has no single-entity lookup, so every value produces the same response.""",
+                    required = true, example = "1017")
+            final String id) {
+        return super.get(uriInfo, id);
+    }
+
+    @Override
+    @Operation(summary = "Create a monitored service",
+            description = """
+                    Not supported here: add services under `/nodes/{nodeCriteria}/ipinterfaces/{ipAddress}/services` or let capsd detect them.
+
+                    The body is mapped to an entity before the 501 is raised, and that mapping reads `serviceType.id`, so a body without a `serviceType` fails with 500 instead.""",
+            operationId = "ifServicesCreate")
+    @ApiResponses({
+            @ApiResponse(responseCode = "500", description = """
+                    The body has no `serviceType`. The body is a `text/plain` message.""",
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = """
+                            Cannot invoke "org.opennms.web.rest.model.v2.ServiceTypeDTO.getId()" because the return value of "org.opennms.web.rest.model.v2.MonitoredServiceDTO.getServiceType()" is null"""))),
+            @ApiResponse(responseCode = "501", description = DOC_NOT_IMPLEMENTED)
+    })
+    public Response create(final SecurityContext securityContext, final UriInfo uriInfo,
+            @RequestBody(description = """
+                    Accepted but not acted on. It still has to carry a `serviceType`, since the body is mapped before the request is refused.""",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = MonitoredServiceDTO.class),
+                                    examples = @ExampleObject(value = """
+                            { "serviceType": { "id": 1, "name": "ICMP" } }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = MonitoredServiceDTO.class),
+                                    examples = @ExampleObject(value = """
+                            <service><serviceType id="1"><name>ICMP</name></serviceType></service>"""))
+                    })
+            final MonitoredServiceDTO object) {
+        return super.create(securityContext, uriInfo, object);
+    }
+
+    @Override
+    @Operation(summary = "Rejected: create a monitored service at a caller-chosen identifier",
+            description = DOC_POST_WITH_ID,
+            operationId = "ifServicesCreateWithId")
+    @Parameters({
+            @Parameter(name = "id", in = ParameterIn.PATH, required = true,
+                    description = "Ignored. Any value produces the same response.",
+                    schema = @Schema(type = "string"), example = "1017")
+    })
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = "Always. The response has no body.")
+    })
+    public Response createSpecific() {
+        return super.createSpecific();
+    }
+
+    @Override
+    @Operation(summary = "Update the monitored services matching a query",
+            description = """
+                    Sets named properties on every monitored service matching the query, which is how services are moved in and out of maintenance mode. Setting `status=F` forces a service unmanaged and `status=A` returns it to managed. Application membership changes send `applicationChanged` events. At most `limit` entities are affected, so this touches ten entities per call unless a larger `limit` is given.
+
+                    A service whose status did not actually change is skipped rather than reported, so the operation answers 204 whether or not anything changed.
+
+                    For example, `_s=status==A` or `_s=node.label==loopback-001`.""",
+            operationId = "ifServicesUpdateMany")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = """
+                    Every matching service was processed. The response has no body."""),
+            @ApiResponse(responseCode = "404", description = DOC_NO_MATCH),
+            @ApiResponse(responseCode = "500", description = DOC_SEARCH_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    public Response updateMany(final SecurityContext securityContext, final UriInfo uriInfo, final SearchContext searchContext,
+            @RequestBody(description = DOC_FORM_BODY,
+                    content = @Content(mediaType = "application/x-www-form-urlencoded",
+                            schema = @Schema(type = "object"),
+                            examples = @ExampleObject(value = """
+                            status=F""")))
+            final MultivaluedMapImpl params) {
+        return super.updateMany(securityContext, uriInfo, searchContext, params);
+    }
+
+    @Override
+    @Hidden
+    public Response update(final SecurityContext securityContext, final UriInfo uriInfo, final Integer id,
+            final OnmsMonitoredService object) {
+        return super.update(securityContext, uriInfo, id, object);
+    }
+
+    @Override
+    @Operation(summary = "Update one monitored service",
+            description = """
+                    Not reachable. The form-parameter handler looks the service up first and that lookup is not implemented, and the JSON or XML replacement handler is not implemented either, so both answer 501. Use the collection-level PUT with an `_s` expression instead.""",
+            operationId = "ifServicesUpdate")
+    @ApiResponses({
+            @ApiResponse(responseCode = "501", description = """
+                    Always. The response has no body.""")
+    })
+    public Response updateProperties(final SecurityContext securityContext, final UriInfo uriInfo,
+            @Parameter(description = """
+                    Unused: this endpoint has no single-entity lookup, so every value produces the same response.""",
+                    required = true, example = "1017")
+            final String id,
+            @RequestBody(description = """
+                    Accepted but not acted on: the endpoint answers 501 for every body.""",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsMonitoredService.class),
+                                    examples = @ExampleObject(value = """
+                            { }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsMonitoredService.class),
+                                    examples = @ExampleObject(value = """
+                            <service/>""")),
+                            @Content(mediaType = "application/x-www-form-urlencoded",
+                                    schema = @Schema(type = "object"),
+                                    examples = @ExampleObject(value = """
+                            status=F"""))
+                    })
+            final MultivaluedMapImpl params) {
+        return super.updateProperties(securityContext, uriInfo, id, params);
+    }
+
+    @Override
+    @Operation(summary = "Delete the monitored services matching a query",
+            description = """
+                    Not supported here: the endpoint answers 501 once it has found at least one match, and 404 when nothing matches.
+
+                    For example, `_s=status==A` or `_s=node.label==loopback-001`.""",
+            operationId = "ifServicesDeleteMany")
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = DOC_NO_MATCH),
+            @ApiResponse(responseCode = "500", description = DOC_SEARCH_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search"))),
+            @ApiResponse(responseCode = "501", description = DOC_NOT_IMPLEMENTED)
+    })
+    public Response deleteMany(final SecurityContext securityContext, final UriInfo uriInfo, final SearchContext searchContext) {
+        return super.deleteMany(securityContext, uriInfo, searchContext);
+    }
+
+    @Override
+    @Operation(summary = "Delete one monitored service",
+            description = """
+                    Not implemented: the lookup this needs is not implemented for monitored services.""",
+            operationId = "ifServicesDelete")
+    @ApiResponses({
+            @ApiResponse(responseCode = "501", description = """
+                    Always. The response has no body.""")
+    })
+    public Response delete(final SecurityContext securityContext, final UriInfo uriInfo,
+            @Parameter(description = """
+                    Unused: this endpoint has no single-entity lookup, so every value produces the same response.""",
+                    required = true, example = "1017")
+            final String id) {
+        return super.delete(securityContext, uriInfo, id);
     }
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/IpInterfaceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/IpInterfaceRestService.java
@@ -333,9 +333,9 @@ public class IpInterfaceRestService extends AbstractDaoRestService<OnmsIpInterfa
     }
 
     @Override
-    @Operation(summary = "Create a IP interface",
+    @Operation(summary = "Create an IP interface",
             description = """
-                    Not supported here: create interfaces under `/nodes/{nodeCriteria}/ipinterfaces` or through provisioning.""",
+                    Answered with 501 for every body.""",
             operationId = "ipInterfacesCreate")
     @ApiResponses({
             @ApiResponse(responseCode = "501", description = DOC_NOT_IMPLEMENTED)
@@ -356,7 +356,7 @@ public class IpInterfaceRestService extends AbstractDaoRestService<OnmsIpInterfa
     }
 
     @Override
-    @Operation(summary = "Rejected: create a IP interface at a caller-chosen identifier",
+    @Operation(summary = "Rejected: create an IP interface at a caller-chosen identifier",
             description = DOC_POST_WITH_ID,
             operationId = "ipInterfacesCreateWithId")
     @Parameters({
@@ -405,11 +405,13 @@ public class IpInterfaceRestService extends AbstractDaoRestService<OnmsIpInterfa
     @Override
     @Operation(summary = "Update one IP interface",
             description = """
-                    Not supported here. Both the JSON or XML replacement form and the form-parameter form answer 501; update interfaces under `/nodes/{nodeCriteria}/ipinterfaces/{ipAddress}` instead.""",
+                    Both the JSON or XML replacement form and the form-parameter form answer 501.""",
             operationId = "ipInterfacesUpdate")
     @ApiResponses({
+            @ApiResponse(responseCode = "400", description = """
+                    More than one node holds that IP address, so the lookup is ambiguous. The response has no body."""),
             @ApiResponse(responseCode = "404", description = """
-                    No interface holds that address. The response has no body."""),
+                    No interface holds that address, or the value is not a parseable address. The response has no body."""),
             @ApiResponse(responseCode = "501", description = """
                     This endpoint does not support update. The response has no body.""")
     })
@@ -457,11 +459,13 @@ public class IpInterfaceRestService extends AbstractDaoRestService<OnmsIpInterfa
     @Override
     @Operation(summary = "Delete one IP interface",
             description = """
-                    Not supported here.""",
+                    Answered with 501 once the address resolves, and 404 when it does not.""",
             operationId = "ipInterfacesDelete")
     @ApiResponses({
+            @ApiResponse(responseCode = "400", description = """
+                    More than one node holds that IP address, so the lookup is ambiguous. The response has no body."""),
             @ApiResponse(responseCode = "404", description = """
-                    No interface holds that address. The response has no body."""),
+                    No interface holds that address, or the value is not a parseable address. The response has no body."""),
             @ApiResponse(responseCode = "501", description = """
                     This endpoint does not support deletion. The response has no body.""")
     })

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/IpInterfaceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/IpInterfaceRestService.java
@@ -48,6 +48,24 @@ import org.opennms.web.rest.support.SearchProperty;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+import org.apache.cxf.jaxrs.ext.search.SearchContext;
+import org.opennms.web.rest.support.MultivaluedMapImpl;
+import org.opennms.web.rest.support.SearchPropertyCollection;
+import org.opennms.web.rest.support.StringCollection;
 
 /**
  * Basic Web Service using REST for {@link OnmsIpInterface} entity.
@@ -134,5 +152,324 @@ public class IpInterfaceRestService extends AbstractDaoRestService<OnmsIpInterfa
 			return iface;
         }
         throw new WebApplicationException("More than one IP address matches " + ipAddress, Status.BAD_REQUEST);
+    }
+
+    @Override
+    @Operation(summary = "List IP interfaces",
+            description = """
+                    IP interfaces matching the query, ordered by database identifier unless `orderBy` says otherwise. The query joins the node, its asset record, location and categories, the SNMP interface and the monitored services, so properties of all of those are searchable.
+
+                    Timestamps are epoch milliseconds in JSON and ISO-8601 with a UTC offset in XML.
+
+                    `application/atom+xml` is also accepted and returns the same document as `application/xml`.
+
+                    For example, `_s=node.label==loopback-001` or `_s=isManaged==M`.""",
+            operationId = "ipInterfacesList")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "One page of matching IP interfaces.",
+                    headers = @Header(name = "Content-Range", description = "`items <offset>-<last>/<totalCount>` for this page.",
+                            schema = @Schema(type = "string")),
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsIpInterfaceList.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "totalCount": 3688,
+                              "count": 1,
+                              "offset": 0,
+                              "ipInterface": [ {
+                                "id": "1",
+                                "ipAddress": "127.0.0.4",
+                                "hostName": "localhost.",
+                                "ifIndex": null,
+                                "isManaged": "M",
+                                "snmpPrimary": "N",
+                                "isDown": false,
+                                "monitoredServiceCount": 1,
+                                "lastCapsdPoll": 1787145520003,
+                                "lastIngressFlow": null,
+                                "lastEgressFlow": null,
+                                "nodeId": 1
+                              } ]
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsIpInterfaceList.class),
+                                    examples = @ExampleObject(value = """
+                            <ipInterfaces count="1" offset="0" totalCount="3688">
+                              <ipInterface isDown="false" id="1" isManaged="M" monitoredServiceCount="1" snmpPrimary="N">
+                                <ipAddress>127.0.0.4</ipAddress>
+                                <hostName>localhost.</hostName>
+                                <lastCapsdPoll>2026-08-19T09:18:40.003-04:00</lastCapsdPoll>
+                                <nodeId>1</nodeId>
+                              </ipInterface>
+                            </ipInterfaces>"""))
+                    }),
+            @ApiResponse(responseCode = "204", description = "No IP interface matched the query. The response has no body."),
+            @ApiResponse(responseCode = "500", description = DOC_SEARCH_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    public Response get(final UriInfo uriInfo, final SearchContext searchContext) {
+        return super.get(uriInfo, searchContext);
+    }
+
+    @Override
+    @Operation(summary = "Count IP interfaces",
+            description = """
+                    Number of IP interfaces matching the query.
+
+                    Only `text/plain` is produced. A request that sends `Accept: application/json` does not match this operation and falls through to the single-entity GET with `count` as the identifier.
+
+                    For example, `_s=node.label==loopback-001` or `_s=isManaged==M`.""",
+            operationId = "ipInterfacesCount")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The number of matching IP interfaces, as a decimal string.",
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "3688"))),
+            @ApiResponse(responseCode = "500", description = DOC_COUNT_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    public Response getCount(final UriInfo uriInfo, final SearchContext searchContext) {
+        return super.getCount(uriInfo, searchContext);
+    }
+
+    @Override
+    @Operation(summary = "List the queryable properties of IP interfaces",
+            description = """
+                    The properties an IP-interface query can filter and sort on, including the joined node, SNMP interface and asset properties.""",
+            operationId = "ipInterfacesSearchProperties")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The properties this endpoint can search and sort on.",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = SearchPropertyCollection.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "totalCount": 1,
+                              "count": 1,
+                              "offset": 0,
+                              "searchProperty": [
+                                { "id": "ipHostName", "name": "Hostname", "type": "STRING", "orderBy": true, "iplike": false }
+                              ]
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = SearchPropertyCollection.class),
+                                    examples = @ExampleObject(value = """
+                            <searchProperties count="1" offset="0" totalCount="1">
+                              <searchProperty type="STRING" orderBy="true" iplike="false" id="ipHostName" name="Hostname"/>
+                            </searchProperties>"""))
+                    })
+    })
+    public Response getProperties(final String query) {
+        return super.getProperties(query);
+    }
+
+    @Override
+    @Operation(summary = "List the values a queryable property takes",
+            description = """
+                    Distinct values held by one IP-interface property. The `value` entries are typed after the property: numbers for `INTEGER`, `LONG` and `FLOAT`, epoch milliseconds for `TIMESTAMP`, strings otherwise.""",
+            operationId = "ipInterfacesSearchPropertyValues")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The distinct values, typed after the property.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = StringCollection.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "totalCount": 3,
+                              "count": 3,
+                              "offset": 0,
+                              "value": [ "10.0.10.0", "10.0.10.1", "10.0.10.10" ]
+                            }"""))),
+            @ApiResponse(responseCode = "404", description = "No property with that `id` is queryable here. The response has no body.")
+    })
+    public Response getPropertyValues(final String propertyId, final String query, final Integer limit) {
+        return super.getPropertyValues(propertyId, query, limit);
+    }
+
+    @Override
+    @Operation(summary = "Get one IP interface",
+            description = """
+                    One IP interface, looked up by IP address rather than by database identifier.
+
+                    Timestamps are epoch milliseconds in JSON and ISO-8601 with a UTC offset in XML.
+
+                    `application/atom+xml` is also accepted and returns the same document as `application/xml`.""",
+            operationId = "ipInterfacesGet")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The requested IP interface.",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsIpInterface.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "id": "2",
+                              "ipAddress": "127.0.0.1",
+                              "hostName": "localhost",
+                              "ifIndex": null,
+                              "isManaged": "M",
+                              "snmpPrimary": "P",
+                              "isDown": false,
+                              "monitoredServiceCount": 2,
+                              "lastCapsdPoll": 1786541086168,
+                              "lastIngressFlow": null,
+                              "lastEgressFlow": null,
+                              "nodeId": 2
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsIpInterface.class),
+                                    examples = @ExampleObject(value = """
+                            <ipInterface isDown="false" id="2" isManaged="M" monitoredServiceCount="2" snmpPrimary="P">
+                              <ipAddress>127.0.0.1</ipAddress>
+                              <hostName>localhost</hostName>
+                              <lastCapsdPoll>2026-08-12T09:24:46.168-04:00</lastCapsdPoll>
+                              <nodeId>2</nodeId>
+                            </ipInterface>"""))
+                    }),
+            @ApiResponse(responseCode = "400", description = """
+                    More than one node holds that IP address, so the lookup is ambiguous. The response has no body."""),
+            @ApiResponse(responseCode = "404", description = """
+                    No interface holds that address, or the value is not a parseable address. The response has no body.""")
+    })
+    public Response get(final UriInfo uriInfo,
+            @Parameter(description = """
+                    IP address of the interface, not its database identifier. Addresses are not unique across nodes, and an address held by more than one node is answered with 400.""",
+                    required = true, example = "127.0.0.1")
+            final String id) {
+        return super.get(uriInfo, id);
+    }
+
+    @Override
+    @Operation(summary = "Create a IP interface",
+            description = """
+                    Not supported here: create interfaces under `/nodes/{nodeCriteria}/ipinterfaces` or through provisioning.""",
+            operationId = "ipInterfacesCreate")
+    @ApiResponses({
+            @ApiResponse(responseCode = "501", description = DOC_NOT_IMPLEMENTED)
+    })
+    public Response create(final SecurityContext securityContext, final UriInfo uriInfo,
+            @RequestBody(description = """
+                    Accepted but not acted on: the endpoint answers 501 for every body.""",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsIpInterface.class),
+                                    examples = @ExampleObject(value = """
+                            { }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsIpInterface.class),
+                                    examples = @ExampleObject(value = """
+                            <ipInterface/>"""))
+                    })
+            final OnmsIpInterface object) {
+        return super.create(securityContext, uriInfo, object);
+    }
+
+    @Override
+    @Operation(summary = "Rejected: create a IP interface at a caller-chosen identifier",
+            description = DOC_POST_WITH_ID,
+            operationId = "ipInterfacesCreateWithId")
+    @Parameters({
+            @Parameter(name = "id", in = ParameterIn.PATH, required = true,
+                    description = "Ignored. Any value produces the same response.",
+                    schema = @Schema(type = "string"), example = "127.0.0.1")
+    })
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = "Always. The response has no body.")
+    })
+    public Response createSpecific() {
+        return super.createSpecific();
+    }
+
+    @Override
+    @Operation(summary = "Update the IP interfaces matching a query",
+            description = """
+                    Not supported here: the endpoint answers 501 once it has found at least one match, and 404 when nothing matches.
+
+                    For example, `_s=node.label==loopback-001` or `_s=isManaged==M`.""",
+            operationId = "ipInterfacesUpdateMany")
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = DOC_NO_MATCH),
+            @ApiResponse(responseCode = "500", description = DOC_SEARCH_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search"))),
+            @ApiResponse(responseCode = "501", description = DOC_NOT_IMPLEMENTED)
+    })
+    public Response updateMany(final SecurityContext securityContext, final UriInfo uriInfo, final SearchContext searchContext,
+            @RequestBody(description = DOC_FORM_BODY,
+                    content = @Content(mediaType = "application/x-www-form-urlencoded",
+                            schema = @Schema(type = "object"),
+                            examples = @ExampleObject(value = """
+                            isManaged=M""")))
+            final MultivaluedMapImpl params) {
+        return super.updateMany(securityContext, uriInfo, searchContext, params);
+    }
+
+    @Override
+    @Hidden
+    public Response update(final SecurityContext securityContext, final UriInfo uriInfo, final Integer id,
+            final OnmsIpInterface object) {
+        return super.update(securityContext, uriInfo, id, object);
+    }
+
+    @Override
+    @Operation(summary = "Update one IP interface",
+            description = """
+                    Not supported here. Both the JSON or XML replacement form and the form-parameter form answer 501; update interfaces under `/nodes/{nodeCriteria}/ipinterfaces/{ipAddress}` instead.""",
+            operationId = "ipInterfacesUpdate")
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = """
+                    No interface holds that address. The response has no body."""),
+            @ApiResponse(responseCode = "501", description = """
+                    This endpoint does not support update. The response has no body.""")
+    })
+    public Response updateProperties(final SecurityContext securityContext, final UriInfo uriInfo,
+            @Parameter(description = """
+                    IP address of the interface, not its database identifier. Addresses are not unique across nodes, and an address held by more than one node is answered with 400.""",
+                    required = true, example = "127.0.0.1")
+            final String id,
+            @RequestBody(description = """
+                    Accepted but not acted on: the endpoint answers 501 for every body.""",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsIpInterface.class),
+                                    examples = @ExampleObject(value = """
+                            { }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsIpInterface.class),
+                                    examples = @ExampleObject(value = """
+                            <ipInterface/>""")),
+                            @Content(mediaType = "application/x-www-form-urlencoded",
+                                    schema = @Schema(type = "object"),
+                                    examples = @ExampleObject(value = """
+                            isManaged=M"""))
+                    })
+            final MultivaluedMapImpl params) {
+        return super.updateProperties(securityContext, uriInfo, id, params);
+    }
+
+    @Override
+    @Operation(summary = "Delete the IP interfaces matching a query",
+            description = """
+                    Not supported here: the endpoint answers 501 once it has found at least one match, and 404 when nothing matches.
+
+                    For example, `_s=node.label==loopback-001` or `_s=isManaged==M`.""",
+            operationId = "ipInterfacesDeleteMany")
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = DOC_NO_MATCH),
+            @ApiResponse(responseCode = "500", description = DOC_SEARCH_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search"))),
+            @ApiResponse(responseCode = "501", description = DOC_NOT_IMPLEMENTED)
+    })
+    public Response deleteMany(final SecurityContext securityContext, final UriInfo uriInfo, final SearchContext searchContext) {
+        return super.deleteMany(securityContext, uriInfo, searchContext);
+    }
+
+    @Override
+    @Operation(summary = "Delete one IP interface",
+            description = """
+                    Not supported here.""",
+            operationId = "ipInterfacesDelete")
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = """
+                    No interface holds that address. The response has no body."""),
+            @ApiResponse(responseCode = "501", description = """
+                    This endpoint does not support deletion. The response has no body.""")
+    })
+    public Response delete(final SecurityContext securityContext, final UriInfo uriInfo,
+            @Parameter(description = """
+                    IP address of the interface, not its database identifier. Addresses are not unique across nodes, and an address held by more than one node is answered with 400.""",
+                    required = true, example = "127.0.0.1")
+            final String id) {
+        return super.delete(securityContext, uriInfo, id);
     }
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/IpInterfaceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/IpInterfaceRestService.java
@@ -157,7 +157,7 @@ public class IpInterfaceRestService extends AbstractDaoRestService<OnmsIpInterfa
     @Override
     @Operation(summary = "List IP interfaces",
             description = """
-                    IP interfaces matching the query, ordered by database identifier unless `orderBy` says otherwise. The query joins the node, its asset record, location and categories, the SNMP interface and the monitored services, so properties of all of those are searchable.
+                    IP interfaces matching the query, ordered by database identifier unless `orderBy` says otherwise. The query joins the node, its asset record and location, and the SNMP interface, so properties of those are searchable; `category.*` and `monitoredService.*` terms are not joined here and fail with 500.
 
                     Timestamps are epoch milliseconds in JSON and ISO-8601 with a UTC offset in XML.
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MenuRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MenuRestService.java
@@ -31,6 +31,11 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.core.time.CentralizedDateTimeFormat;
 import org.opennms.web.rest.support.menu.HttpMenuRequestContext;
@@ -58,7 +63,103 @@ public class MenuRestService {
     @GET
     @Path("/")
     @Produces({MediaType.APPLICATION_JSON})
-    @Operation(summary = "Get main menu", description = "Get main menu", operationId = "MenuRestServiceGetMainMenu")
+    @Operation(summary = "Get main menu",
+            description = """
+        The whole menubar for the calling user, assembled from the menu template plus the request's
+        roles, so two users can get different `menus` contents from the same call. Alongside the menu
+        trees the response carries the chrome the Vue shell needs: `baseHref`, `username`, `version`,
+        `copyrightDates`, the formatted server date and time, the notification status, and the Zenith
+        Connect and add-node feature flags.
+
+        `menus` is the top-level bar. `helpMenu`, `selfServiceMenu`, `userNotificationMenu`,
+        `provisionMenu` and `configurationMenu` are the fixed right-hand entries, each a single menu
+        object rather than a list. Every entry shares one shape; unused members come back as null, and
+        `items` is null for a leaf and a list for a submenu.""",
+            operationId = "MenuRestServiceGetMainMenu")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The menu definition for the calling user.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = MainMenu.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "templateName": "default",
+                      "baseHref": "http://localhost:8980/opennms/",
+                      "homeUrl": "http://localhost:8980/opennms/index.jsp",
+                      "formattedDateTime": "2026-08-26T02:57:01-04:00",
+                      "formattedDate": "August 26, 2026",
+                      "formattedTime": "02:57:01 UTC-04",
+                      "noticeStatus": "Off",
+                      "username": "admin",
+                      "baseNodeUrl": "element/node.jsp?node=",
+                      "zenithConnectEnabled": false,
+                      "zenithConnectBaseUrl": "",
+                      "zenithConnectRelativeUrl": "",
+                      "displayAddNodeButton": false,
+                      "sideMenuInitialExpand": false,
+                      "copyrightDates": "2002-2026",
+                      "version": "36.0.4-SNAPSHOT",
+                      "menus": [
+                        {
+                          "type": "header",
+                          "id": "emptyHeader",
+                          "name": "",
+                          "url": null,
+                          "isExternalLink": null,
+                          "locationMatch": null,
+                          "action": null,
+                          "linkTarget": null,
+                          "icon": null,
+                          "roles": null,
+                          "requiredSystemProperties": [],
+                          "items": null
+                        }
+                      ],
+                      "helpMenu": {
+                        "type": null,
+                        "id": "helpMenu",
+                        "name": "Help",
+                        "url": "#",
+                        "roles": null,
+                        "requiredSystemProperties": [],
+                        "items": []
+                      },
+                      "selfServiceMenu": {
+                        "id": "selfServiceMenu",
+                        "name": "admin",
+                        "url": "account/selfService/index.jsp",
+                        "requiredSystemProperties": [],
+                        "items": [
+                          {"id": "changePassword", "name": "Change Password", "url": "account/selfService/newPasswordEntry", "items": null}
+                        ]
+                      },
+                      "userNotificationMenu": {
+                        "id": "userNotificationMenu",
+                        "requiredSystemProperties": [],
+                        "items": [
+                          {"id": "userNotificationConfiguration", "url": "admin/notification/index.jsp", "items": null}
+                        ]
+                      },
+                      "provisionMenu": {
+                        "id": "provisionMenu",
+                        "name": "Quick-Add Node",
+                        "url": "admin/ng-requisitions/quick-add-node.jsp#/",
+                        "roles": ["ROLE_ADMIN", "ROLE_PROVISION"],
+                        "requiredSystemProperties": [],
+                        "items": null
+                      },
+                      "configurationMenu": {
+                        "id": "configurationMenu",
+                        "name": "Configure OpenNMS",
+                        "url": "admin/index.jsp",
+                        "roles": ["ROLE_ADMIN"],
+                        "requiredSystemProperties": [],
+                        "items": null
+                      }
+                    }"""))),
+            @ApiResponse(responseCode = "500", description = "The menu template could not be read or parsed. The cause is logged, not returned.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error building menu.")))
+    })
     public Response getMainMenu(final @Context HttpServletRequest request) {
         try {
             MainMenu mainMenu = buildMenu(request);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MenuRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MenuRestService.java
@@ -67,9 +67,9 @@ public class MenuRestService {
             description = """
         The whole menubar for the calling user, assembled from the menu template plus the request's
         roles, so two users can get different `menus` contents from the same call. Alongside the menu
-        trees the response carries the chrome the Vue shell needs: `baseHref`, `username`, `version`,
-        `copyrightDates`, the formatted server date and time, the notification status, and the Zenith
-        Connect and add-node feature flags.
+        trees the response carries `baseHref`, `username`, `version`, `copyrightDates`, the formatted
+        server date and time, the notification status, and the Zenith Connect and add-node feature
+        flags.
 
         `menus` is the top-level bar. `helpMenu`, `selfServiceMenu`, `userNotificationMenu`,
         `provisionMenu` and `configurationMenu` are the fixed right-hand entries, each a single menu

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MinionRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MinionRestService.java
@@ -332,7 +332,7 @@ public class MinionRestService extends AbstractDaoRestService<OnmsMinion,OnmsMin
     @Override
     @Operation(summary = "Create a Minion",
             description = """
-                    Not supported: Minions register themselves by heartbeat. The endpoint answers 501 for every body.""",
+                    Answered with 501 for every body.""",
             operationId = "minionsCreate")
     @ApiResponses({
             @ApiResponse(responseCode = "501", description = DOC_NOT_IMPLEMENTED)
@@ -452,7 +452,7 @@ public class MinionRestService extends AbstractDaoRestService<OnmsMinion,OnmsMin
     @Override
     @Operation(summary = "Delete the Minions matching a query",
             description = """
-                    Deletes every Minion matching the query. At most `limit` entities are affected, so this touches ten entities per call unless a larger `limit` is given.
+                    Deletes every Minion matching the query. At most `limit` entities are affected, ten by default.
 
                     For example, `_s=location==Default`.""",
             operationId = "minionsDeleteMany")

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MinionRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MinionRestService.java
@@ -51,6 +51,22 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.apache.cxf.jaxrs.ext.search.SearchContext;
+import org.opennms.web.rest.support.MultivaluedMapImpl;
+import org.opennms.web.rest.support.SearchPropertyCollection;
+import org.opennms.web.rest.support.StringCollection;
 
 /**
  * Basic Web Service using REST for {@link OnmsMinion} entity
@@ -149,5 +165,323 @@ public class MinionRestService extends AbstractDaoRestService<OnmsMinion,OnmsMin
     @Override
     protected OnmsMinion doGet(UriInfo uriInfo, String id) {
         return getDao().get(id);
+    }
+
+    @Override
+    @Operation(summary = "List Minions",
+            description = """
+                    Minions matching the query, by descending label unless `orderBy` says otherwise. Minions register themselves through heartbeats, so an instance with no Minion deployed answers 204 here.
+
+                    The `date` member is the last heartbeat: epoch milliseconds in JSON, ISO-8601 with a UTC offset in XML.
+
+                    `application/atom+xml` is also accepted and returns the same document as `application/xml`.
+
+                    For example, `_s=location==Default`.""",
+            operationId = "minionsList")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "One page of matching Minions.",
+                    headers = @Header(name = "Content-Range", description = "`items <offset>-<last>/<totalCount>` for this page.",
+                            schema = @Schema(type = "string")),
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsMinionCollection.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "totalCount": 1,
+                              "count": 1,
+                              "offset": 0,
+                              "minion": [ {
+                                "id": "00000000-0000-0000-0000-000000ddba11",
+                                "label": "minion-01",
+                                "location": "Default",
+                                "type": "Minion",
+                                "status": "Started",
+                                "version": "36.0.4-SNAPSHOT",
+                                "date": 1787727804037,
+                                "lastCheckedIn": null,
+                                "properties": { }
+                              } ]
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsMinionCollection.class),
+                                    examples = @ExampleObject(value = """
+                            <minions count="1" offset="0" totalCount="1">
+                              <minion id="00000000-0000-0000-0000-000000ddba11" label="minion-01" location="Default" type="Minion" date="2026-08-26T03:03:24.037-04:00" status="Started" version="36.0.4-SNAPSHOT">
+                                <properties/>
+                              </minion>
+                            </minions>"""))
+                    }),
+            @ApiResponse(responseCode = "204", description = "No Minion matched the query. The response has no body."),
+            @ApiResponse(responseCode = "500", description = DOC_SEARCH_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    public Response get(final UriInfo uriInfo, final SearchContext searchContext) {
+        return super.get(uriInfo, searchContext);
+    }
+
+    @Override
+    @Operation(summary = "Count Minions",
+            description = """
+                    Number of Minions matching the query.
+
+                    Only `text/plain` is produced. A request that sends `Accept: application/json` does not match this operation and falls through to the single-entity GET with `count` as the identifier.
+
+                    For example, `_s=location==Default`.""",
+            operationId = "minionsCount")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The number of matching Minions, as a decimal string.",
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "0"))),
+            @ApiResponse(responseCode = "500", description = DOC_COUNT_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    public Response getCount(final UriInfo uriInfo, final SearchContext searchContext) {
+        return super.getCount(uriInfo, searchContext);
+    }
+
+    @Override
+    @Operation(summary = "List the queryable properties of Minions",
+            description = """
+                    The properties a Minion query can filter and sort on.""",
+            operationId = "minionsSearchProperties")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The properties this endpoint can search and sort on.",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = SearchPropertyCollection.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "totalCount": 1,
+                              "count": 1,
+                              "offset": 0,
+                              "searchProperty": [
+                                { "id": "label", "name": "Label", "type": "STRING", "orderBy": true, "iplike": false }
+                              ]
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = SearchPropertyCollection.class),
+                                    examples = @ExampleObject(value = """
+                            <searchProperties count="1" offset="0" totalCount="1">
+                              <searchProperty type="STRING" orderBy="true" iplike="false" id="label" name="Label"/>
+                            </searchProperties>"""))
+                    })
+    })
+    public Response getProperties(final String query) {
+        return super.getProperties(query);
+    }
+
+    @Override
+    @Operation(summary = "List the values a queryable property takes",
+            description = """
+                    Distinct values held by one Minion property. With no Minion registered the `value` array is empty and `totalCount` and `count` are `null`.""",
+            operationId = "minionsSearchPropertyValues")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The distinct values, typed after the property.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = StringCollection.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "totalCount": null,
+                              "count": null,
+                              "offset": 0,
+                              "value": [ ]
+                            }"""))),
+            @ApiResponse(responseCode = "404", description = "No property with that `id` is queryable here. The response has no body.")
+    })
+    public Response getPropertyValues(final String propertyId, final String query, final Integer limit) {
+        return super.getPropertyValues(propertyId, query, limit);
+    }
+
+    @Override
+    @Operation(summary = "Get one Minion",
+            description = """
+                    One Minion by identifier.
+
+                    `application/atom+xml` is also accepted and returns the same document as `application/xml`.""",
+            operationId = "minionsGet")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The requested Minion.",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsMinion.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "id": "00000000-0000-0000-0000-000000ddba11",
+                              "label": "minion-01",
+                              "location": "Default",
+                              "type": "Minion",
+                              "status": "Started",
+                              "version": "36.0.4-SNAPSHOT",
+                              "date": 1787727804037,
+                              "lastCheckedIn": null,
+                              "properties": { }
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsMinion.class),
+                                    examples = @ExampleObject(value = """
+                            <minion status="Started" version="36.0.4-SNAPSHOT" id="00000000-0000-0000-0000-000000ddba11" label="minion-01" location="Default" type="Minion" date="2026-08-26T03:03:24.037-04:00">
+                              <properties/>
+                            </minion>"""))
+                    }),
+            @ApiResponse(responseCode = "404", description = """
+                    No Minion has that identifier. The response has no body.""")
+    })
+    public Response get(final UriInfo uriInfo,
+            @Parameter(description = """
+                    Identifier the Minion reports for itself, which is also its primary key.""",
+                    required = true, example = "00000000-0000-0000-0000-000000ddba11")
+            final String id) {
+        return super.get(uriInfo, id);
+    }
+
+    @Override
+    @Operation(summary = "Create a Minion",
+            description = """
+                    Not supported: Minions register themselves by heartbeat. The endpoint answers 501 for every body.""",
+            operationId = "minionsCreate")
+    @ApiResponses({
+            @ApiResponse(responseCode = "501", description = DOC_NOT_IMPLEMENTED)
+    })
+    public Response create(final SecurityContext securityContext, final UriInfo uriInfo,
+            @RequestBody(description = """
+                    Accepted but not acted on: the endpoint answers 501 for every body.""",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsMinion.class),
+                                    examples = @ExampleObject(value = """
+                            { }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsMinion.class),
+                                    examples = @ExampleObject(value = """
+                            <minion/>"""))
+                    })
+            final OnmsMinion object) {
+        return super.create(securityContext, uriInfo, object);
+    }
+
+    @Override
+    @Operation(summary = "Rejected: create a Minion at a caller-chosen identifier",
+            description = DOC_POST_WITH_ID,
+            operationId = "minionsCreateWithId")
+    @Parameters({
+            @Parameter(name = "id", in = ParameterIn.PATH, required = true,
+                    description = "Ignored. Any value produces the same response.",
+                    schema = @Schema(type = "string"), example = "00000000-0000-0000-0000-000000ddba11")
+    })
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = "Always. The response has no body.")
+    })
+    public Response createSpecific() {
+        return super.createSpecific();
+    }
+
+    @Override
+    @Operation(summary = "Update the Minions matching a query",
+            description = """
+                    Not supported for Minions: the endpoint answers 501 once it has found at least one match, and 404 when nothing matches.
+
+                    For example, `_s=location==Default`.""",
+            operationId = "minionsUpdateMany")
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = DOC_NO_MATCH),
+            @ApiResponse(responseCode = "500", description = DOC_SEARCH_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search"))),
+            @ApiResponse(responseCode = "501", description = DOC_NOT_IMPLEMENTED)
+    })
+    public Response updateMany(final SecurityContext securityContext, final UriInfo uriInfo, final SearchContext searchContext,
+            @RequestBody(description = DOC_FORM_BODY,
+                    content = @Content(mediaType = "application/x-www-form-urlencoded",
+                            schema = @Schema(type = "object"),
+                            examples = @ExampleObject(value = """
+                            label=minion-01""")))
+            final MultivaluedMapImpl params) {
+        return super.updateMany(securityContext, uriInfo, searchContext, params);
+    }
+
+    @Override
+    @Hidden
+    public Response update(final SecurityContext securityContext, final UriInfo uriInfo, final String id,
+            final OnmsMinion object) {
+        return super.update(securityContext, uriInfo, id, object);
+    }
+
+    @Override
+    @Operation(summary = "Update one Minion",
+            description = """
+                    Replaces a Minion record. With a JSON or XML body the stored row is replaced wholesale, so members left out of the body are cleared, and the `id` in the body has to equal the identifier in the path. The form-parameter form is not implemented and answers 501.
+
+                    Heartbeats overwrite these fields again, so an edit made here lasts only until the Minion next checks in.""",
+            operationId = "minionsUpdate")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = """
+                    The Minion record was replaced. The response has no body."""),
+            @ApiResponse(responseCode = "400", description = """
+                    The `id` in the body does not match the identifier in the path. The body is a `text/plain` message.""",
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = """
+                            The ID of the object doesn't match the ID of the path: Other != ApiDocMinion"""))),
+            @ApiResponse(responseCode = "404", description = """
+                    No Minion has that identifier, or the body was empty. The response has no body."""),
+            @ApiResponse(responseCode = "501", description = """
+                    Reached only by a form-encoded body: updating named properties is not implemented here. The response has no body.""")
+    })
+    public Response updateProperties(final SecurityContext securityContext, final UriInfo uriInfo,
+            @Parameter(description = """
+                    Identifier the Minion reports for itself, which is also its primary key.""",
+                    required = true, example = "00000000-0000-0000-0000-000000ddba11")
+            final String id,
+            @RequestBody(description = """
+                    JSON or XML replaces the whole Minion record. A form-encoded body is accepted by the router but answered with 501.""",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsMinion.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "id": "00000000-0000-0000-0000-000000ddba11",
+                              "label": "minion-01",
+                              "location": "Default",
+                              "type": "Minion",
+                              "status": "Stopped",
+                              "version": "36.0.4-SNAPSHOT"
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsMinion.class),
+                                    examples = @ExampleObject(value = """
+                            <minion id="00000000-0000-0000-0000-000000ddba11" label="minion-01" location="Default" type="Minion" status="Stopped"/>""")),
+                            @Content(mediaType = "application/x-www-form-urlencoded",
+                                    schema = @Schema(type = "object"),
+                                    examples = @ExampleObject(value = """
+                            label=minion-01"""))
+                    })
+            final MultivaluedMapImpl params) {
+        return super.updateProperties(securityContext, uriInfo, id, params);
+    }
+
+    @Override
+    @Operation(summary = "Delete the Minions matching a query",
+            description = """
+                    Deletes every Minion matching the query. At most `limit` entities are affected, so this touches ten entities per call unless a larger `limit` is given.
+
+                    For example, `_s=location==Default`.""",
+            operationId = "minionsDeleteMany")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Every matching Minion was deleted. The response has no body."),
+            @ApiResponse(responseCode = "404", description = DOC_NO_MATCH),
+            @ApiResponse(responseCode = "500", description = DOC_SEARCH_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    public Response deleteMany(final SecurityContext securityContext, final UriInfo uriInfo, final SearchContext searchContext) {
+        return super.deleteMany(securityContext, uriInfo, searchContext);
+    }
+
+    @Override
+    @Operation(summary = "Delete one Minion",
+            description = """
+                    Deletes one Minion record. A `monitoringSystemDeleted` event is sent, and the Minion's node is removed from the requisition named by `opennms.minion.provisioning.foreignSourcePattern` (`Minions` by default).""",
+            operationId = "minionsDelete")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The Minion was deleted. The response has no body."),
+            @ApiResponse(responseCode = "404", description = """
+                    No Minion has that identifier. The response has no body.""")
+    })
+    public Response delete(final SecurityContext securityContext, final UriInfo uriInfo,
+            @Parameter(description = """
+                    Identifier the Minion reports for itself, which is also its primary key.""",
+                    required = true, example = "00000000-0000-0000-0000-000000ddba11")
+            final String id) {
+        return super.delete(securityContext, uriInfo, id);
     }
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MinionRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MinionRestService.java
@@ -415,7 +415,8 @@ public class MinionRestService extends AbstractDaoRestService<OnmsMinion,OnmsMin
                             examples = @ExampleObject(value = """
                             The ID of the object doesn't match the ID of the path: Other != ApiDocMinion"""))),
             @ApiResponse(responseCode = "404", description = """
-                    No Minion has that identifier, or the body was empty. The response has no body."""),
+                    The body was empty. An unknown identifier is not a 404: the row is saved as new, so a
+                    JSON or XML PUT to a nonexistent id inserts a Minion record and answers 204."""),
             @ApiResponse(responseCode = "501", description = """
                     Reached only by a form-encoded body: updating named properties is not implemented here. The response has no body.""")
     })

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MonitoringLocationRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MonitoringLocationRestService.java
@@ -46,6 +46,22 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.apache.cxf.jaxrs.ext.search.SearchContext;
+import org.opennms.web.rest.support.MultivaluedMapImpl;
+import org.opennms.web.rest.support.SearchPropertyCollection;
+import org.opennms.web.rest.support.StringCollection;
 
 /**
  * Basic Web Service using REST for {@link OnmsMonitoringLocation} entity
@@ -131,5 +147,331 @@ public class MonitoringLocationRestService extends AbstractDaoRestService<OnmsMo
     @Override
     protected void doDelete(SecurityContext securityContext, UriInfo uriInfo, OnmsMonitoringLocation location) {
         getDao().delete(location);
+    }
+
+    @Override
+    @Operation(summary = "List monitoring locations",
+            description = """
+                    Monitoring locations matching the query, ordered by name unless `orderBy` says otherwise. In JSON the name and area are the members `location-name` and `monitoring-area`; in XML they are attributes of the same names.
+
+                    `application/atom+xml` is also accepted and returns the same document as `application/xml`.
+
+                    For example, `_s=monitoringArea==localhost`. `_s=id==...` does not parse here; the key property is `locationName`.""",
+            operationId = "monitoringLocationsList")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "One page of matching monitoring locations.",
+                    headers = @Header(name = "Content-Range", description = "`items <offset>-<last>/<totalCount>` for this page.",
+                            schema = @Schema(type = "string")),
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsMonitoringLocationDefinitionList.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "totalCount": 1,
+                              "count": 1,
+                              "offset": 0,
+                              "location": [ {
+                                "location-name": "Default",
+                                "monitoring-area": "localhost",
+                                "priority": 100,
+                                "latitude": null,
+                                "longitude": null,
+                                "geolocation": null,
+                                "tags": []
+                              } ]
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsMonitoringLocationDefinitionList.class),
+                                    examples = @ExampleObject(value = """
+                            <locations xmlns:ns2="http://xmlns.opennms.org/xsd/config/monitoring-locations" count="1" offset="0" totalCount="1">
+                              <location location-name="Default" monitoring-area="localhost" priority="100">
+                                <ns2:tags/>
+                              </location>
+                            </locations>"""))
+                    }),
+            @ApiResponse(responseCode = "204", description = "No monitoring location matched the query. The response has no body."),
+            @ApiResponse(responseCode = "500", description = DOC_SEARCH_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    public Response get(final UriInfo uriInfo, final SearchContext searchContext) {
+        return super.get(uriInfo, searchContext);
+    }
+
+    @Override
+    @Operation(summary = "Count monitoring locations",
+            description = """
+                    Number of monitoring locations matching the query.
+
+                    Only `text/plain` is produced. A request that sends `Accept: application/json` does not match this operation and falls through to the single-entity GET with `count` as the identifier.
+
+                    For example, `_s=monitoringArea==localhost`. `_s=id==...` does not parse here; the key property is `locationName`.""",
+            operationId = "monitoringLocationsCount")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The number of matching monitoring locations, as a decimal string.",
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "1"))),
+            @ApiResponse(responseCode = "500", description = DOC_COUNT_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    public Response getCount(final UriInfo uriInfo, final SearchContext searchContext) {
+        return super.getCount(uriInfo, searchContext);
+    }
+
+    @Override
+    @Operation(summary = "List the queryable properties of monitoring locations",
+            description = """
+                    The properties a monitoring-location query can filter and sort on.""",
+            operationId = "monitoringLocationsSearchProperties")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The properties this endpoint can search and sort on.",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = SearchPropertyCollection.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "totalCount": 1,
+                              "count": 1,
+                              "offset": 0,
+                              "searchProperty": [
+                                { "id": "latitude", "name": "Latitude", "type": "FLOAT", "orderBy": true, "iplike": false }
+                              ]
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = SearchPropertyCollection.class),
+                                    examples = @ExampleObject(value = """
+                            <searchProperties count="1" offset="0" totalCount="1">
+                              <searchProperty type="FLOAT" orderBy="true" iplike="false" id="latitude" name="Latitude"/>
+                            </searchProperties>"""))
+                    })
+    })
+    public Response getProperties(final String query) {
+        return super.getProperties(query);
+    }
+
+    @Override
+    @Operation(summary = "List the values a queryable property takes",
+            description = """
+                    Distinct values held by one monitoring-location property.""",
+            operationId = "monitoringLocationsSearchPropertyValues")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The distinct values, typed after the property.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = StringCollection.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "totalCount": 1,
+                              "count": 1,
+                              "offset": 0,
+                              "value": [ "Default" ]
+                            }"""))),
+            @ApiResponse(responseCode = "500", description = """
+                    The property is declared as an integer but read back as a bigint, which is the case for `priority`. The body is a `text/plain` message.""",
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = """
+                            class java.lang.Long cannot be cast to class java.lang.Integer (java.lang.Long and java.lang.Integer are in module java.base of loader 'bootstrap') (through reference chain: org.opennms.web.rest.support.IntegerCollection["value"]->java.util.ArrayList[0])"""))),
+            @ApiResponse(responseCode = "404", description = "No property with that `id` is queryable here. The response has no body.")
+    })
+    public Response getPropertyValues(final String propertyId, final String query, final Integer limit) {
+        return super.getPropertyValues(propertyId, query, limit);
+    }
+
+    @Override
+    @Operation(summary = "Get one monitoring location",
+            description = """
+                    One monitoring location by name.
+
+                    `application/atom+xml` is also accepted and returns the same document as `application/xml`.""",
+            operationId = "monitoringLocationsGet")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The requested monitoring location.",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsMonitoringLocation.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "location-name": "Default",
+                              "monitoring-area": "localhost",
+                              "priority": 100,
+                              "latitude": null,
+                              "longitude": null,
+                              "geolocation": null,
+                              "tags": []
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsMonitoringLocation.class),
+                                    examples = @ExampleObject(value = """
+                            <location xmlns="http://xmlns.opennms.org/xsd/config/monitoring-locations" location-name="Default" monitoring-area="localhost" priority="100">
+                              <tags/>
+                            </location>"""))
+                    }),
+            @ApiResponse(responseCode = "404", description = """
+                    No monitoring location has that name. The response has no body.""")
+    })
+    public Response get(final UriInfo uriInfo,
+            @Parameter(description = """
+                    Name of the monitoring location, which is also its primary key.""",
+                    required = true, example = "Default")
+            final String id) {
+        return super.get(uriInfo, id);
+    }
+
+    @Override
+    @Operation(summary = "Create a monitoring location",
+            description = """
+                    Creates a monitoring location. The name in the body becomes the primary key and is returned in the `Location` header.""",
+            operationId = "monitoringLocationsCreate")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = """
+                    The monitoring location was created. The response has no body.""",
+                    headers = @Header(name = "Location", description = "URI of the created monitoring location.",
+                            schema = @Schema(type = "string"))),
+            @ApiResponse(responseCode = "500", description = """
+                    A monitoring location with that name already exists. The body is a `text/plain` message naming the violated constraint.""",
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = """
+                            could not execute statement; SQL [n/a]; constraint [monitoringlocations_pkey]; nested exception is org.hibernate.exception.ConstraintViolationException: could not execute statement""")))
+    })
+    public Response create(final SecurityContext securityContext, final UriInfo uriInfo,
+            @RequestBody(description = """
+                    The monitoring location to create. `location-name` and `monitoring-area` are required; omitted `priority` defaults to 100.""",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsMonitoringLocation.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "location-name": "Raleigh",
+                              "monitoring-area": "raleigh",
+                              "priority": 100
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsMonitoringLocation.class),
+                                    examples = @ExampleObject(value = """
+                            <location location-name="Raleigh" monitoring-area="raleigh" priority="100"/>"""))
+                    })
+            final OnmsMonitoringLocation object) {
+        return super.create(securityContext, uriInfo, object);
+    }
+
+    @Override
+    @Operation(summary = "Rejected: create a monitoring location at a caller-chosen identifier",
+            description = DOC_POST_WITH_ID,
+            operationId = "monitoringLocationsCreateWithId")
+    @Parameters({
+            @Parameter(name = "id", in = ParameterIn.PATH, required = true,
+                    description = "Ignored. Any value produces the same response.",
+                    schema = @Schema(type = "string"), example = "Default")
+    })
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = "Always. The response has no body.")
+    })
+    public Response createSpecific() {
+        return super.createSpecific();
+    }
+
+    @Override
+    @Operation(summary = "Update the monitoring locations matching a query",
+            description = """
+                    Not supported for monitoring locations: the endpoint answers 501 once it has found at least one match, and 404 when nothing matches.
+
+                    For example, `_s=monitoringArea==localhost`. `_s=id==...` does not parse here; the key property is `locationName`.""",
+            operationId = "monitoringLocationsUpdateMany")
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = DOC_NO_MATCH),
+            @ApiResponse(responseCode = "500", description = DOC_SEARCH_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search"))),
+            @ApiResponse(responseCode = "501", description = DOC_NOT_IMPLEMENTED)
+    })
+    public Response updateMany(final SecurityContext securityContext, final UriInfo uriInfo, final SearchContext searchContext,
+            @RequestBody(description = DOC_FORM_BODY,
+                    content = @Content(mediaType = "application/x-www-form-urlencoded",
+                            schema = @Schema(type = "object"),
+                            examples = @ExampleObject(value = """
+                            monitoring-area=localhost""")))
+            final MultivaluedMapImpl params) {
+        return super.updateMany(securityContext, uriInfo, searchContext, params);
+    }
+
+    @Override
+    @Hidden
+    public Response update(final SecurityContext securityContext, final UriInfo uriInfo, final String id,
+            final OnmsMonitoringLocation object) {
+        return super.update(securityContext, uriInfo, id, object);
+    }
+
+    @Override
+    @Operation(summary = "Update one monitoring location",
+            description = """
+                    Replaces a monitoring location. With a JSON or XML body the stored row is replaced wholesale, so members left out of the body revert to their defaults, and the name in the body has to equal the name in the path. The form-parameter form is not implemented and answers 501.""",
+            operationId = "monitoringLocationsUpdate")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = """
+                    The monitoring location was replaced. The response has no body."""),
+            @ApiResponse(responseCode = "400", description = """
+                    The name in the body does not match the name in the path. The body is a `text/plain` message.""",
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = """
+                            The ID of the object doesn't match the ID of the path: Other != Default"""))),
+            @ApiResponse(responseCode = "404", description = """
+                    No monitoring location has that name, or the body was empty. The response has no body."""),
+            @ApiResponse(responseCode = "501", description = """
+                    Reached only by a form-encoded body: updating named properties is not implemented here. The response has no body.""")
+    })
+    public Response updateProperties(final SecurityContext securityContext, final UriInfo uriInfo,
+            @Parameter(description = """
+                    Name of the monitoring location, which is also its primary key.""",
+                    required = true, example = "Default")
+            final String id,
+            @RequestBody(description = """
+                    JSON or XML replaces the whole monitoring location. A form-encoded body is accepted by the router but answered with 501.""",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsMonitoringLocation.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "location-name": "Default",
+                              "monitoring-area": "localhost",
+                              "priority": 100,
+                              "latitude": 35.8,
+                              "longitude": -78.6
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsMonitoringLocation.class),
+                                    examples = @ExampleObject(value = """
+                            <location location-name="Default" monitoring-area="localhost" priority="100"/>""")),
+                            @Content(mediaType = "application/x-www-form-urlencoded",
+                                    schema = @Schema(type = "object"),
+                                    examples = @ExampleObject(value = """
+                            monitoring-area=localhost"""))
+                    })
+            final MultivaluedMapImpl params) {
+        return super.updateProperties(securityContext, uriInfo, id, params);
+    }
+
+    @Override
+    @Operation(summary = "Delete the monitoring locations matching a query",
+            description = """
+                    Deletes every monitoring location matching the query. At most `limit` entities are affected, so this touches ten entities per call unless a larger `limit` is given.
+
+                    For example, `_s=monitoringArea==localhost`. `_s=id==...` does not parse here; the key property is `locationName`.""",
+            operationId = "monitoringLocationsDeleteMany")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Every matching monitoring location was deleted. The response has no body."),
+            @ApiResponse(responseCode = "404", description = DOC_NO_MATCH),
+            @ApiResponse(responseCode = "500", description = DOC_SEARCH_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    public Response deleteMany(final SecurityContext securityContext, final UriInfo uriInfo, final SearchContext searchContext) {
+        return super.deleteMany(securityContext, uriInfo, searchContext);
+    }
+
+    @Override
+    @Operation(summary = "Delete one monitoring location",
+            description = """
+                    Deletes one monitoring location by name.""",
+            operationId = "monitoringLocationsDelete")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The monitoring location was deleted. The response has no body."),
+            @ApiResponse(responseCode = "404", description = """
+                    No monitoring location has that name. The response has no body.""")
+    })
+    public Response delete(final SecurityContext securityContext, final UriInfo uriInfo,
+            @Parameter(description = """
+                    Name of the monitoring location, which is also its primary key.""",
+                    required = true, example = "Default")
+            final String id) {
+        return super.delete(securityContext, uriInfo, id);
     }
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MonitoringLocationRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MonitoringLocationRestService.java
@@ -442,7 +442,7 @@ public class MonitoringLocationRestService extends AbstractDaoRestService<OnmsMo
     @Override
     @Operation(summary = "Delete the monitoring locations matching a query",
             description = """
-                    Deletes every monitoring location matching the query. At most `limit` entities are affected, so this touches ten entities per call unless a larger `limit` is given.
+                    Deletes every monitoring location matching the query. At most `limit` entities are affected, ten by default.
 
                     For example, `_s=monitoringArea==localhost`. `_s=id==...` does not parse here; the key property is `locationName`.""",
             operationId = "monitoringLocationsDeleteMany")

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MonitoringLocationRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MonitoringLocationRestService.java
@@ -406,7 +406,8 @@ public class MonitoringLocationRestService extends AbstractDaoRestService<OnmsMo
                             examples = @ExampleObject(value = """
                             The ID of the object doesn't match the ID of the path: Other != Default"""))),
             @ApiResponse(responseCode = "404", description = """
-                    No monitoring location has that name, or the body was empty. The response has no body."""),
+                    The body was empty. An unknown name is not a 404: the row is saved as new, so a JSON
+                    or XML PUT to a nonexistent name creates the location and answers 204."""),
             @ApiResponse(responseCode = "501", description = """
                     Reached only by a form-encoded body: updating named properties is not implemented here. The response has no body.""")
     })

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MonitoringSystemsRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MonitoringSystemsRestService.java
@@ -22,6 +22,11 @@
 package org.opennms.web.rest.v2;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.netmgt.dao.api.MonitoringSystemDao;
 import org.opennms.netmgt.model.OnmsMonitoringSystem;
@@ -54,17 +59,45 @@ public class MonitoringSystemsRestService {
     private MonitoringSystemDao dao;
 
     public static class MonitoringSystemResponseDTO {
+        @Schema(description = "The system's id. For the main system this is the instance UUID from `opennms.properties`.",
+                example = "e126608f-9801-4c7f-9369-87179a3ea979")
         public String id;
+
+        @Schema(description = "Human-readable label, usually the host name.", example = "localhost")
         public String label;
+
+        @Schema(description = "Monitoring location the system belongs to.", example = "Default")
         public String location;
+
+        @Schema(description = "System role. The main system reports `OpenNMS`; Minions and Sentinels report their own types.",
+                example = "OpenNMS")
         public String type;
     }
 
     @GET
     @Path("/main")
     @Produces({MediaType.APPLICATION_JSON})
-    @Operation(summary = "Get main monitoring system", description = "Get main monitoring system",
+    @Operation(summary = "Get main monitoring system",
+            description = """
+        Identity of the core OpenNMS instance itself, as opposed to the Minions and Sentinels that also
+        register as monitoring systems. Four fields only: no capabilities or status.""",
             operationId = "MonitoringSystemsRestServiceGetMainMonitoringSystem")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The main monitoring system.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = MonitoringSystemResponseDTO.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "id": "e126608f-9801-4c7f-9369-87179a3ea979",
+                      "label": "localhost",
+                      "location": "Default",
+                      "type": "OpenNMS"
+                    }"""))),
+            @ApiResponse(responseCode = "204", description = "No main monitoring system is registered, which normally means the core has not started fully."),
+            @ApiResponse(responseCode = "500", description = "The lookup failed. The cause is logged, not returned.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error getting monitoring system.")))
+    })
     public Response getMainMonitoringSystem(final @Context HttpServletRequest request) {
         try {
             OnmsMonitoringSystem system = dao.getMainMonitoringSystem();

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MonitoringSystemsRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MonitoringSystemsRestService.java
@@ -80,7 +80,7 @@ public class MonitoringSystemsRestService {
     @Operation(summary = "Get main monitoring system",
             description = """
         Identity of the core OpenNMS instance itself, as opposed to the Minions and Sentinels that also
-        register as monitoring systems. Four fields only: no capabilities or status.""",
+        register as monitoring systems. The response carries `id`, `label`, `location` and `type`.""",
             operationId = "MonitoringSystemsRestServiceGetMainMonitoringSystem")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "The main monitoring system.",
@@ -93,7 +93,7 @@ public class MonitoringSystemsRestService {
                       "location": "Default",
                       "type": "OpenNMS"
                     }"""))),
-            @ApiResponse(responseCode = "204", description = "No main monitoring system is registered, which normally means the core has not started fully."),
+            @ApiResponse(responseCode = "204", description = "No main monitoring system is registered."),
             @ApiResponse(responseCode = "500", description = "The lookup failed. The cause is logged, not returned.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Error getting monitoring system.")))

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NewsFeedRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NewsFeedRestService.java
@@ -53,6 +53,11 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import joptsimple.internal.Strings;
 
@@ -100,7 +105,43 @@ public class NewsFeedRestService {
     @GET
     @Path("/")
     @Produces({MediaType.APPLICATION_JSON})
-    @Operation(summary = "Get news feed", description = "Get news feed", operationId = "NewsFeedRestServiceGetNewsFeed")
+    @Operation(summary = "Get news feed",
+            description = """
+        Fetches an RSS feed server-side and returns it as JSON. The source defaults to
+        `https://www.opennms.com/feed/` and can be overridden with the `opennms.newsFeedPanel.url`
+        system property. Responses are cached in the web tier for five minutes, so repeated calls do
+        not re-fetch and a change at the source can take that long to appear.
+
+        `description` is the feed's raw HTML and `shortDescription` the same text with markup stripped.
+        No publication date is carried through: the items arrive in feed order.
+
+        The call reaches the internet from the OpenNMS host. An install with no outbound access answers
+        500 rather than an empty feed.""",
+            operationId = "NewsFeedRestServiceGetNewsFeed")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The parsed feed.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = NewsFeed.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "items": [
+                        {
+                          "categories": ["News"],
+                          "tags": ["meridian"],
+                          "title": "August 2026 Releases - Meridian 2025.0.9 and 2024.3.12",
+                          "link": "https://www.opennms.com/en/blog/2026-08-12-august-2026-releases/",
+                          "description": "<p>In August, we released updates to all OpenNMS Meridian versions under active support.</p>",
+                          "shortDescription": "In August, we released updates to all OpenNMS Meridian versions under active support."
+                        }
+                      ],
+                      "channelTitle": "The OpenNMS Group, Inc."
+                    }"""))),
+            @ApiResponse(responseCode = "500", description = """
+                    The feed could not be fetched or parsed: an unreachable source, a non-200 from it, or
+                    a body that is not the expected RSS. The cause is logged, not returned.""",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error building news feed.")))
+    })
     public Response getNewsFeed(final @Context HttpServletRequest request) {
         try {
             String responseBody = this.cache.get("newsfeed");

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeCategoriesRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeCategoriesRestService.java
@@ -279,7 +279,7 @@ public class NodeCategoriesRestService extends AbstractNodeDependentRestService<
     @Path("{id}")
     @Operation(
             summary = "Rejected: add a category at a caller-chosen path",
-            description = "Always answered with 404. Post the category to the collection instead; its name travels in the body.",
+            description = "Always answered with 404, whether or not the category exists.",
             operationId = "NodeCategoriesRestServicePOSTCategorySpecific",
             parameters = {
                     @Parameter(in = ParameterIn.PATH, name = "nodeCriteria", required = true,
@@ -300,9 +300,9 @@ public class NodeCategoriesRestService extends AbstractNodeDependentRestService<
             summary = "Add a node to a category",
             description = """
         Add the node to the named surveillance category and send a
-        `nodeCategoryMembershipChanged` event. A category that does not yet exist is created, so a typo
-        silently creates a new category rather than failing. Adding a category the node already has is
-        also a 201. The membership URI is returned in the `Location` header.""",
+        `nodeCategoryMembershipChanged` event. A category that does not yet exist is created. Adding a
+        category the node already has is also a 201. The membership URI is returned in the `Location`
+        header.""",
             operationId = "NodeCategoriesRestServicePOSTCategory",
             parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
                     description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
@@ -346,8 +346,8 @@ public class NodeCategoriesRestService extends AbstractNodeDependentRestService<
         Apply the form parameters as bean properties to a set of category rows. The criteria for this
         resource are not restricted to the node in the path, so the selection is every category in the
         system, capped by the default `limit` of 10. The node in the path affects only the 404 check.
-        `name` is rejected, so in practice this reaches `description`, and it edits the shared category
-        definition rather than anything belonging to this node. Prefer the single-category form.""",
+        `name` is rejected with 400, so the writable property is `description`, and it is written on
+        the shared category definition rather than on anything belonging to this node.""",
             operationId = "NodeCategoriesRestServicePUTCategories",
             parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
                             description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
@@ -378,10 +378,8 @@ public class NodeCategoriesRestService extends AbstractNodeDependentRestService<
     @Operation(
             summary = "Not implemented: replace a category from a document",
             description = """
-        `AbstractDaoRestServiceWithDTO.doUpdate` is not overridden for categories, so this variant
-        cannot succeed. It also binds `{id}` as an integer while the collection addresses categories by
-        name, so a name in the path is answered with 404 before the handler runs. Use the form-encoded
-        `PUT` on the same path to change the description.""",
+        Answered with 501. This variant binds `{id}` as an integer while the collection addresses
+        categories by name, so a name in the path is answered with 404 before the handler runs.""",
             operationId = "NodeCategoriesRestServicePUTCategoryDocument",
             parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
                             description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
@@ -453,8 +451,7 @@ public class NodeCategoriesRestService extends AbstractNodeDependentRestService<
         Delete category rows outright. The criteria for this resource are not restricted to the node in
         the path, so the selection is every category in the system, capped by the default `limit` of 10.
         Each deletion removes the shared category definition and therefore its membership on every node,
-        not only on the node in the path. There is no confirmation step and no filter that narrows this
-        to one node, so prefer the single-category form.""",
+        not only on the node in the path.""",
             operationId = "NodeCategoriesRestServiceDELETECategories",
             parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
                             description = "Node database id, or `foreignSource:foreignId`.", example = "257"))

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeCategoriesRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeCategoriesRestService.java
@@ -345,7 +345,7 @@ public class NodeCategoriesRestService extends AbstractNodeDependentRestService<
             description = """
         Apply the form parameters as bean properties to a set of category rows. The criteria for this
         resource are not restricted to the node in the path, so the selection is every category in the
-        system, capped by the default `limit` of 10. The node in the path affects only the 404 check.
+        system, capped by the default `limit` of 10. This route never reads the node segment at all.
         `name` is rejected with 400, so the writable property is `description`, and it is written on
         the shared category definition rather than on anything belonging to this node.""",
             operationId = "NodeCategoriesRestServicePUTCategories",
@@ -362,10 +362,9 @@ public class NodeCategoriesRestService extends AbstractNodeDependentRestService<
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Cannot rename category."))),
             @ApiResponse(responseCode = "404", description = "No category row matched. No body is returned."),
-            @ApiResponse(responseCode = "500", description = "The node path segment is neither a number nor `foreignSource:foreignId`.",
+            @ApiResponse(responseCode = "500", description = "The `_s` search expression did not parse. The node segment is never parsed on this route, so a bad node segment alone is not an error.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN,
-                            schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+                            schema = @Schema(type = "string")))
     })
     @Override
     public Response updateMany(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo, @Context final SearchContext searchContext, final MultivaluedMapImpl params) {
@@ -458,7 +457,7 @@ public class NodeCategoriesRestService extends AbstractNodeDependentRestService<
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "The selected category rows were deleted."),
             @ApiResponse(responseCode = "404", description = "No category row matched. No body is returned."),
-            @ApiResponse(responseCode = "500", description = "The node path segment is neither a number nor `foreignSource:foreignId`.",
+            @ApiResponse(responseCode = "500", description = "The node path segment is neither a number nor `foreignSource:foreignId`, the node id is valid but names no node while at least one category matched, or the `_s` search expression did not parse.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "For input string: \"notanumber\"")))

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeCategoriesRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeCategoriesRestService.java
@@ -24,15 +24,32 @@ package org.opennms.web.rest.v2;
 import java.util.Collection;
 import java.util.Optional;
 
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 import org.apache.cxf.jaxrs.ext.search.SearchContext;
 import org.opennms.core.config.api.JaxbListWrapper;
@@ -100,6 +117,48 @@ public class NodeCategoriesRestService extends AbstractNodeDependentRestService<
 
     @GET
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get the categories of a node",
+            description = """
+        Return the surveillance categories the node belongs to. This operation reads the node's category
+        set directly, so `_s`, `limit`, `offset`, `orderBy` and `order` are accepted but have no effect
+        and the whole set is always returned. The order is the set's iteration order, which is not
+        stable across calls.
+
+        A node with no categories gives a 200 whose `totalCount` and `count` are `null` rather than
+        `0`.""",
+            operationId = "NodeCategoriesRestServiceGETCategories",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                    description = "Node database id, or `foreignSource:foreignId`. A value that is neither is answered with 500.", example = "257"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The node's categories.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsCategoryCollection.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 2,
+                      "count": 2,
+                      "offset": 0,
+                      "category": [
+                        {"id": 1, "authorizedGroups": [], "name": "Routers"},
+                        {"id": 4, "authorizedGroups": [], "name": "Production"}
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsCategoryCollection.class),
+                                    examples = @ExampleObject(value = """
+                    <categories count="2" offset="0" totalCount="2">
+                      <category id="1" name="Routers"/>
+                      <category id="4" name="Production"/>
+                    </categories>"""))
+                    }),
+            @ApiResponse(responseCode = "404", description = "No such node. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The node path segment is neither a number nor `foreignSource:foreignId`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
     public Response get(@Context final UriInfo uriInfo, @Context final SearchContext searchContext) {
         final OnmsNode node = getNode(uriInfo);
         if (node == null) return Response.status(Status.NOT_FOUND).build();
@@ -109,10 +168,336 @@ public class NodeCategoriesRestService extends AbstractNodeDependentRestService<
     @GET
     @Path("count")
     @Produces({MediaType.TEXT_PLAIN})
+    @Operation(
+            summary = "Count the categories of a node",
+            description = """
+        Return the size of the node's category set as a bare decimal string. `_s` is accepted but has no
+        effect, so this is not a filtered count.""",
+            operationId = "NodeCategoriesRestServiceGETCategoryCount",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                    description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Number of categories the node belongs to.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "2"))),
+            @ApiResponse(responseCode = "404", description = "No such node. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The node path segment is neither a number nor `foreignSource:foreignId`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
     public Response getCount(@Context final UriInfo uriInfo, @Context final SearchContext searchContext) {
         final OnmsNode node = getNode(uriInfo);
         if (node == null) return Response.status(Status.NOT_FOUND).build();
         return Response.ok(node.getCategories().size()).build();
+    }
+
+    // The generic operations below are inherited from AbstractDaoRestServiceWithDTO. They are
+    // overridden here only so that each concrete path carries its own OpenAPI documentation; the
+    // bodies delegate unchanged.
+    @GET
+    @Path("properties")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Operation(
+            summary = "Get category search properties",
+            description = """
+        This resource declares no search property set, so the operation answers 204 with no body. The
+        category collection ignores `_s` in any case.""",
+            operationId = "NodeCategoriesRestServiceGETCategorySearchProperties",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @ApiResponse(responseCode = "204", description = "No search properties are declared for this resource. No body is returned.")
+    @Override
+    public Response getProperties(
+            @Parameter(in = ParameterIn.QUERY, name = "q",
+                    description = "Case-insensitive substring matched against the property `name`, not its id. Has no effect while the property set is empty.", example = "Name")
+            @QueryParam("q") final String query) {
+        return super.getProperties(query);
+    }
+
+    @GET
+    @Path("properties/{propertyId}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Operation(
+            summary = "Get values of a category search property",
+            description = "Answered with 404 for every `propertyId`, because this resource declares no search property set.",
+            operationId = "NodeCategoriesRestServiceGETCategorySearchPropertyValues",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @ApiResponse(responseCode = "404", description = "No search property has that id. No body is returned.")
+    @Override
+    public Response getPropertyValues(
+            @Parameter(in = ParameterIn.PATH, name = "propertyId", description = "Property id.", example = "name")
+            @PathParam("propertyId") final String propertyId,
+            @Parameter(in = ParameterIn.QUERY, name = "q", description = "Substring the value must contain.", example = "Rout")
+            @QueryParam("q") final String query,
+            @Parameter(in = ParameterIn.QUERY, name = "limit", description = "Maximum number of values to return.", example = "10")
+            @QueryParam("limit") final Integer limit) {
+        return super.getPropertyValues(propertyId, query, limit);
+    }
+
+    @GET
+    @Path("{id}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get one category of a node",
+            description = """
+        Return the named category if the node belongs to it. The name is matched exactly and
+        case-sensitively. A category that exists in the system but is not on this node is a 404.""",
+            operationId = "NodeCategoriesRestServiceGETCategoryByName",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The category.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsCategory.class),
+                                    examples = @ExampleObject(value = """
+                    {"id": 1, "authorizedGroups": [], "name": "Routers"}""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsCategory.class),
+                                    examples = @ExampleObject(value = """
+                    <category id="1" name="Routers"/>"""))
+                    }),
+            @ApiResponse(responseCode = "404", description = "The node does not belong to a category with that name. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The node path segment is neither a number nor `foreignSource:foreignId`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    @Override
+    public Response get(
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "id",
+                    description = "Category name, not its database id.", example = "Routers")
+            @PathParam("id") final String id) {
+        return super.get(uriInfo, id);
+    }
+
+    @POST
+    @Path("{id}")
+    @Operation(
+            summary = "Rejected: add a category at a caller-chosen path",
+            description = "Always answered with 404. Post the category to the collection instead; its name travels in the body.",
+            operationId = "NodeCategoriesRestServicePOSTCategorySpecific",
+            parameters = {
+                    @Parameter(in = ParameterIn.PATH, name = "nodeCriteria", required = true,
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"),
+                    @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                            description = "Category name. The value is not read: every request to this path is answered with 404.",
+                            example = "Routers")
+            })
+    @ApiResponse(responseCode = "404", description = "Not supported. No body is returned.")
+    @Override
+    public Response createSpecific() {
+        return super.createSpecific();
+    }
+
+    @POST
+    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Operation(
+            summary = "Add a node to a category",
+            description = """
+        Add the node to the named surveillance category and send a
+        `nodeCategoryMembershipChanged` event. A category that does not yet exist is created, so a typo
+        silently creates a new category rather than failing. Adding a category the node already has is
+        also a 201. The membership URI is returned in the `Location` header.""",
+            operationId = "NodeCategoriesRestServicePOSTCategory",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                    description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @RequestBody(required = true, description = "The category to add. Only `name` is read.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsCategory.class),
+                            examples = @ExampleObject(value = """
+                    {"name": "Production"}""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = OnmsCategory.class),
+                            examples = @ExampleObject(value = """
+                    <category name="Production"/>"""))
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "The node was added to the category. `Location` carries the membership URI.",
+                    headers = @Header(name = "Location", description = "URI of the category on this node.",
+                            schema = @Schema(type = "string", example = "http://localhost:8980/opennms/api/v2/nodes/257/categories/Production"))),
+            @ApiResponse(responseCode = "400", description = "The node was not found, or the body carried no category name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "no name", value = "Category's name cannot be null"),
+                                    @ExampleObject(name = "no node", value = "Node was not found.")
+                            })),
+            @ApiResponse(responseCode = "500", description = "The node path segment could not be parsed, or the body could not be deserialised.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    @Override
+    public Response create(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo, final OnmsCategory object) {
+        return super.create(securityContext, uriInfo, object);
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Operation(
+            summary = "Update properties of several categories",
+            description = """
+        Apply the form parameters as bean properties to a set of category rows. The criteria for this
+        resource are not restricted to the node in the path, so the selection is every category in the
+        system, capped by the default `limit` of 10. The node in the path affects only the 404 check.
+        `name` is rejected, so in practice this reaches `description`, and it edits the shared category
+        definition rather than anything belonging to this node. Prefer the single-category form.""",
+            operationId = "NodeCategoriesRestServicePUTCategories",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @RequestBody(required = true, description = "Category bean properties to set, form-encoded. `name` is rejected.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "object"),
+                    examples = @ExampleObject(value = "description=Managed+by+the+network+team")))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The selected category rows were updated."),
+            @ApiResponse(responseCode = "400", description = "The body tried to change `name`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot rename category."))),
+            @ApiResponse(responseCode = "404", description = "No category row matched. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The node path segment is neither a number nor `foreignSource:foreignId`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    @Override
+    public Response updateMany(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo, @Context final SearchContext searchContext, final MultivaluedMapImpl params) {
+        return super.updateMany(securityContext, uriInfo, searchContext, params);
+    }
+
+    @PUT
+    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Path("{id}")
+    @Operation(
+            summary = "Not implemented: replace a category from a document",
+            description = """
+        `AbstractDaoRestServiceWithDTO.doUpdate` is not overridden for categories, so this variant
+        cannot succeed. It also binds `{id}` as an integer while the collection addresses categories by
+        name, so a name in the path is answered with 404 before the handler runs. Use the form-encoded
+        `PUT` on the same path to change the description.""",
+            operationId = "NodeCategoriesRestServicePUTCategoryDocument",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @RequestBody(description = "Ignored.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = OnmsCategory.class),
+                            examples = @ExampleObject(value = "{\"name\": \"Routers\"}")),
+                    @Content(mediaType = MediaType.APPLICATION_XML, schema = @Schema(implementation = OnmsCategory.class),
+                            examples = @ExampleObject(value = "<category name=\"Routers\"/>"))
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = "`{id}` is not an integer, which is the case for every category name."),
+            @ApiResponse(responseCode = "501", description = "Replacing a category from a document is not implemented. No body is returned.")
+    })
+    @Override
+    public Response update(
+            @Context final SecurityContext securityContext,
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "id",
+                    description = "Bound as an integer here, unlike every other operation on this path.", example = "1")
+            @PathParam("id") final Integer id,
+            final OnmsCategory object) {
+        return super.update(securityContext, uriInfo, id, object);
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Path("{id}")
+    @Operation(
+            summary = "Update properties of a category",
+            description = """
+        Apply the form parameters as bean properties to the named category. The node in the path selects
+        the category and is checked for membership, but the row that is written is the shared category
+        definition, so the change is visible on every node in that category. `name` is rejected.""",
+            operationId = "NodeCategoriesRestServicePUTCategoryProperties",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @RequestBody(required = true, description = "Category bean properties to set, form-encoded. `name` is rejected.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "object"),
+                    examples = @ExampleObject(value = "description=Managed+by+the+network+team")))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The category was updated."),
+            @ApiResponse(responseCode = "400", description = "The body tried to change `name`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot rename category."))),
+            @ApiResponse(responseCode = "404", description = "The node does not belong to a category with that name. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The node path segment is neither a number nor `foreignSource:foreignId`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    @Override
+    public Response updateProperties(
+            @Context final SecurityContext securityContext,
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "id",
+                    description = "Category name.", example = "Routers")
+            @PathParam("id") final String id,
+            final MultivaluedMapImpl params) {
+        return super.updateProperties(securityContext, uriInfo, id, params);
+    }
+
+    @DELETE
+    @Operation(
+            summary = "Delete several categories",
+            description = """
+        Delete category rows outright. The criteria for this resource are not restricted to the node in
+        the path, so the selection is every category in the system, capped by the default `limit` of 10.
+        Each deletion removes the shared category definition and therefore its membership on every node,
+        not only on the node in the path. There is no confirmation step and no filter that narrows this
+        to one node, so prefer the single-category form.""",
+            operationId = "NodeCategoriesRestServiceDELETECategories",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The selected category rows were deleted."),
+            @ApiResponse(responseCode = "404", description = "No category row matched. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The node path segment is neither a number nor `foreignSource:foreignId`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    @Override
+    public Response deleteMany(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo, @Context final SearchContext searchContext) {
+        return super.deleteMany(securityContext, uriInfo, searchContext);
+    }
+
+    @DELETE
+    @Path("{id}")
+    @Operation(
+            summary = "Delete a category",
+            description = """
+        Remove the named category from the node and then delete the category row itself, so the category
+        disappears from every other node that carried it as well. A `nodeCategoryMembershipChanged`
+        event is sent for the node in the path only.""",
+            operationId = "NodeCategoriesRestServiceDELETECategoryByName",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The category was deleted."),
+            @ApiResponse(responseCode = "404", description = "The node does not belong to a category with that name. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The node path segment is neither a number nor `foreignSource:foreignId`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    @Override
+    public Response delete(
+            @Context final SecurityContext securityContext,
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "id",
+                    description = "Category name.", example = "ApiDoc-Cat")
+            @PathParam("id") final String id) {
+        return super.delete(securityContext, uriInfo, id);
     }
 
     @Override

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeIpInterfacesRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeIpInterfacesRestService.java
@@ -207,8 +207,8 @@ public class NodeIpInterfacesRestService extends AbstractNodeDependentRestServic
 
         `isDown` and `monitoredServiceCount` are derived, not stored. In JSON `id` is a string while
         `nodeId` is a number, and `lastIngressFlow` and `lastEgressFlow` are epoch milliseconds rather
-        than the `string/date-time` the derived schema shows. A FIQL term on `ipAddress` is rejected
-        with 500; filter on `ipHostName` or `isManaged` instead.
+        than the `string/date-time` the derived schema shows. A FIQL term on `ipAddress` is answered
+        with 500, while `ipHostName` and `isManaged` resolve.
 
         Example query: `_s=isManaged==M&orderBy=ipHostName`.""",
             operationId = "NodeIpInterfacesRestServiceGETIpInterfaces",
@@ -296,8 +296,7 @@ public class NodeIpInterfacesRestService extends AbstractNodeDependentRestServic
             summary = "Get IP interface search properties",
             description = """
         List the properties that may appear in a `_s` expression or in `orderBy` for this resource. The
-        set spans the interface, its SNMP interface, its monitored services and the owning node, so it
-        is wider than the fields of the interface itself.""",
+        set spans the interface, its SNMP interface, its monitored services and the owning node.""",
             operationId = "NodeIpInterfacesRestServiceGETIpInterfaceSearchProperties",
             parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
                             description = "Node database id, or `foreignSource:foreignId`. The property list does not depend on it.", example = "257"))
@@ -412,7 +411,7 @@ public class NodeIpInterfacesRestService extends AbstractNodeDependentRestServic
     @Path("{id}")
     @Operation(
             summary = "Rejected: create an IP interface at a caller-chosen path",
-            description = "Always answered with 404. Post the interface to the collection instead; its address travels in the body.",
+            description = "Always answered with 404, whether or not the address exists.",
             operationId = "NodeIpInterfacesRestServicePOSTIpInterfaceSpecific",
             parameters = {
                     @Parameter(in = ParameterIn.PATH, name = "nodeCriteria", required = true,
@@ -519,10 +518,9 @@ public class NodeIpInterfacesRestService extends AbstractNodeDependentRestServic
     @Operation(
             summary = "Not implemented: replace an IP interface from a document",
             description = """
-        `AbstractDaoRestServiceWithDTO.doUpdate` is not overridden for IP interfaces, so this variant
-        cannot succeed. It also binds `{id}` as an integer while the collection addresses interfaces by
-        IP address, so an address in the path is answered with 404 before the handler runs. Use the
-        form-encoded `PUT` on the same path to change properties.""",
+        Answered with 501. This variant binds `{id}` as an integer while the collection addresses
+        interfaces by IP address, so an address in the path is answered with 404 before the handler
+        runs.""",
             operationId = "NodeIpInterfacesRestServicePUTIpInterfaceDocument",
             parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
                             description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
@@ -555,9 +553,8 @@ public class NodeIpInterfacesRestService extends AbstractNodeDependentRestServic
             summary = "Update properties of an IP interface",
             description = """
         Apply the form parameters as bean properties to one IP interface of the node. Only the
-        properties present in the body are touched. `ipAddress` is rejected: delete the interface and
-        add it again to renumber it. No event is sent, so daemons holding the previous value are not
-        notified.""",
+        properties present in the body are touched. `ipAddress` is answered with 400. No event is
+        sent.""",
             operationId = "NodeIpInterfacesRestServicePUTIpInterfaceProperties",
             parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
                             description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
@@ -906,8 +903,8 @@ public class NodeIpInterfacesRestService extends AbstractNodeDependentRestServic
             summary = "Add or replace a metadata entry of an IP interface",
             description = """
         Set one metadata entry on the interface from the request body. An existing entry with the same
-        context and key is overwritten, so this is an upsert rather than an append. No `@Consumes` is
-        declared, so both JSON and XML bodies are accepted; the XML root element is `meta-data`.""",
+        context and key is overwritten. No `@Consumes` is declared, so both JSON and XML bodies are
+        accepted; the XML root element is `meta-data`.""",
             operationId = "NodeIpInterfacesRestServicePOSTMetaDataByIpAddress",
             parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
                             description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
@@ -968,8 +965,7 @@ public class NodeIpInterfacesRestService extends AbstractNodeDependentRestServic
             description = """
         Set one metadata entry on the interface with context, key and value all taken from the path. An
         existing entry with the same context and key is overwritten. A value containing `/` has to be
-        percent-encoded, and an empty value cannot be expressed this way; use the `POST` form for
-        those.""",
+        percent-encoded, and an empty value cannot be expressed this way.""",
             operationId = "NodeIpInterfacesRestServicePUTMetaDataByIpAddress",
             parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
                             description = "Node database id, or `foreignSource:foreignId`.", example = "257"))

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeIpInterfacesRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeIpInterfacesRestService.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -32,6 +33,7 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.container.ResourceContext;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
@@ -40,6 +42,18 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import org.apache.cxf.jaxrs.ext.search.SearchContext;
 import org.opennms.core.config.api.JaxbListWrapper;
 import org.opennms.core.criteria.Alias.JoinType;
 import org.opennms.core.criteria.CriteriaBuilder;
@@ -57,6 +71,8 @@ import org.opennms.web.rest.support.MultivaluedMapImpl;
 import org.opennms.web.rest.support.RedirectHelper;
 import org.opennms.web.rest.support.SearchProperties;
 import org.opennms.web.rest.support.SearchProperty;
+import org.opennms.web.rest.support.SearchPropertyCollection;
+import org.opennms.web.rest.support.StringCollection;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -178,10 +194,498 @@ public class NodeIpInterfacesRestService extends AbstractNodeDependentRestServic
         return node.getIpInterfaceByIpAddress(ipAddress);
     }
 
+    // The generic collection and item operations below are inherited from AbstractDaoRestServiceWithDTO.
+    // They are overridden here only so that each concrete path carries its own OpenAPI documentation;
+    // the bodies delegate unchanged.
+    @GET
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get the IP interfaces of a node",
+            description = """
+        Return the node's IP interfaces. The criteria are restricted to the node in the path, so `_s`
+        narrows within the node rather than across the system. `limit` defaults to 10.
+
+        `isDown` and `monitoredServiceCount` are derived, not stored. In JSON `id` is a string while
+        `nodeId` is a number, and `lastIngressFlow` and `lastEgressFlow` are epoch milliseconds rather
+        than the `string/date-time` the derived schema shows. A FIQL term on `ipAddress` is rejected
+        with 500; filter on `ipHostName` or `isManaged` instead.
+
+        Example query: `_s=isManaged==M&orderBy=ipHostName`.""",
+            operationId = "NodeIpInterfacesRestServiceGETIpInterfaces",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`. A value that is neither is answered with 500.", example = "257"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Matching IP interfaces.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsIpInterfaceList.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 1,
+                      "count": 1,
+                      "offset": 0,
+                      "ipInterface": [
+                        {
+                          "id": "23615",
+                          "nodeId": 257,
+                          "ipAddress": "192.0.2.31",
+                          "hostName": "apidoc.example.org",
+                          "ifIndex": null,
+                          "isManaged": "M",
+                          "snmpPrimary": "P",
+                          "monitoredServiceCount": 0,
+                          "isDown": true,
+                          "lastIngressFlow": null,
+                          "lastEgressFlow": null
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsIpInterfaceList.class),
+                                    examples = @ExampleObject(value = """
+                    <ipInterfaces count="1" offset="0" totalCount="1">
+                      <ipInterface isDown="true" id="23615" isManaged="M" monitoredServiceCount="0" snmpPrimary="P">
+                        <ipAddress>192.0.2.31</ipAddress>
+                        <hostName>apidoc.example.org</hostName>
+                        <nodeId>257</nodeId>
+                      </ipInterface>
+                    </ipInterfaces>"""))
+                    }),
+            @ApiResponse(responseCode = "204", description = "The node has no matching IP interface. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The node path segment could not be parsed, or the FIQL expression could not be parsed or resolved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    @Override
+    public Response get(@Context final UriInfo uriInfo, @Context final SearchContext searchContext) {
+        return super.get(uriInfo, searchContext);
+    }
+
+    @GET
+    @Path("count")
+    @Produces({MediaType.TEXT_PLAIN})
+    @Operation(
+            summary = "Count the IP interfaces of a node",
+            description = """
+        Return the number of the node's IP interfaces matching `_s` as a bare decimal string.
+
+        Example query: `_s=isManaged==M`.""",
+            operationId = "NodeIpInterfacesRestServiceGETIpInterfaceCount",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Number of matching IP interfaces.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "2"))),
+            @ApiResponse(responseCode = "500", description = "The node path segment could not be parsed, or the FIQL expression could not be parsed or resolved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    @Override
+    public Response getCount(@Context final UriInfo uriInfo, @Context final SearchContext searchContext) {
+        return super.getCount(uriInfo, searchContext);
+    }
+
+    @GET
+    @Path("properties")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Operation(
+            summary = "Get IP interface search properties",
+            description = """
+        List the properties that may appear in a `_s` expression or in `orderBy` for this resource. The
+        set spans the interface, its SNMP interface, its monitored services and the owning node, so it
+        is wider than the fields of the interface itself.""",
+            operationId = "NodeIpInterfacesRestServiceGETIpInterfaceSearchProperties",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`. The property list does not depend on it.", example = "257"))
+    @ApiResponse(responseCode = "200", description = "Supported search properties.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = SearchPropertyCollection.class),
+                    examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 2,
+                      "count": 2,
+                      "offset": 0,
+                      "searchProperty": [
+                        {"id": "ipHostName", "name": "Hostname", "type": "STRING", "orderBy": true, "iplike": false},
+                        {"id": "isManaged", "name": "Management Status", "type": "STRING", "orderBy": true, "iplike": false}
+                      ]
+                    }""")))
+    @Override
+    public Response getProperties(
+            @Parameter(in = ParameterIn.QUERY, name = "q",
+                    description = "Case-insensitive substring matched against the property `name`, not its id.", example = "Managed")
+            @QueryParam("q") final String query) {
+        return super.getProperties(query);
+    }
+
+    @GET
+    @Path("properties/{propertyId}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Operation(
+            summary = "Get values of an IP interface search property",
+            description = """
+        Return the distinct values a search property takes. The values are read from the whole table
+        rather than from the interfaces of the node in the path.""",
+            operationId = "NodeIpInterfacesRestServiceGETIpInterfaceSearchPropertyValues",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Distinct values of the property.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = StringCollection.class),
+                            examples = @ExampleObject(value = """
+                    {"totalCount": 2, "count": 2, "offset": 0, "value": ["M", "U"]}"""))),
+            @ApiResponse(responseCode = "404", description = "No search property has that id. No body is returned.")
+    })
+    @Override
+    public Response getPropertyValues(
+            @Parameter(in = ParameterIn.PATH, name = "propertyId",
+                    description = "Property id as reported by the `properties` operation.", example = "isManaged")
+            @PathParam("propertyId") final String propertyId,
+            @Parameter(in = ParameterIn.QUERY, name = "q", description = "Substring the value must contain.", example = "M")
+            @QueryParam("q") final String query,
+            @Parameter(in = ParameterIn.QUERY, name = "limit", description = "Maximum number of values to return.", example = "10")
+            @QueryParam("limit") final Integer limit) {
+        return super.getPropertyValues(propertyId, query, limit);
+    }
+
+    @GET
+    @Path("{id}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get an IP interface of a node",
+            description = """
+        Return one IP interface of the node, addressed by its IP address rather than by its database
+        id. The address has to match the stored form exactly; there is no wildcard or hostname
+        lookup.""",
+            operationId = "NodeIpInterfacesRestServiceGETIpInterfaceByAddress",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The IP interface.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsIpInterface.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "id": "23615",
+                      "nodeId": 257,
+                      "ipAddress": "192.0.2.31",
+                      "hostName": "apidoc.example.org",
+                      "ifIndex": null,
+                      "isManaged": "M",
+                      "snmpPrimary": "P",
+                      "monitoredServiceCount": 0,
+                      "isDown": true,
+                      "lastIngressFlow": null,
+                      "lastEgressFlow": null
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsIpInterface.class),
+                                    examples = @ExampleObject(value = """
+                    <ipInterface isDown="true" id="23615" isManaged="M" monitoredServiceCount="0" snmpPrimary="P">
+                      <ipAddress>192.0.2.31</ipAddress>
+                      <hostName>apidoc.example.org</hostName>
+                      <nodeId>257</nodeId>
+                    </ipInterface>"""))
+                    }),
+            @ApiResponse(responseCode = "404", description = "The node has no interface with that address. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The node path segment is neither a number nor `foreignSource:foreignId`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    @Override
+    public Response get(
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "id",
+                    description = "IP address of the interface, not its database id.", example = "192.0.2.31")
+            @PathParam("id") final String id) {
+        return super.get(uriInfo, id);
+    }
+
+    @POST
+    @Path("{id}")
+    @Operation(
+            summary = "Rejected: create an IP interface at a caller-chosen path",
+            description = "Always answered with 404. Post the interface to the collection instead; its address travels in the body.",
+            operationId = "NodeIpInterfacesRestServicePOSTIpInterfaceSpecific",
+            parameters = {
+                    @Parameter(in = ParameterIn.PATH, name = "nodeCriteria", required = true,
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"),
+                    @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                            description = "IP address of the interface. The value is not read: every request to this path is answered with 404.",
+                            example = "192.0.2.31")
+            })
+    @ApiResponse(responseCode = "404", description = "Not supported. No body is returned.")
+    @Override
+    public Response createSpecific() {
+        return super.createSpecific();
+    }
+
+    @POST
+    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Operation(
+            summary = "Add an IP interface to a node",
+            description = """
+        Attach an IP interface to the node and send a `nodeGainedInterface` event. `ipAddress` is the
+        only required field. Set `snmpPrimary` to `P` to make the interface the node's primary SNMP
+        address, `S` for secondary, `N` for not eligible. `isManaged` of `M` marks the interface as
+        managed and `U` as unmanaged. The new interface's URI is returned in the `Location` header.""",
+            operationId = "NodeIpInterfacesRestServicePOSTIpInterface",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                    description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @RequestBody(required = true, description = "The IP interface to add.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsIpInterface.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "ipAddress": "192.0.2.31",
+                      "hostName": "apidoc.example.org",
+                      "isManaged": "M",
+                      "snmpPrimary": "P"
+                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = OnmsIpInterface.class),
+                            examples = @ExampleObject(value = """
+                    <ipInterface isManaged="M" snmpPrimary="P">
+                      <ipAddress>192.0.2.31</ipAddress>
+                      <hostName>apidoc.example.org</hostName>
+                    </ipInterface>"""))
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "The interface was added. `Location` carries its URI.",
+                    headers = @Header(name = "Location", description = "URI of the created IP interface.",
+                            schema = @Schema(type = "string", example = "http://localhost:8980/opennms/api/v2/nodes/257/ipinterfaces/192.0.2.31"))),
+            @ApiResponse(responseCode = "400", description = "The node was not found, or the body carried no usable IP address.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "no address", value = "IP Interface's ipAddress cannot be null"),
+                                    @ExampleObject(name = "no node", value = "Node was not found.")
+                            })),
+            @ApiResponse(responseCode = "500", description = "The node path segment could not be parsed, or the body could not be deserialised.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    @Override
+    public Response create(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo, final OnmsIpInterface object) {
+        return super.create(securityContext, uriInfo, object);
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Operation(
+            summary = "Update properties of several IP interfaces of a node",
+            description = """
+        Apply the form parameters as bean properties to every IP interface of the node matching `_s`.
+        The default `limit` of 10 applies to the selection. `ipAddress` cannot be set this way. The
+        whole call runs in one transaction, so a per-interface failure aborts the batch.
+
+        Example query: `_s=isManaged==U&limit=100`.""",
+            operationId = "NodeIpInterfacesRestServicePUTIpInterfaces",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @RequestBody(required = true, description = "IP interface bean properties to set, form-encoded.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "object"),
+                    examples = @ExampleObject(value = "is-managed=M")))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "All selected interfaces were updated."),
+            @ApiResponse(responseCode = "400", description = "The body tried to change `ipAddress`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot change the IP address."))),
+            @ApiResponse(responseCode = "404", description = "No interface matched. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The node path segment could not be parsed, or the FIQL expression could not be parsed or resolved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    @Override
+    public Response updateMany(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo, @Context final SearchContext searchContext, final MultivaluedMapImpl params) {
+        return super.updateMany(securityContext, uriInfo, searchContext, params);
+    }
+
+    @PUT
+    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Path("{id}")
+    @Operation(
+            summary = "Not implemented: replace an IP interface from a document",
+            description = """
+        `AbstractDaoRestServiceWithDTO.doUpdate` is not overridden for IP interfaces, so this variant
+        cannot succeed. It also binds `{id}` as an integer while the collection addresses interfaces by
+        IP address, so an address in the path is answered with 404 before the handler runs. Use the
+        form-encoded `PUT` on the same path to change properties.""",
+            operationId = "NodeIpInterfacesRestServicePUTIpInterfaceDocument",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @RequestBody(description = "Ignored.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = OnmsIpInterface.class),
+                            examples = @ExampleObject(value = "{\"isManaged\": \"M\"}")),
+                    @Content(mediaType = MediaType.APPLICATION_XML, schema = @Schema(implementation = OnmsIpInterface.class),
+                            examples = @ExampleObject(value = "<ipInterface isManaged=\"M\"/>"))
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = "`{id}` is not an integer, which is the case for every IP address."),
+            @ApiResponse(responseCode = "501", description = "Replacing an IP interface from a document is not implemented. No body is returned.")
+    })
+    @Override
+    public Response update(
+            @Context final SecurityContext securityContext,
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "id",
+                    description = "Bound as an integer here, unlike every other operation on this path.", example = "23615")
+            @PathParam("id") final Integer id,
+            final OnmsIpInterface object) {
+        return super.update(securityContext, uriInfo, id, object);
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Path("{id}")
+    @Operation(
+            summary = "Update properties of an IP interface",
+            description = """
+        Apply the form parameters as bean properties to one IP interface of the node. Only the
+        properties present in the body are touched. `ipAddress` is rejected: delete the interface and
+        add it again to renumber it. No event is sent, so daemons holding the previous value are not
+        notified.""",
+            operationId = "NodeIpInterfacesRestServicePUTIpInterfaceProperties",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @RequestBody(required = true, description = "IP interface bean properties to set, form-encoded.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "object"),
+                    examples = @ExampleObject(value = "ip-host-name=apidoc-renamed.example.org&is-managed=M")))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The interface was updated."),
+            @ApiResponse(responseCode = "400", description = "The body tried to change `ipAddress`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot change the IP address."))),
+            @ApiResponse(responseCode = "404", description = "The node has no interface with that address. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The node path segment is neither a number nor `foreignSource:foreignId`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    @Override
+    public Response updateProperties(
+            @Context final SecurityContext securityContext,
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "id",
+                    description = "IP address of the interface.", example = "192.0.2.31")
+            @PathParam("id") final String id,
+            final MultivaluedMapImpl params) {
+        return super.updateProperties(securityContext, uriInfo, id, params);
+    }
+
+    @DELETE
+    @Operation(
+            summary = "Delete several IP interfaces of a node",
+            description = """
+        Delete every IP interface of the node matching `_s` and send a `deleteInterface` event for each.
+        The default `limit` of 10 applies to the selection, so a call without an explicit `limit`
+        deletes at most 10 interfaces. The interfaces' monitored services and metadata go with them.
+
+        Example query: `_s=isManaged==U&limit=100`.""",
+            operationId = "NodeIpInterfacesRestServiceDELETEIpInterfaces",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The selected interfaces were deleted."),
+            @ApiResponse(responseCode = "404", description = "No interface matched. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The node path segment could not be parsed, or the FIQL expression could not be parsed or resolved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    @Override
+    public Response deleteMany(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo, @Context final SearchContext searchContext) {
+        return super.deleteMany(securityContext, uriInfo, searchContext);
+    }
+
+    @DELETE
+    @Path("{id}")
+    @Operation(
+            summary = "Delete an IP interface",
+            description = """
+        Delete one IP interface of the node and send a `deleteInterface` event. Its monitored services
+        and metadata go with it.""",
+            operationId = "NodeIpInterfacesRestServiceDELETEIpInterfaceByAddress",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The interface was deleted."),
+            @ApiResponse(responseCode = "404", description = "The node has no interface with that address. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The node path segment is neither a number nor `foreignSource:foreignId`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    @Override
+    public Response delete(
+            @Context final SecurityContext securityContext,
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "id",
+                    description = "IP address of the interface.", example = "192.0.2.31")
+            @PathParam("id") final String id) {
+        return super.delete(securityContext, uriInfo, id);
+    }
+
     @GET
     @Path("{ipAddress}/metadata")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
-    public OnmsMetaDataList getMetaData(@Context final UriInfo uriInfo, @PathParam("ipAddress") String ipAddress) {
+    @Operation(
+            summary = "Get all metadata of an IP interface",
+            description = """
+        Return every metadata entry attached to the interface, across all contexts. An empty result is
+        still a 200; `totalCount` and `count` are then `null` rather than `0`. A node that does not
+        exist is answered with 500 rather than 400.""",
+            operationId = "NodeIpInterfacesRestServiceGETMetaDataByIpAddress",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Metadata entries of the interface.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsMetaDataList.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 1,
+                      "count": 1,
+                      "offset": 0,
+                      "metaData": [{"context": "X-ApiDoc", "key": "vlan", "value": "42"}]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsMetaDataList.class),
+                                    examples = @ExampleObject(value = """
+                    <meta-data-list count="1" offset="0" totalCount="1">
+                      <meta-data><context>X-ApiDoc</context><key>vlan</key><value>42</value></meta-data>
+                    </meta-data-list>"""))
+                    }),
+            @ApiResponse(responseCode = "400", description = "The node has no interface with that address.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "getMetaData: Can't find interface 198.51.100.99"))),
+            @ApiResponse(responseCode = "500", description = "The node does not exist, or the node path segment is neither a number nor `foreignSource:foreignId`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot invoke \"org.opennms.netmgt.model.OnmsNode.getIpInterfaceByIpAddress(String)\" because \"node\" is null")))
+    })
+    public OnmsMetaDataList getMetaData(
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "ipAddress",
+                    description = "IP address of the interface.", example = "192.0.2.31")
+            @PathParam("ipAddress") String ipAddress) {
         final OnmsIpInterface intf = getInterface(uriInfo, ipAddress);
 
         if (intf == null) {
@@ -194,7 +698,42 @@ public class NodeIpInterfacesRestService extends AbstractNodeDependentRestServic
     @GET
     @Path("{ipAddress}/metadata/{context}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
-    public OnmsMetaDataList getMetaData(@Context final UriInfo uriInfo, @PathParam("ipAddress") String ipAddress, @PathParam("context") String context) {
+    @Operation(
+            summary = "Get metadata of an IP interface in one context",
+            description = """
+        Return the interface's metadata entries whose context matches exactly, case-sensitively. A
+        context that holds no entries and a context that does not exist both give a 200 with an empty
+        list.""",
+            operationId = "NodeIpInterfacesRestServiceGETMetaDataByIpAddressAndContext",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Metadata entries in that context, possibly empty.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsMetaDataList.class),
+                            examples = {
+                                    @ExampleObject(name = "match", value = """
+                    {"totalCount": 1, "count": 1, "offset": 0, "metaData": [{"context": "X-ApiDoc", "key": "vlan", "value": "42"}]}"""),
+                                    @ExampleObject(name = "no match", value = """
+                    {"totalCount": null, "count": null, "offset": 0, "metaData": []}""")
+                            })),
+            @ApiResponse(responseCode = "400", description = "The node has no interface with that address.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "getMetaData: Can't find interface 198.51.100.99"))),
+            @ApiResponse(responseCode = "500", description = "The node does not exist, or its path segment could not be parsed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    public OnmsMetaDataList getMetaData(
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "ipAddress",
+                    description = "IP address of the interface.", example = "192.0.2.31")
+            @PathParam("ipAddress") String ipAddress,
+            @Parameter(in = ParameterIn.PATH, name = "context",
+                    description = "Metadata context to filter on.", example = "X-ApiDoc")
+            @PathParam("context") String context) {
         final OnmsIpInterface intf = getInterface(uriInfo, ipAddress);
 
         if (intf == null) {
@@ -209,7 +748,40 @@ public class NodeIpInterfacesRestService extends AbstractNodeDependentRestServic
     @GET
     @Path("{ipAddress}/metadata/{context}/{key}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
-    public OnmsMetaDataList getMetaData(@Context final UriInfo uriInfo, @PathParam("ipAddress") String ipAddress, @PathParam("context") String context, @PathParam("key") String key) {
+    @Operation(
+            summary = "Get one metadata entry of an IP interface",
+            description = """
+        Return the interface's metadata entries matching both context and key. At most one entry can
+        match, but the response is still the list envelope.""",
+            operationId = "NodeIpInterfacesRestServiceGETMetaDataByIpAddressAndContextAndKey",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The matching entry, or an empty list.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsMetaDataList.class),
+                            examples = @ExampleObject(value = """
+                    {"totalCount": 1, "count": 1, "offset": 0, "metaData": [{"context": "X-ApiDoc", "key": "vlan", "value": "42"}]}"""))),
+            @ApiResponse(responseCode = "400", description = "The node has no interface with that address.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "getMetaData: Can't find interface 198.51.100.99"))),
+            @ApiResponse(responseCode = "500", description = "The node does not exist, or its path segment could not be parsed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    public OnmsMetaDataList getMetaData(
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "ipAddress",
+                    description = "IP address of the interface.", example = "192.0.2.31")
+            @PathParam("ipAddress") String ipAddress,
+            @Parameter(in = ParameterIn.PATH, name = "context",
+                    description = "Metadata context.", example = "X-ApiDoc")
+            @PathParam("context") String context,
+            @Parameter(in = ParameterIn.PATH, name = "key",
+                    description = "Metadata key within the context.", example = "vlan")
+            @PathParam("key") String key) {
         final OnmsIpInterface intf = getInterface(uriInfo, ipAddress);
 
         if (intf == null) {
@@ -224,7 +796,38 @@ public class NodeIpInterfacesRestService extends AbstractNodeDependentRestServic
     @DELETE
     @Path("{ipAddress}/metadata/{context}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
-    public Response deleteMetaData(@Context final UriInfo uriInfo, @PathParam("ipAddress") final String ipAddress, @PathParam("context") final String context) {
+    @Operation(
+            summary = "Delete a metadata context of an IP interface",
+            description = """
+        Remove every metadata entry of the interface in the given context. Deleting a context that
+        holds no entries is also a 204. The context is checked before the interface is looked up, so a
+        non-`X-` context is answered with 403 even for an interface that does not exist.""",
+            operationId = "NodeIpInterfacesRestServiceDELETEMetaDataByIpAddressAndContext",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The context was removed."),
+            @ApiResponse(responseCode = "400", description = "The node has no interface with that address.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "deleteMetaData: Can't find interface 198.51.100.99"))),
+            @ApiResponse(responseCode = "403", description = "The context does not start with `X-`. Only user-defined contexts may be written through this API.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Only metadata in contexts starting with 'X-' can be modified"))),
+            @ApiResponse(responseCode = "500", description = "The node does not exist, or its path segment could not be parsed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    public Response deleteMetaData(
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "ipAddress",
+                    description = "IP address of the interface.", example = "192.0.2.31")
+            @PathParam("ipAddress") final String ipAddress,
+            @Parameter(in = ParameterIn.PATH, name = "context",
+                    description = "Metadata context to remove. Must start with `X-`.", example = "X-ApiDoc")
+            @PathParam("context") final String context) {
         checkUserDefinedMetadataContext(context);
 
         writeLock();
@@ -245,7 +848,40 @@ public class NodeIpInterfacesRestService extends AbstractNodeDependentRestServic
     @DELETE
     @Path("{ipAddress}/metadata/{context}/{key}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
-    public Response deleteMetaData(@Context final UriInfo uriInfo, @PathParam("ipAddress") final String ipAddress, @PathParam("context") String context, @PathParam("key") final String key) {
+    @Operation(
+            summary = "Delete one metadata entry of an IP interface",
+            description = """
+        Remove a single metadata entry of the interface. Deleting a key that does not exist is also a
+        204.""",
+            operationId = "NodeIpInterfacesRestServiceDELETEMetaDataByIpAddressAndContextAndKey",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The entry was removed."),
+            @ApiResponse(responseCode = "400", description = "The node has no interface with that address.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "deleteMetaData: Can't find interface 198.51.100.99"))),
+            @ApiResponse(responseCode = "403", description = "The context does not start with `X-`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Only metadata in contexts starting with 'X-' can be modified"))),
+            @ApiResponse(responseCode = "500", description = "The node does not exist, or its path segment could not be parsed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    public Response deleteMetaData(
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "ipAddress",
+                    description = "IP address of the interface.", example = "192.0.2.31")
+            @PathParam("ipAddress") final String ipAddress,
+            @Parameter(in = ParameterIn.PATH, name = "context",
+                    description = "Metadata context. Must start with `X-`.", example = "X-ApiDoc")
+            @PathParam("context") String context,
+            @Parameter(in = ParameterIn.PATH, name = "key",
+                    description = "Metadata key to remove.", example = "vlan")
+            @PathParam("key") final String key) {
         checkUserDefinedMetadataContext(context);
 
         writeLock();
@@ -266,7 +902,47 @@ public class NodeIpInterfacesRestService extends AbstractNodeDependentRestServic
     @POST
     @Path("{ipAddress}/metadata")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
-    public Response postMetaData(@Context final UriInfo uriInfo, @PathParam("ipAddress") final String ipAddress, final OnmsMetaData entity) {
+    @Operation(
+            summary = "Add or replace a metadata entry of an IP interface",
+            description = """
+        Set one metadata entry on the interface from the request body. An existing entry with the same
+        context and key is overwritten, so this is an upsert rather than an append. No `@Consumes` is
+        declared, so both JSON and XML bodies are accepted; the XML root element is `meta-data`.""",
+            operationId = "NodeIpInterfacesRestServicePOSTMetaDataByIpAddress",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @RequestBody(required = true, description = "The metadata entry to set. The context must start with `X-`.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsMetaData.class),
+                            examples = @ExampleObject(value = """
+                    {"context": "X-ApiDoc", "key": "vlan", "value": "42"}""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = OnmsMetaData.class),
+                            examples = @ExampleObject(value = """
+                    <meta-data><context>X-ApiDoc</context><key>vlan</key><value>42</value></meta-data>"""))
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The entry was stored."),
+            @ApiResponse(responseCode = "400", description = "The node has no interface with that address.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "postMetaData: Can't find interface 198.51.100.99"))),
+            @ApiResponse(responseCode = "403", description = "The context does not start with `X-`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Only metadata in contexts starting with 'X-' can be modified"))),
+            @ApiResponse(responseCode = "500", description = "The node does not exist, its path segment could not be parsed, or the body could not be deserialised.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    public Response postMetaData(
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "ipAddress",
+                    description = "IP address of the interface.", example = "192.0.2.31")
+            @PathParam("ipAddress") final String ipAddress,
+            final OnmsMetaData entity) {
         checkUserDefinedMetadataContext(entity.getContext());
 
         writeLock();
@@ -287,7 +963,45 @@ public class NodeIpInterfacesRestService extends AbstractNodeDependentRestServic
     @PUT
     @Path("{ipAddress}/metadata/{context}/{key}/{value}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
-    public Response putMetaData(@Context final UriInfo uriInfo, @PathParam("ipAddress") final String ipAddress, @PathParam("context") final String context, @PathParam("key") final String key, @PathParam("value") final String value) {        checkUserDefinedMetadataContext(context);
+    @Operation(
+            summary = "Set a metadata entry of an IP interface from the path",
+            description = """
+        Set one metadata entry on the interface with context, key and value all taken from the path. An
+        existing entry with the same context and key is overwritten. A value containing `/` has to be
+        percent-encoded, and an empty value cannot be expressed this way; use the `POST` form for
+        those.""",
+            operationId = "NodeIpInterfacesRestServicePUTMetaDataByIpAddress",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The entry was stored."),
+            @ApiResponse(responseCode = "400", description = "The node has no interface with that address.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "putMetaData: Can't find interface 198.51.100.99"))),
+            @ApiResponse(responseCode = "403", description = "The context does not start with `X-`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Only metadata in contexts starting with 'X-' can be modified"))),
+            @ApiResponse(responseCode = "500", description = "The node does not exist, or its path segment could not be parsed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    public Response putMetaData(
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "ipAddress",
+                    description = "IP address of the interface.", example = "192.0.2.31")
+            @PathParam("ipAddress") final String ipAddress,
+            @Parameter(in = ParameterIn.PATH, name = "context",
+                    description = "Metadata context. Must start with `X-`.", example = "X-ApiDoc")
+            @PathParam("context") final String context,
+            @Parameter(in = ParameterIn.PATH, name = "key",
+                    description = "Metadata key.", example = "vlan")
+            @PathParam("key") final String key,
+            @Parameter(in = ParameterIn.PATH, name = "value",
+                    description = "Metadata value.", example = "42")
+            @PathParam("value") final String value) {        checkUserDefinedMetadataContext(context);
         checkUserDefinedMetadataContext(context);
 
         writeLock();

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeMonitoredServiceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeMonitoredServiceRestService.java
@@ -461,7 +461,7 @@ public class NodeMonitoredServiceRestService extends AbstractNodeDependentRestSe
     @Path("{id}")
     @Operation(
             summary = "Rejected: create a monitored service at a caller-chosen path",
-            description = "Always answered with 404. Post the service to the collection instead; its name travels in the body.",
+            description = "Always answered with 404, whether or not the service exists.",
             operationId = "NodeMonitoredServiceRestServicePOSTServiceSpecific",
             parameters = {
                     @Parameter(in = ParameterIn.PATH, name = "nodeCriteria", required = true,
@@ -483,11 +483,9 @@ public class NodeMonitoredServiceRestService extends AbstractNodeDependentRestSe
             description = """
         Attach a monitored service to the interface and send a `nodeGainedService` event, plus an
         application-changed event for each application named in the body. `serviceType.name` is
-        required; a service type that does not yet exist is created, so a typo silently adds a new type
-        rather than failing. `status` in the body is not applied: the service is stored with no status,
-        and a daemon reacting to the `nodeGainedService` event sets it shortly afterwards, so an
-        immediate read-back can show `status` and `statusLong` as `null`. The new service's URI is
-        returned in the `Location` header.""",
+        required, and a service type that does not yet exist is created. `status` in the body is not
+        applied: the service is stored with no status, so an immediate read-back can show `status` and
+        `statusLong` as `null`. The new service's URI is returned in the `Location` header.""",
             operationId = "NodeMonitoredServiceRestServicePOSTService",
             parameters = {
                     @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
@@ -568,10 +566,8 @@ public class NodeMonitoredServiceRestService extends AbstractNodeDependentRestSe
     @Operation(
             summary = "Not implemented: replace a monitored service from a document",
             description = """
-        `AbstractDaoRestServiceWithDTO.doUpdate` is not overridden for monitored services, so this
-        variant cannot succeed. It also binds `{id}` as an integer while the collection addresses
-        services by name, so a name in the path is answered with 404 before the handler runs. Use the
-        form-encoded `PUT` on the same path to change properties.""",
+        Answered with 501. This variant binds `{id}` as an integer while the collection addresses
+        services by name, so a name in the path is answered with 404 before the handler runs.""",
             operationId = "NodeMonitoredServiceRestServicePUTServiceDocument",
             parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
                             description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
@@ -605,8 +601,8 @@ public class NodeMonitoredServiceRestService extends AbstractNodeDependentRestSe
             description = """
         Apply the form parameters as bean properties to one service of the interface. Setting `status`
         to `A` resumes polling and `F` forces the service out of service. A body that leaves the status
-        unchanged is answered with 304, so a 204 is the signal that the status actually moved. A change
-        to `applications` sends an application-changed event.""",
+        unchanged is answered with 304. A change to `applications` sends an application-changed
+        event.""",
             operationId = "NodeMonitoredServiceRestServicePUTServiceProperties",
             parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
                             description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
@@ -956,8 +952,8 @@ public class NodeMonitoredServiceRestService extends AbstractNodeDependentRestSe
             summary = "Add or replace a metadata entry of a monitored service",
             description = """
         Set one metadata entry on the service from the request body. An existing entry with the same
-        context and key is overwritten, so this is an upsert rather than an append. No `@Consumes` is
-        declared, so both JSON and XML bodies are accepted; the XML root element is `meta-data`.""",
+        context and key is overwritten. No `@Consumes` is declared, so both JSON and XML bodies are
+        accepted; the XML root element is `meta-data`.""",
             operationId = "NodeMonitoredServiceRestServicePOSTMetaDataByService",
             parameters = {
                     @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
@@ -1018,8 +1014,7 @@ public class NodeMonitoredServiceRestService extends AbstractNodeDependentRestSe
             description = """
         Set one metadata entry on the service with context, key and value all taken from the path. An
         existing entry with the same context and key is overwritten. A value containing `/` has to be
-        percent-encoded, and an empty value cannot be expressed this way; use the `POST` form for
-        those.""",
+        percent-encoded, and an empty value cannot be expressed this way.""",
             operationId = "NodeMonitoredServiceRestServicePUTMetaDataByService",
             parameters = {
                     @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeMonitoredServiceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeMonitoredServiceRestService.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -34,6 +35,7 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.PathSegment;
@@ -43,6 +45,17 @@ import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import org.apache.cxf.jaxrs.ext.search.SearchContext;
 import org.opennms.core.config.api.JaxbListWrapper;
 import org.opennms.core.criteria.Alias.JoinType;
 import org.opennms.core.criteria.CriteriaBuilder;
@@ -231,11 +244,499 @@ public class NodeMonitoredServiceRestService extends AbstractNodeDependentRestSe
         return iface == null? null : iface.getMonitoredServiceByServiceType(serviceName);
     }
 
+    // The generic collection and item operations below are inherited from AbstractDaoRestServiceWithDTO.
+    // They are overridden here only so that each concrete path carries its own OpenAPI documentation;
+    // the bodies delegate unchanged.
+    @GET
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get the monitored services of an IP interface",
+            description = """
+        Return the monitored services of the IP interface named in the path. The criteria are restricted
+        to that node and address, so `_s` narrows within the interface. `limit` defaults to 10.
+
+        The criteria join the owning node's categories without a `distinct`, so a node carrying more
+        than one surveillance category yields the same service once per category. `totalCount` and
+        `GET .../services/count` are inflated by the same factor.
+
+        `status` holds the single-letter poller status and `statusLong` its label. `lastGood` and
+        `lastFail` are epoch milliseconds in JSON, not the `string/date-time` the derived schema
+        shows.
+
+        Example query: `_s=status==A&orderBy=id`.""",
+            operationId = "NodeMonitoredServiceRestServiceGETServices",
+            parameters = {
+                    @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`. A value that is neither is answered with 500.", example = "257"),
+                    @Parameter(in = ParameterIn.PATH, name = "id",
+                            description = "IP address of the owning interface.", example = "192.0.2.31")
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Matching monitored services.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsMonitoredServiceList.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 1,
+                      "count": 1,
+                      "offset": 0,
+                      "service": [
+                        {
+                          "id": 23618,
+                          "ipInterfaceId": 23615,
+                          "serviceType": {"id": 6, "name": "ICMP"},
+                          "status": "A",
+                          "statusLong": "Managed",
+                          "down": false,
+                          "source": null,
+                          "qualifier": null,
+                          "notify": null,
+                          "lastGood": null,
+                          "lastFail": null
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsMonitoredServiceList.class),
+                                    examples = @ExampleObject(value = """
+                    <services count="1" offset="0" totalCount="1">
+                      <service down="false" status="A" statusLong="Managed" id="23618">
+                        <ipInterfaceId>23615</ipInterfaceId>
+                        <serviceType id="6"><name>ICMP</name></serviceType>
+                      </service>
+                    </services>"""))
+                    }),
+            @ApiResponse(responseCode = "204", description = "The interface has no matching service. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The node path segment could not be parsed, or the FIQL expression could not be parsed or resolved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    @Override
+    public Response get(@Context final UriInfo uriInfo, @Context final SearchContext searchContext) {
+        return super.get(uriInfo, searchContext);
+    }
+
+    @GET
+    @Path("count")
+    @Produces({MediaType.TEXT_PLAIN})
+    @Operation(
+            summary = "Count the monitored services of an IP interface",
+            description = """
+        Return the number of the interface's services matching `_s` as a bare decimal string. The count
+        carries the same category-join inflation as the collection: a node with two categories reports
+        each service twice.
+
+        Example query: `_s=status==A`.""",
+            operationId = "NodeMonitoredServiceRestServiceGETServiceCount",
+            parameters = {
+                    @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"),
+                    @Parameter(in = ParameterIn.PATH, name = "id",
+                            description = "IP address of the owning interface.", example = "192.0.2.31")
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Number of matching services.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "2"))),
+            @ApiResponse(responseCode = "500", description = "The node path segment could not be parsed, or the FIQL expression could not be parsed or resolved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    @Override
+    public Response getCount(@Context final UriInfo uriInfo, @Context final SearchContext searchContext) {
+        return super.getCount(uriInfo, searchContext);
+    }
+
+    @GET
+    @Path("properties")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Operation(
+            summary = "Get monitored service search properties",
+            description = """
+        This resource declares no search property set, so the operation answers 204 with no body. FIQL
+        expressions still work on this resource; they are validated against the entity by Hibernate
+        rather than against a property list.""",
+            operationId = "NodeMonitoredServiceRestServiceGETServiceSearchProperties",
+            parameters = {
+                    @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"),
+                    @Parameter(in = ParameterIn.PATH, name = "id",
+                            description = "IP address of the owning interface.", example = "192.0.2.31")
+            })
+    @ApiResponse(responseCode = "204", description = "No search properties are declared for this resource. No body is returned.")
+    @Override
+    public Response getProperties(
+            @Parameter(in = ParameterIn.QUERY, name = "q",
+                    description = "Case-insensitive substring matched against the property `name`, not its id. Has no effect while the property set is empty.", example = "Status")
+            @QueryParam("q") final String query) {
+        return super.getProperties(query);
+    }
+
+    @GET
+    @Path("properties/{propertyId}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Operation(
+            summary = "Get values of a monitored service search property",
+            description = """
+        Answered with 404 for every `propertyId`, because this resource declares no search property
+        set.""",
+            operationId = "NodeMonitoredServiceRestServiceGETServiceSearchPropertyValues",
+            parameters = {
+                    @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"),
+                    @Parameter(in = ParameterIn.PATH, name = "id",
+                            description = "IP address of the owning interface.", example = "192.0.2.31")
+            })
+    @ApiResponse(responseCode = "404", description = "No search property has that id. No body is returned.")
+    @Override
+    public Response getPropertyValues(
+            @Parameter(in = ParameterIn.PATH, name = "propertyId", description = "Property id.", example = "status")
+            @PathParam("propertyId") final String propertyId,
+            @Parameter(in = ParameterIn.QUERY, name = "q", description = "Substring the value must contain.", example = "A")
+            @QueryParam("q") final String query,
+            @Parameter(in = ParameterIn.QUERY, name = "limit", description = "Maximum number of values to return.", example = "10")
+            @QueryParam("limit") final Integer limit) {
+        return super.getPropertyValues(propertyId, query, limit);
+    }
+
+    @GET
+    @Path("{id}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get a monitored service",
+            description = """
+        Return one monitored service of the interface, addressed by service name rather than by its
+        database id. The name is matched exactly.""",
+            operationId = "NodeMonitoredServiceRestServiceGETServiceByName",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The monitored service.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsMonitoredService.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "id": 23618,
+                      "ipInterfaceId": 23615,
+                      "serviceType": {"id": 6, "name": "ICMP"},
+                      "status": "A",
+                      "statusLong": "Managed",
+                      "down": false,
+                      "source": null,
+                      "qualifier": null,
+                      "notify": null,
+                      "lastGood": null,
+                      "lastFail": null
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsMonitoredService.class),
+                                    examples = @ExampleObject(value = """
+                    <service down="false" status="A" statusLong="Managed" id="23618">
+                      <ipInterfaceId>23615</ipInterfaceId>
+                      <serviceType id="6"><name>ICMP</name></serviceType>
+                    </service>"""))
+                    }),
+            @ApiResponse(responseCode = "404", description = "The interface has no service with that name. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The node path segment is neither a number nor `foreignSource:foreignId`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    @Override
+    public Response get(
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "id",
+                    description = "IP address of the owning interface, then the service name. The two path templates are both named `id`.",
+                    example = "ICMP")
+            @PathParam("id") final String id) {
+        return super.get(uriInfo, id);
+    }
+
+    @POST
+    @Path("{id}")
+    @Operation(
+            summary = "Rejected: create a monitored service at a caller-chosen path",
+            description = "Always answered with 404. Post the service to the collection instead; its name travels in the body.",
+            operationId = "NodeMonitoredServiceRestServicePOSTServiceSpecific",
+            parameters = {
+                    @Parameter(in = ParameterIn.PATH, name = "nodeCriteria", required = true,
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"),
+                    @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                            description = "IP address of the owning interface, then the service name. The two path templates are both named `id`, and neither value is read: every request to this path is answered with 404.",
+                            example = "ICMP")
+            })
+    @ApiResponse(responseCode = "404", description = "Not supported. No body is returned.")
+    @Override
+    public Response createSpecific() {
+        return super.createSpecific();
+    }
+
+    @POST
+    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Operation(
+            summary = "Add a monitored service to an IP interface",
+            description = """
+        Attach a monitored service to the interface and send a `nodeGainedService` event, plus an
+        application-changed event for each application named in the body. `serviceType.name` is
+        required; a service type that does not yet exist is created, so a typo silently adds a new type
+        rather than failing. `status` in the body is not applied: the service is stored with no status,
+        and a daemon reacting to the `nodeGainedService` event sets it shortly afterwards, so an
+        immediate read-back can show `status` and `statusLong` as `null`. The new service's URI is
+        returned in the `Location` header.""",
+            operationId = "NodeMonitoredServiceRestServicePOSTService",
+            parameters = {
+                    @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"),
+                    @Parameter(in = ParameterIn.PATH, name = "id",
+                            description = "IP address of the owning interface.", example = "192.0.2.31")
+            })
+    @RequestBody(required = true, description = "The monitored service to add.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsMonitoredService.class),
+                            examples = @ExampleObject(value = """
+                    {"serviceType": {"name": "ICMP"}}""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = OnmsMonitoredService.class),
+                            examples = @ExampleObject(value = """
+                    <service><serviceType><name>ICMP</name></serviceType></service>"""))
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "The service was added. `Location` carries its URI.",
+                    headers = @Header(name = "Location", description = "URI of the created monitored service.",
+                            schema = @Schema(type = "string", example = "http://localhost:8980/opennms/api/v2/nodes/257/ipinterfaces/192.0.2.31/services/ICMP"))),
+            @ApiResponse(responseCode = "400", description = "The interface was not found, or the body carried no service type name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "no service type", value = "Service type names cannot be null"),
+                                    @ExampleObject(name = "no interface", value = "IP interface was not found")
+                            })),
+            @ApiResponse(responseCode = "500", description = "The node path segment could not be parsed, or the body could not be deserialised.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    @Override
+    public Response create(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo, final OnmsMonitoredService object) {
+        return super.create(securityContext, uriInfo, object);
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Operation(
+            summary = "Update properties of several monitored services",
+            description = """
+        Apply the form parameters as bean properties to every service of the interface matching `_s`.
+        The default `limit` of 10 applies to the selection. A change to `status` sends the matching
+        service-status event, and a change to `applications` sends an application-changed event. The
+        whole call runs in one transaction, so a per-service failure aborts the batch.
+
+        Example query: `_s=status==N&limit=100`.""",
+            operationId = "NodeMonitoredServiceRestServicePUTServices",
+            parameters = {
+                    @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"),
+                    @Parameter(in = ParameterIn.PATH, name = "id",
+                            description = "IP address of the owning interface.", example = "192.0.2.31")
+            })
+    @RequestBody(required = true, description = "Monitored service bean properties to set, form-encoded.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "object"),
+                    examples = @ExampleObject(value = "status=A")))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "All selected services were updated."),
+            @ApiResponse(responseCode = "404", description = "No service matched. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The node path segment could not be parsed, or the FIQL expression could not be parsed or resolved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    @Override
+    public Response updateMany(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo, @Context final SearchContext searchContext, final MultivaluedMapImpl params) {
+        return super.updateMany(securityContext, uriInfo, searchContext, params);
+    }
+
+    @PUT
+    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Path("{id}")
+    @Operation(
+            summary = "Not implemented: replace a monitored service from a document",
+            description = """
+        `AbstractDaoRestServiceWithDTO.doUpdate` is not overridden for monitored services, so this
+        variant cannot succeed. It also binds `{id}` as an integer while the collection addresses
+        services by name, so a name in the path is answered with 404 before the handler runs. Use the
+        form-encoded `PUT` on the same path to change properties.""",
+            operationId = "NodeMonitoredServiceRestServicePUTServiceDocument",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @RequestBody(description = "Ignored.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = OnmsMonitoredService.class),
+                            examples = @ExampleObject(value = "{\"status\": \"A\"}")),
+                    @Content(mediaType = MediaType.APPLICATION_XML, schema = @Schema(implementation = OnmsMonitoredService.class),
+                            examples = @ExampleObject(value = "<service status=\"A\"/>"))
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = "`{id}` is not an integer, which is the case for every service name."),
+            @ApiResponse(responseCode = "501", description = "Replacing a monitored service from a document is not implemented. No body is returned.")
+    })
+    @Override
+    public Response update(
+            @Context final SecurityContext securityContext,
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "id",
+                    description = "Bound as an integer here, unlike every other operation on this path.", example = "23618")
+            @PathParam("id") final Integer id,
+            final OnmsMonitoredService object) {
+        return super.update(securityContext, uriInfo, id, object);
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Path("{id}")
+    @Operation(
+            summary = "Update properties of a monitored service",
+            description = """
+        Apply the form parameters as bean properties to one service of the interface. Setting `status`
+        to `A` resumes polling and `F` forces the service out of service. A body that leaves the status
+        unchanged is answered with 304, so a 204 is the signal that the status actually moved. A change
+        to `applications` sends an application-changed event.""",
+            operationId = "NodeMonitoredServiceRestServicePUTServiceProperties",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @RequestBody(required = true, description = "Monitored service bean properties to set, form-encoded.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "object"),
+                    examples = @ExampleObject(value = "status=F")))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The service status changed."),
+            @ApiResponse(responseCode = "304", description = "The service was written but its status is unchanged. No body is returned."),
+            @ApiResponse(responseCode = "404", description = "The interface has no service with that name. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The node path segment is neither a number nor `foreignSource:foreignId`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    @Override
+    public Response updateProperties(
+            @Context final SecurityContext securityContext,
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "id",
+                    description = "IP address of the owning interface, then the service name.", example = "ICMP")
+            @PathParam("id") final String id,
+            final MultivaluedMapImpl params) {
+        return super.updateProperties(securityContext, uriInfo, id, params);
+    }
+
+    @DELETE
+    @Operation(
+            summary = "Delete several monitored services",
+            description = """
+        Delete every service of the interface matching `_s` and send a `deleteService` event for each,
+        plus an application-changed event per affected application. The default `limit` of 10 applies to
+        the selection.
+
+        Example query: `_s=status==N&limit=100`.""",
+            operationId = "NodeMonitoredServiceRestServiceDELETEServices",
+            parameters = {
+                    @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"),
+                    @Parameter(in = ParameterIn.PATH, name = "id",
+                            description = "IP address of the owning interface.", example = "192.0.2.31")
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The selected services were deleted."),
+            @ApiResponse(responseCode = "404", description = "No service matched. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The node path segment could not be parsed, or the FIQL expression could not be parsed or resolved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    @Override
+    public Response deleteMany(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo, @Context final SearchContext searchContext) {
+        return super.deleteMany(securityContext, uriInfo, searchContext);
+    }
+
+    @DELETE
+    @Path("{id}")
+    @Operation(
+            summary = "Delete a monitored service",
+            description = """
+        Delete one service of the interface and send a `deleteService` event, plus an
+        application-changed event per application the service belonged to. The service type itself is
+        left in place even when no service references it any more.""",
+            operationId = "NodeMonitoredServiceRestServiceDELETEServiceByName",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The service was deleted."),
+            @ApiResponse(responseCode = "404", description = "The interface has no service with that name. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The node path segment is neither a number nor `foreignSource:foreignId`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    @Override
+    public Response delete(
+            @Context final SecurityContext securityContext,
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "id",
+                    description = "IP address of the owning interface, then the service name.", example = "ICMP")
+            @PathParam("id") final String id) {
+        return super.delete(securityContext, uriInfo, id);
+    }
+
     @GET
     @Path("{serviceName}/metadata")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
-    @Operation(summary = "Get metadata by service", description = "Get metadata by service", operationId = "NodeMonitoredServiceRestServiceGetMetaDataByService")
-    public OnmsMetaDataList getMetaData(@Context final UriInfo uriInfo, @PathParam("serviceName") String serviceName) {
+    @Operation(
+            summary = "Get all metadata of a monitored service",
+            description = """
+        Return every metadata entry attached to the service, across all contexts. An empty result is
+        still a 200; `totalCount` and `count` are then `null` rather than `0`. A service name that does
+        not exist on the interface is answered with 500 rather than 400.""",
+            operationId = "NodeMonitoredServiceRestServiceGetMetaDataByService",
+            parameters = {
+                    @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"),
+                    @Parameter(in = ParameterIn.PATH, name = "id",
+                            description = "IP address of the owning interface.", example = "192.0.2.31")
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Metadata entries of the service.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsMetaDataList.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 1,
+                      "count": 1,
+                      "offset": 0,
+                      "metaData": [{"context": "X-ApiDoc", "key": "sla", "value": "gold"}]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsMetaDataList.class),
+                                    examples = @ExampleObject(value = """
+                    <meta-data-list count="1" offset="0" totalCount="1">
+                      <meta-data><context>X-ApiDoc</context><key>sla</key><value>gold</value></meta-data>
+                    </meta-data-list>"""))
+                    }),
+            @ApiResponse(responseCode = "500", description = "The interface has no service with that name, or the node path segment could not be parsed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot invoke \"org.opennms.netmgt.model.OnmsMonitoredService.getMetaData()\" because \"service\" is null")))
+    })
+    public OnmsMetaDataList getMetaData(
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "serviceName",
+                    description = "Service name.", example = "ICMP")
+            @PathParam("serviceName") String serviceName) {
         final OnmsMonitoredService service = getService(uriInfo, serviceName);
 
         if (serviceName == null) {
@@ -248,8 +749,41 @@ public class NodeMonitoredServiceRestService extends AbstractNodeDependentRestSe
     @GET
     @Path("{serviceName}/metadata/{context}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
-    @Operation(summary = "Get metadata by service and context", description = "Get metadata by service and context", operationId = "NodeMonitoredServiceRestServiceGetMetaDataByServiceAndContext")
-    public OnmsMetaDataList getMetaData(@Context final UriInfo uriInfo, @PathParam("serviceName") String serviceName, @PathParam("context") String context) {
+    @Operation(
+            summary = "Get metadata of a monitored service in one context",
+            description = """
+        Return the service's metadata entries whose context matches exactly, case-sensitively. A context
+        that holds no entries and a context that does not exist both give a 200 with an empty list.""",
+            operationId = "NodeMonitoredServiceRestServiceGetMetaDataByServiceAndContext",
+            parameters = {
+                    @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"),
+                    @Parameter(in = ParameterIn.PATH, name = "id",
+                            description = "IP address of the owning interface.", example = "192.0.2.31")
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Metadata entries in that context, possibly empty.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsMetaDataList.class),
+                            examples = {
+                                    @ExampleObject(name = "match", value = """
+                    {"totalCount": 1, "count": 1, "offset": 0, "metaData": [{"context": "X-ApiDoc", "key": "sla", "value": "gold"}]}"""),
+                                    @ExampleObject(name = "no match", value = """
+                    {"totalCount": null, "count": null, "offset": 0, "metaData": []}""")
+                            })),
+            @ApiResponse(responseCode = "500", description = "The interface has no service with that name, or the node path segment could not be parsed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    public OnmsMetaDataList getMetaData(
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "serviceName",
+                    description = "Service name.", example = "ICMP")
+            @PathParam("serviceName") String serviceName,
+            @Parameter(in = ParameterIn.PATH, name = "context",
+                    description = "Metadata context to filter on.", example = "X-ApiDoc")
+            @PathParam("context") String context) {
         final OnmsMonitoredService service = getService(uriInfo, serviceName);
 
         if (serviceName == null) {
@@ -264,8 +798,40 @@ public class NodeMonitoredServiceRestService extends AbstractNodeDependentRestSe
     @GET
     @Path("{serviceName}/metadata/{context}/{key}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
-    @Operation(summary = "Get metadata by service, context and key", description = "Get metadata by service, context and key", operationId = "NodeMonitoredServiceRestServiceGetMetaDataByServiceAndContextAndKey")
-    public OnmsMetaDataList getMetaData(@Context final UriInfo uriInfo, @PathParam("serviceName") String serviceName, @PathParam("context") String context, @PathParam("key") String key) {
+    @Operation(
+            summary = "Get one metadata entry of a monitored service",
+            description = """
+        Return the service's metadata entries matching both context and key. At most one entry can
+        match, but the response is still the list envelope.""",
+            operationId = "NodeMonitoredServiceRestServiceGetMetaDataByServiceAndContextAndKey",
+            parameters = {
+                    @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"),
+                    @Parameter(in = ParameterIn.PATH, name = "id",
+                            description = "IP address of the owning interface.", example = "192.0.2.31")
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The matching entry, or an empty list.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsMetaDataList.class),
+                            examples = @ExampleObject(value = """
+                    {"totalCount": 1, "count": 1, "offset": 0, "metaData": [{"context": "X-ApiDoc", "key": "sla", "value": "gold"}]}"""))),
+            @ApiResponse(responseCode = "500", description = "The interface has no service with that name, or the node path segment could not be parsed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    public OnmsMetaDataList getMetaData(
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "serviceName",
+                    description = "Service name.", example = "ICMP")
+            @PathParam("serviceName") String serviceName,
+            @Parameter(in = ParameterIn.PATH, name = "context",
+                    description = "Metadata context.", example = "X-ApiDoc")
+            @PathParam("context") String context,
+            @Parameter(in = ParameterIn.PATH, name = "key",
+                    description = "Metadata key within the context.", example = "sla")
+            @PathParam("key") String key) {
         final OnmsMonitoredService service = getService(uriInfo, serviceName);
 
         if (serviceName == null) {
@@ -280,7 +846,38 @@ public class NodeMonitoredServiceRestService extends AbstractNodeDependentRestSe
     @DELETE
     @Path("{serviceName}/metadata/{context}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
-    public Response deleteMetaData(@Context final UriInfo uriInfo, @PathParam("serviceName") final String serviceName, @PathParam("context") final String context) {
+    @Operation(
+            summary = "Delete a metadata context of a monitored service",
+            description = """
+        Remove every metadata entry of the service in the given context. Deleting a context that holds
+        no entries is also a 204. The context is checked before the service is looked up, so a non-`X-`
+        context is answered with 403 even for a service that does not exist.""",
+            operationId = "NodeMonitoredServiceRestServiceDELETEMetaDataByServiceAndContext",
+            parameters = {
+                    @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"),
+                    @Parameter(in = ParameterIn.PATH, name = "id",
+                            description = "IP address of the owning interface.", example = "192.0.2.31")
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The context was removed."),
+            @ApiResponse(responseCode = "403", description = "The context does not start with `X-`. Only user-defined contexts may be written through this API.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Only metadata in contexts starting with 'X-' can be modified"))),
+            @ApiResponse(responseCode = "500", description = "The interface has no service with that name, or the node path segment could not be parsed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    public Response deleteMetaData(
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "serviceName",
+                    description = "Service name.", example = "ICMP")
+            @PathParam("serviceName") final String serviceName,
+            @Parameter(in = ParameterIn.PATH, name = "context",
+                    description = "Metadata context to remove. Must start with `X-`.", example = "X-ApiDoc")
+            @PathParam("context") final String context) {
         checkUserDefinedMetadataContext(context);
 
         writeLock();
@@ -301,7 +898,40 @@ public class NodeMonitoredServiceRestService extends AbstractNodeDependentRestSe
     @DELETE
     @Path("{serviceName}/metadata/{context}/{key}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
-    public Response deleteMetaData(@Context final UriInfo uriInfo, @PathParam("serviceName") final String serviceName, @PathParam("context") final String context, @PathParam("key") final String key) {
+    @Operation(
+            summary = "Delete one metadata entry of a monitored service",
+            description = """
+        Remove a single metadata entry of the service. Deleting a key that does not exist is also a
+        204.""",
+            operationId = "NodeMonitoredServiceRestServiceDELETEMetaDataByServiceAndContextAndKey",
+            parameters = {
+                    @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"),
+                    @Parameter(in = ParameterIn.PATH, name = "id",
+                            description = "IP address of the owning interface.", example = "192.0.2.31")
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The entry was removed."),
+            @ApiResponse(responseCode = "403", description = "The context does not start with `X-`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Only metadata in contexts starting with 'X-' can be modified"))),
+            @ApiResponse(responseCode = "500", description = "The interface has no service with that name, or the node path segment could not be parsed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    public Response deleteMetaData(
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "serviceName",
+                    description = "Service name.", example = "ICMP")
+            @PathParam("serviceName") final String serviceName,
+            @Parameter(in = ParameterIn.PATH, name = "context",
+                    description = "Metadata context. Must start with `X-`.", example = "X-ApiDoc")
+            @PathParam("context") final String context,
+            @Parameter(in = ParameterIn.PATH, name = "key",
+                    description = "Metadata key to remove.", example = "sla")
+            @PathParam("key") final String key) {
         checkUserDefinedMetadataContext(context);
 
         writeLock();
@@ -322,7 +952,47 @@ public class NodeMonitoredServiceRestService extends AbstractNodeDependentRestSe
     @POST
     @Path("{serviceName}/metadata")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
-    public Response postMetaData(@Context final UriInfo uriInfo, @PathParam("serviceName") final String serviceName, final OnmsMetaData entity) {
+    @Operation(
+            summary = "Add or replace a metadata entry of a monitored service",
+            description = """
+        Set one metadata entry on the service from the request body. An existing entry with the same
+        context and key is overwritten, so this is an upsert rather than an append. No `@Consumes` is
+        declared, so both JSON and XML bodies are accepted; the XML root element is `meta-data`.""",
+            operationId = "NodeMonitoredServiceRestServicePOSTMetaDataByService",
+            parameters = {
+                    @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"),
+                    @Parameter(in = ParameterIn.PATH, name = "id",
+                            description = "IP address of the owning interface.", example = "192.0.2.31")
+            })
+    @RequestBody(required = true, description = "The metadata entry to set. The context must start with `X-`.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsMetaData.class),
+                            examples = @ExampleObject(value = """
+                    {"context": "X-ApiDoc", "key": "sla", "value": "gold"}""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = OnmsMetaData.class),
+                            examples = @ExampleObject(value = """
+                    <meta-data><context>X-ApiDoc</context><key>sla</key><value>gold</value></meta-data>"""))
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The entry was stored."),
+            @ApiResponse(responseCode = "403", description = "The context does not start with `X-`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Only metadata in contexts starting with 'X-' can be modified"))),
+            @ApiResponse(responseCode = "500", description = "The interface has no service with that name, the node path segment could not be parsed, or the body could not be deserialised.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    public Response postMetaData(
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "serviceName",
+                    description = "Service name.", example = "ICMP")
+            @PathParam("serviceName") final String serviceName,
+            final OnmsMetaData entity) {
         checkUserDefinedMetadataContext(entity.getContext());
 
         writeLock();
@@ -343,7 +1013,45 @@ public class NodeMonitoredServiceRestService extends AbstractNodeDependentRestSe
     @PUT
     @Path("{serviceName}/metadata/{context}/{key}/{value}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
-    public Response putMetaData(@Context final UriInfo uriInfo, @PathParam("serviceName") final String serviceName, @PathParam("context") final String context, @PathParam("key") final String key, @PathParam("value") final String value) {
+    @Operation(
+            summary = "Set a metadata entry of a monitored service from the path",
+            description = """
+        Set one metadata entry on the service with context, key and value all taken from the path. An
+        existing entry with the same context and key is overwritten. A value containing `/` has to be
+        percent-encoded, and an empty value cannot be expressed this way; use the `POST` form for
+        those.""",
+            operationId = "NodeMonitoredServiceRestServicePUTMetaDataByService",
+            parameters = {
+                    @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`.", example = "257"),
+                    @Parameter(in = ParameterIn.PATH, name = "id",
+                            description = "IP address of the owning interface.", example = "192.0.2.31")
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The entry was stored."),
+            @ApiResponse(responseCode = "403", description = "The context does not start with `X-`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Only metadata in contexts starting with 'X-' can be modified"))),
+            @ApiResponse(responseCode = "500", description = "The interface has no service with that name, or the node path segment could not be parsed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    public Response putMetaData(
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "serviceName",
+                    description = "Service name.", example = "ICMP")
+            @PathParam("serviceName") final String serviceName,
+            @Parameter(in = ParameterIn.PATH, name = "context",
+                    description = "Metadata context. Must start with `X-`.", example = "X-ApiDoc")
+            @PathParam("context") final String context,
+            @Parameter(in = ParameterIn.PATH, name = "key",
+                    description = "Metadata key.", example = "sla")
+            @PathParam("key") final String key,
+            @Parameter(in = ParameterIn.PATH, name = "value",
+                    description = "Metadata value.", example = "gold")
+            @PathParam("value") final String value) {
         checkUserDefinedMetadataContext(context);
 
         writeLock();

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeMonitoredServiceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeMonitoredServiceRestService.java
@@ -483,9 +483,10 @@ public class NodeMonitoredServiceRestService extends AbstractNodeDependentRestSe
             description = """
         Attach a monitored service to the interface and send a `nodeGainedService` event, plus an
         application-changed event for each application named in the body. `serviceType.name` is
-        required, and a service type that does not yet exist is created. `status` in the body is not
-        applied: the service is stored with no status, so an immediate read-back can show `status` and
-        `statusLong` as `null`. The new service's URI is returned in the `Location` header.""",
+        required, and a service type that does not yet exist is created. `status` in the body is applied
+        as given; omitting it stores the service with no status, so an immediate read-back can show
+        `status` and `statusLong` as `null`. The new service's URI is returned in the `Location`
+        header.""",
             operationId = "NodeMonitoredServiceRestServicePOSTService",
             parameters = {
                     @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
@@ -38,6 +38,7 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.container.ResourceContext;
 import javax.ws.rs.core.Context;
@@ -48,8 +49,19 @@ import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.cxf.jaxrs.ext.search.SearchBean;
+import org.apache.cxf.jaxrs.ext.search.SearchContext;
 import org.opennms.core.config.api.JaxbListWrapper;
 import org.opennms.core.criteria.Alias.JoinType;
 import org.opennms.core.criteria.CriteriaBuilder;
@@ -74,6 +86,9 @@ import org.opennms.web.rest.support.MultivaluedMapImpl;
 import org.opennms.web.rest.support.RedirectHelper;
 import org.opennms.web.rest.support.SearchProperties;
 import org.opennms.web.rest.support.SearchProperty;
+import org.opennms.web.rest.support.SearchPropertyCollection;
+import org.opennms.web.rest.support.StringCollection;
+import org.opennms.web.rest.v2.model.NodeServiceTypeDto;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -480,11 +495,491 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
         return getDao().get(id);
     }
 
+    // The generic collection and item operations below are inherited from AbstractDaoRestServiceWithDTO.
+    // They are overridden here only so that each concrete path carries its own OpenAPI documentation;
+    // the bodies delegate unchanged.
+    @GET
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get nodes",
+            description = """
+        Return the nodes matching the FIQL expression in `_s`, or the first page of all nodes when `_s`
+        is absent. `limit` defaults to 10, so an unfiltered call returns 10 nodes and reports the
+        unpaged total in `totalCount`. A `Content-Range` header of the form `items 0-9/3677` accompanies
+        a 200. Nodes with `type` of `D` (deleted) are not excluded.
+
+        In JSON, `id` is a string and `createTime`, `lastIngressFlow`, `lastEgressFlow` and the asset
+        record timestamps are epoch milliseconds; the auto-derived `string/date-time` schema for those
+        fields does not describe the JSON wire format. The XML representation of the same fields is
+        ISO-8601 with an offset.
+
+        Example query: `_s=node.foreignSource==Servers;category.name==Production&orderBy=label`.""",
+            operationId = "NodeRestServiceGETNodes")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Matching nodes.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsNodeList.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 1,
+                      "count": 1,
+                      "offset": 0,
+                      "node": [
+                        {
+                          "id": "257",
+                          "label": "ApiDoc-node",
+                          "labelSource": "U",
+                          "type": "A",
+                          "foreignSource": "ApiDoc",
+                          "foreignId": "apidoc-1",
+                          "location": "Default",
+                          "sysContact": "noc@example.org",
+                          "sysName": "apidoc",
+                          "sysDescription": "ApiDoc probe node",
+                          "createTime": 1787727308166,
+                          "lastIngressFlow": null,
+                          "lastEgressFlow": null,
+                          "nodeParentID": null,
+                          "categories": [],
+                          "assetRecord": {
+                            "id": 23599,
+                            "category": "Unspecified",
+                            "lastModifiedBy": "",
+                            "lastModifiedDate": 1787727308166
+                          }
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsNodeList.class),
+                                    examples = @ExampleObject(value = """
+                    <nodes count="1" offset="0" totalCount="1">
+                      <node foreignId="apidoc-1" foreignSource="ApiDoc" label="ApiDoc-node" id="257" type="A">
+                        <createTime>2026-08-26T02:55:08.166-04:00</createTime>
+                        <labelSource>U</labelSource>
+                        <location>Default</location>
+                        <sysContact>noc@example.org</sysContact>
+                      </node>
+                    </nodes>"""))
+                    }),
+            @ApiResponse(responseCode = "204", description = "No node matched. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The FIQL expression could not be parsed, or it names a property Hibernate cannot resolve.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    @Override
+    public Response get(@Context final UriInfo uriInfo, @Context final SearchContext searchContext) {
+        return super.get(uriInfo, searchContext);
+    }
+
+    @GET
+    @Path("count")
+    @Produces({MediaType.TEXT_PLAIN})
+    @Operation(
+            summary = "Count nodes",
+            description = """
+        Return the number of nodes matching `_s` as a bare decimal string. `limit` and `offset` do not
+        affect the count.
+
+        Example query: `_s=node.foreignSource==Servers`.""",
+            operationId = "NodeRestServiceGETNodeCount")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Number of matching nodes.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "3677"))),
+            @ApiResponse(responseCode = "500", description = "The FIQL expression could not be parsed or resolved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    @Override
+    public Response getCount(@Context final UriInfo uriInfo, @Context final SearchContext searchContext) {
+        return super.getCount(uriInfo, searchContext);
+    }
+
+    @GET
+    @Path("properties")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Operation(
+            summary = "Get node search properties",
+            description = """
+        List the properties that may appear in a `_s` expression or in `orderBy` for the node
+        resources. A property that carries a closed set of values reports them in `values`, keyed by
+        the value stored in the database.""",
+            operationId = "NodeRestServiceGETNodeSearchProperties")
+    @ApiResponse(responseCode = "200", description = "Supported search properties.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = SearchPropertyCollection.class),
+                    examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 2,
+                      "count": 2,
+                      "offset": 0,
+                      "searchProperty": [
+                        {"id": "label", "name": "Label", "type": "STRING", "orderBy": true, "iplike": false},
+                        {
+                          "id": "labelSource",
+                          "name": "Label Source",
+                          "type": "STRING",
+                          "orderBy": true,
+                          "iplike": false,
+                          "values": {
+                            "A": "IP Address",
+                            "H": "Hostname",
+                            "N": "NetBIOS",
+                            "S": "SNMP sysName",
+                            " ": "Unknown",
+                            "U": "User-Defined"
+                          }
+                        }
+                      ]
+                    }""")))
+    @Override
+    public Response getProperties(
+            @Parameter(in = ParameterIn.QUERY, name = "q",
+                    description = "Case-insensitive substring matched against the property `name`, not its id.",
+                    example = "Label")
+            @QueryParam("q") final String query) {
+        return super.getProperties(query);
+    }
+
+    @GET
+    @Path("properties/{propertyId}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Operation(
+            summary = "Get values of a node search property",
+            description = """
+        Return the distinct values a search property takes across the node table, or its declared value
+        list when it has one. The wrapper element is named `value` regardless of the property type;
+        numeric and timestamp properties come back in the collection type matching the property, with
+        the same envelope.""",
+            operationId = "NodeRestServiceGETNodeSearchPropertyValues")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Distinct values of the property.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = StringCollection.class),
+                            examples = @ExampleObject(value = """
+                    {"totalCount": 3, "count": 3, "offset": 0, "value": ["core-switch-01", "core-switch-02", "edge-router-01"]}"""))),
+            @ApiResponse(responseCode = "404", description = "No search property has that id. No body is returned.")
+    })
+    @Override
+    public Response getPropertyValues(
+            @Parameter(in = ParameterIn.PATH, name = "propertyId",
+                    description = "Property id as reported by `GET /nodes/properties`.", example = "label")
+            @PathParam("propertyId") final String propertyId,
+            @Parameter(in = ParameterIn.QUERY, name = "q",
+                    description = "Substring the value must contain. Case-sensitive for declared value lists, case-insensitive for values read from the database.",
+                    example = "core")
+            @QueryParam("q") final String query,
+            @Parameter(in = ParameterIn.QUERY, name = "limit",
+                    description = "Maximum number of values to return. Applied only when the values are read from the database.", example = "10")
+            @QueryParam("limit") final Integer limit) {
+        return super.getPropertyValues(propertyId, query, limit);
+    }
+
+    @GET
+    @Path("{id}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get a node",
+            description = """
+        Return one node by database id or by `foreignSource:foreignId`. Timestamps are epoch
+        milliseconds in JSON and ISO-8601 with an offset in XML.""",
+            operationId = "NodeRestServiceGETNodeById")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The node.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsNode.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "id": "257",
+                      "label": "ApiDoc-node",
+                      "labelSource": "U",
+                      "type": "A",
+                      "foreignSource": "ApiDoc",
+                      "foreignId": "apidoc-1",
+                      "location": "Default",
+                      "sysContact": "noc@example.org",
+                      "sysName": "apidoc",
+                      "sysDescription": "ApiDoc probe node",
+                      "createTime": 1787727308166,
+                      "lastIngressFlow": null,
+                      "lastEgressFlow": null,
+                      "nodeParentID": null,
+                      "categories": [],
+                      "assetRecord": {
+                        "id": 23599,
+                        "category": "Unspecified",
+                        "lastModifiedBy": "",
+                        "lastModifiedDate": 1787727308166
+                      }
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsNode.class),
+                                    examples = @ExampleObject(value = """
+                    <node foreignId="apidoc-1" foreignSource="ApiDoc" label="ApiDoc-node" id="257" type="A">
+                      <createTime>2026-08-26T02:55:08.166-04:00</createTime>
+                      <labelSource>U</labelSource>
+                      <location>Default</location>
+                      <sysContact>noc@example.org</sysContact>
+                    </node>"""))
+                    }),
+            @ApiResponse(responseCode = "404", description = "No such node. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The path segment is neither a number nor `foreignSource:foreignId`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    @Override
+    public Response get(@Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "id",
+                    description = "Node database id, or `foreignSource:foreignId`. A value that is neither is answered with 500.",
+                    example = "257")
+            @PathParam("id") final String id) {
+        return super.get(uriInfo, id);
+    }
+
+    @POST
+    @Path("{id}")
+    @Operation(
+            summary = "Rejected: create a node at a caller-chosen id",
+            description = "Always answered with 404. Node ids are assigned by the server; post to `/nodes` instead.",
+            operationId = "NodeRestServicePOSTNodeSpecific",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                    description = "Node database id, or `foreignSource:foreignId`. The value is not read: every request to this path is answered with 404.",
+                    example = "257"))
+    @ApiResponse(responseCode = "404", description = "Creating a node at a specific id is not supported. No body is returned.")
+    @Override
+    public Response createSpecific() {
+        return super.createSpecific();
+    }
+
+    @POST
+    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Operation(
+            summary = "Create a node",
+            description = """
+        Create a node and send a `nodeAdded` event. `label` is the only field worth supplying in
+        practice; when `location` is omitted the default monitoring location is used. The new node's
+        URI is returned in the `Location` header. Provisiond does not own a node created this way, so a
+        requisition synchronisation will not preserve it unless the matching `foreignSource` and
+        `foreignId` also exist in a requisition.
+
+        JSON is read by Jackson with a JAXB introspector and XML by JAXB; the two representations are
+        not interchangeable. A body that fails to parse is answered with 500, not 400.""",
+            operationId = "NodeRestServicePOSTNode")
+    @RequestBody(required = true, description = "The node to create.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsNode.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "label": "ApiDoc-node",
+                      "labelSource": "U",
+                      "type": "A",
+                      "foreignSource": "ApiDoc",
+                      "foreignId": "apidoc-1",
+                      "sysContact": "noc@example.org",
+                      "sysName": "apidoc",
+                      "sysDescription": "ApiDoc probe node"
+                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = OnmsNode.class),
+                            examples = @ExampleObject(value = """
+                    <node label="ApiDoc-node" labelSource="U" type="A" foreignSource="ApiDoc" foreignId="apidoc-1">
+                      <location>Default</location>
+                      <sysContact>noc@example.org</sysContact>
+                    </node>"""))
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Node created. `Location` carries the URI of the new node.",
+                    headers = @Header(name = "Location", description = "URI of the created node.",
+                            schema = @Schema(type = "string", example = "http://localhost:8980/opennms/api/v2/nodes/257"))),
+            @ApiResponse(responseCode = "400", description = "The body was absent after deserialisation.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Node object cannot be null"))),
+            @ApiResponse(responseCode = "500", description = "The body could not be deserialised.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "No content to map to Object due to end of input")))
+    })
+    @Override
+    public Response create(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo, final OnmsNode object) {
+        return super.create(securityContext, uriInfo, object);
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Operation(
+            summary = "Update properties of several nodes",
+            description = """
+        Apply the form parameters as bean properties to every node matching `_s`. The default `limit`
+        of 10 applies to the selection, so a call without an explicit `limit` updates at most 10 nodes;
+        pass a filter narrow enough to describe the set you mean. The whole call runs in one
+        transaction, so a per-node failure aborts the batch.
+
+        Example query: `_s=node.foreignSource==ApiDoc&limit=100`.""",
+            operationId = "NodeRestServicePUTNodes")
+    @RequestBody(required = true, description = "Node bean properties to set, form-encoded.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "object"),
+                    examples = @ExampleObject(value = "sys-contact=noc%40example.org&sys-description=updated+by+ReST")))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "All selected nodes were updated."),
+            @ApiResponse(responseCode = "404", description = "No node matched. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The FIQL expression could not be parsed or resolved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    @Override
+    public Response updateMany(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo, @Context final SearchContext searchContext, final MultivaluedMapImpl params) {
+        return super.updateMany(securityContext, uriInfo, searchContext, params);
+    }
+
+    @PUT
+    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Path("{id}")
+    @Operation(
+            summary = "Not implemented: replace a node from a document",
+            description = """
+        Answered with 501. `AbstractDaoRestServiceWithDTO.doUpdate` is not overridden for nodes. Use
+        the form-encoded `PUT /nodes/{id}` to change individual properties. Because this variant binds
+        `{id}` as an integer, a non-numeric path segment is answered with 404 before the handler
+        runs.""",
+            operationId = "NodeRestServicePUTNodeDocument")
+    @RequestBody(description = "Ignored.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = OnmsNode.class),
+                            examples = @ExampleObject(value = "{\"label\": \"ApiDoc-node\"}")),
+                    @Content(mediaType = MediaType.APPLICATION_XML, schema = @Schema(implementation = OnmsNode.class),
+                            examples = @ExampleObject(value = "<node label=\"ApiDoc-node\"/>"))
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = "`{id}` is not an integer."),
+            @ApiResponse(responseCode = "501", description = "Replacing a node from a document is not implemented. No body is returned.")
+    })
+    @Override
+    public Response update(
+            @Context final SecurityContext securityContext,
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "id", description = "Node database id.", example = "257")
+            @PathParam("id") final Integer id,
+            final OnmsNode object) {
+        return super.update(securityContext, uriInfo, id, object);
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Path("{id}")
+    @Operation(
+            summary = "Update properties of a node",
+            description = """
+        Apply the form parameters as bean properties to one node. Only the properties present in the
+        body are touched. No event is sent, so daemons holding the previous value are not notified.""",
+            operationId = "NodeRestServicePUTNodeProperties")
+    @RequestBody(required = true, description = "Node bean properties to set, form-encoded.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "object"),
+                    examples = @ExampleObject(value = "sys-contact=noc%40example.org")))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The node was updated."),
+            @ApiResponse(responseCode = "404", description = "No such node. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The path segment is neither a number nor `foreignSource:foreignId`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    @Override
+    public Response updateProperties(
+            @Context final SecurityContext securityContext,
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "id",
+                    description = "Node database id, or `foreignSource:foreignId`.", example = "257")
+            @PathParam("id") final String id,
+            final MultivaluedMapImpl params) {
+        return super.updateProperties(securityContext, uriInfo, id, params);
+    }
+
+    @DELETE
+    @Operation(
+            summary = "Delete several nodes",
+            description = """
+        Delete every node matching `_s` and send a `deleteNode` event for each. The default `limit` of
+        10 applies to the selection, so a call without an explicit `limit` deletes at most 10 nodes.
+        There is no confirmation step: pass a filter that describes exactly the nodes you mean.
+
+        Example query: `_s=node.foreignSource==ApiDoc&limit=100`.""",
+            operationId = "NodeRestServiceDELETENodes")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The selected nodes were deleted."),
+            @ApiResponse(responseCode = "404", description = "No node matched. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The FIQL expression could not be parsed or resolved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    @Override
+    public Response deleteMany(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo, @Context final SearchContext searchContext) {
+        return super.deleteMany(securityContext, uriInfo, searchContext);
+    }
+
+    @DELETE
+    @Path("{id}")
+    @Operation(
+            summary = "Delete a node",
+            description = """
+        Delete one node and send a `deleteNode` event. The node's interfaces, services, outages and
+        metadata go with it.""",
+            operationId = "NodeRestServiceDELETENodeById")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The node was deleted."),
+            @ApiResponse(responseCode = "404", description = "No such node. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The path segment is neither a number nor `foreignSource:foreignId`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    @Override
+    public Response delete(
+            @Context final SecurityContext securityContext,
+            @Context final UriInfo uriInfo,
+            @Parameter(in = ParameterIn.PATH, name = "id",
+                    description = "Node database id, or `foreignSource:foreignId`.", example = "257")
+            @PathParam("id") final String id) {
+        return super.delete(securityContext, uriInfo, id);
+    }
+
     @GET
     @Path("service-types")
     @Produces(MediaType.APPLICATION_JSON)
     @Transactional(readOnly = true)
-    @Operation(summary = "Get all service types", description = "Returns all monitored service types for use in node filtering", operationId = "NodeRestServiceGETServiceTypes")
+    @Operation(
+            summary = "Get all service types",
+            description = """
+        Return every monitored service type known to the system, sorted by name. The list is
+        system-wide, not scoped to a node, and is the set of names accepted by
+        `POST /nodes/{nodeCriteria}/ipinterfaces/{ipAddress}/services`.
+
+        This operation produces JSON only. A request with `Accept: application/xml` does not match it
+        and falls through to `GET /nodes/{id}` with an id of `service-types`, which is answered with
+        500.""",
+            operationId = "NodeRestServiceGETServiceTypes")
+    @ApiResponse(responseCode = "200", description = "All service types, sorted by name.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    array = @ArraySchema(schema = @Schema(implementation = NodeServiceTypeDto.class)),
+                    examples = @ExampleObject(value = """
+                    [
+                      {"name": "DNS", "id": 4},
+                      {"name": "HTTP-8080", "id": 2},
+                      {"name": "ICMP", "id": 1},
+                      {"name": "SNMP", "id": 3}
+                    ]""")))
     public Response getServiceTypes() {
         final List<Map<String,Object>> result = m_serviceTypeDao.findAll().stream()
             .sorted(Comparator.comparing(OnmsServiceType::getName))
@@ -527,8 +1022,29 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
     @PUT
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Path("{nodeCriteria}/rescan")
-    @Operation(summary = "Rescan node by NodeId", description = "Rescan node by NodeId", operationId = "NodeRestServicePUTRescanNodeByNodeId")
-    public Response rescanNode(@PathParam("nodeCriteria") final String nodeCriteria) {
+    @Operation(
+            summary = "Request a rescan of a node",
+            description = """
+        Send a `forceRescan` event for the node and return as soon as the event is queued. The 200 says
+        the event was accepted, not that the scan has run or succeeded; watch provisiond for the
+        outcome. The request body is not read, although the operation is declared as consuming
+        `application/x-www-form-urlencoded`.""",
+            operationId = "NodeRestServicePUTRescanNodeByNodeId")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The rescan event was sent. No body is returned."),
+            @ApiResponse(responseCode = "404", description = "No such node.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Node 999999 was not found."))),
+            @ApiResponse(responseCode = "500", description = "The path segment is neither a number nor `foreignSource:foreignId`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    public Response rescanNode(
+            @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                    description = "Node database id, or `foreignSource:foreignId`.", example = "257")
+            @PathParam("nodeCriteria") final String nodeCriteria) {
         final OnmsNode node = m_dao.get(nodeCriteria);
         if (node == null) {
             throw getException(Status.NOT_FOUND, "Node {} was not found.", nodeCriteria);
@@ -542,8 +1058,50 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
     @GET
     @Path("{nodeCriteria}/metadata")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
-    @Operation(summary = "Get Metadata by NodeId", description = "Get Metadata by NodeId", operationId = "NodeRestServiceGETMetaDataByNodeId")
-    public OnmsMetaDataList getMetaData(@PathParam("nodeCriteria") String nodeCriteria) {
+    @Operation(
+            summary = "Get all metadata of a node",
+            description = """
+        Return every metadata entry attached to the node, across all contexts. Contexts populated by
+        the system (`requisition`, `snmp` and vendor contexts) appear alongside user-defined `X-`
+        contexts. An empty result is still a 200; `totalCount` and `count` are then `null` rather
+        than `0`.""",
+            operationId = "NodeRestServiceGETMetaDataByNodeId")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Metadata entries of the node.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsMetaDataList.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 2,
+                      "count": 2,
+                      "offset": 0,
+                      "metaData": [
+                        {"context": "X-ApiDoc", "key": "owner", "value": "noc-team"},
+                        {"context": "X-ApiDoc", "key": "tier", "value": "gold"}
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsMetaDataList.class),
+                                    examples = @ExampleObject(value = """
+                    <meta-data-list count="2" offset="0" totalCount="2">
+                      <meta-data><context>X-ApiDoc</context><key>owner</key><value>noc-team</value></meta-data>
+                      <meta-data><context>X-ApiDoc</context><key>tier</key><value>gold</value></meta-data>
+                    </meta-data-list>"""))
+                    }),
+            @ApiResponse(responseCode = "400", description = "No such node.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "getMetaData: Can't find node 999999"))),
+            @ApiResponse(responseCode = "500", description = "The node path segment is neither a number nor `foreignSource:foreignId`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    public OnmsMetaDataList getMetaData(
+            @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                    description = "Node database id, or `foreignSource:foreignId`. A value that is neither is answered with 500.", example = "257")
+            @PathParam("nodeCriteria") String nodeCriteria) {
         final OnmsNode node = getDao().get(nodeCriteria);
 
         if (node == null) {
@@ -556,8 +1114,47 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
     @GET
     @Path("{nodeCriteria}/metadata/{context}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
-    @Operation(summary = "Get Metadata by NodeId and Context", description = "Get Metadata by NodeId and Context", operationId = "NodeRestServiceGETMetaDataByNodeIdAndContext")
-    public OnmsMetaDataList getMetaData(@PathParam("nodeCriteria") String nodeCriteria, @PathParam("context") String context) {
+    @Operation(
+            summary = "Get metadata of a node in one context",
+            description = """
+        Return the node's metadata entries whose context matches exactly, case-sensitively. A context
+        that holds no entries and a context that does not exist are indistinguishable: both give a 200
+        with an empty list.""",
+            operationId = "NodeRestServiceGETMetaDataByNodeIdAndContext")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Metadata entries in that context, possibly empty.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsMetaDataList.class),
+                                    examples = {
+                                            @ExampleObject(name = "match", value = """
+                    {"totalCount": 1, "count": 1, "offset": 0, "metaData": [{"context": "X-ApiDoc", "key": "owner", "value": "noc-team"}]}"""),
+                                            @ExampleObject(name = "no match", value = """
+                    {"totalCount": null, "count": null, "offset": 0, "metaData": []}""")
+                                    }),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsMetaDataList.class),
+                                    examples = @ExampleObject(value = """
+                    <meta-data-list count="1" offset="0" totalCount="1">
+                      <meta-data><context>X-ApiDoc</context><key>owner</key><value>noc-team</value></meta-data>
+                    </meta-data-list>"""))
+                    }),
+            @ApiResponse(responseCode = "400", description = "No such node.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "getMetaData: Can't find node 999999"))),
+            @ApiResponse(responseCode = "500", description = "The node path segment is neither a number nor `foreignSource:foreignId`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    public OnmsMetaDataList getMetaData(
+            @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                    description = "Node database id, or `foreignSource:foreignId`.", example = "257")
+            @PathParam("nodeCriteria") String nodeCriteria,
+            @Parameter(in = ParameterIn.PATH, name = "context",
+                    description = "Metadata context to filter on.", example = "X-ApiDoc")
+            @PathParam("context") String context) {
         final OnmsNode node = getDao().get(nodeCriteria);
 
         if (node == null) {
@@ -572,8 +1169,38 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
     @GET
     @Path("{nodeCriteria}/metadata/{context}/{key}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
-    @Operation(summary = "Get Metadata by NodeId, Context and Key", description = "Get Metadata by NodeId, Context and Key", operationId = "NodeRestServiceGETMetaDataByNodeIdAndContextAndKey")
-    public OnmsMetaDataList getMetaData(@PathParam("nodeCriteria") String nodeCriteria, @PathParam("context") String context, @PathParam("key") String key) {
+    @Operation(
+            summary = "Get one metadata entry of a node",
+            description = """
+        Return the node's metadata entries matching both context and key. At most one entry can match,
+        but the response is still the list envelope. An unknown context or key gives a 200 with an
+        empty list.""",
+            operationId = "NodeRestServiceGETMetaDataByNodeIdAndContextAndKey")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The matching entry, or an empty list.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsMetaDataList.class),
+                            examples = @ExampleObject(value = """
+                    {"totalCount": 1, "count": 1, "offset": 0, "metaData": [{"context": "X-ApiDoc", "key": "owner", "value": "noc-team"}]}"""))),
+            @ApiResponse(responseCode = "400", description = "No such node.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "getMetaData: Can't find node 999999"))),
+            @ApiResponse(responseCode = "500", description = "The node path segment is neither a number nor `foreignSource:foreignId`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    public OnmsMetaDataList getMetaData(
+            @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                    description = "Node database id, or `foreignSource:foreignId`.", example = "257")
+            @PathParam("nodeCriteria") String nodeCriteria,
+            @Parameter(in = ParameterIn.PATH, name = "context",
+                    description = "Metadata context.", example = "X-ApiDoc")
+            @PathParam("context") String context,
+            @Parameter(in = ParameterIn.PATH, name = "key",
+                    description = "Metadata key within the context.", example = "owner")
+            @PathParam("key") String key) {
         final OnmsNode node = getDao().get(nodeCriteria);
 
         if (node == null) {
@@ -588,7 +1215,35 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
     @DELETE
     @Path("{nodeCriteria}/metadata/{context}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
-    public Response deleteMetaData(@PathParam("nodeCriteria") final String nodeCriteria, @PathParam("context") final String context) {
+    @Operation(
+            summary = "Delete a metadata context of a node",
+            description = """
+        Remove every metadata entry of the node in the given context. Deleting a context that holds no
+        entries is also a 204. The context is checked before the node is looked up, so a non-`X-`
+        context is answered with 403 even for a node that does not exist.""",
+            operationId = "NodeRestServiceDELETEMetaDataByNodeIdAndContext")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The context was removed."),
+            @ApiResponse(responseCode = "400", description = "No such node.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "deleteMetaData: Can't find node 999999"))),
+            @ApiResponse(responseCode = "403", description = "The context does not start with `X-`. Only user-defined contexts may be written through this API.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Only metadata in contexts starting with 'X-' can be modified"))),
+            @ApiResponse(responseCode = "500", description = "The node path segment is neither a number nor `foreignSource:foreignId`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    public Response deleteMetaData(
+            @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                    description = "Node database id, or `foreignSource:foreignId`.", example = "257")
+            @PathParam("nodeCriteria") final String nodeCriteria,
+            @Parameter(in = ParameterIn.PATH, name = "context",
+                    description = "Metadata context to remove. Must start with `X-`.", example = "X-ApiDoc")
+            @PathParam("context") final String context) {
         checkUserDefinedMetadataContext(context);
 
         writeLock();
@@ -608,7 +1263,37 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
     @DELETE
     @Path("{nodeCriteria}/metadata/{context}/{key}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
-    public Response deleteMetaData(@PathParam("nodeCriteria") final String nodeCriteria, @PathParam("context") final String context, @PathParam("key") final String key) {
+    @Operation(
+            summary = "Delete one metadata entry of a node",
+            description = """
+        Remove a single metadata entry of the node. Deleting a key that does not exist is also a
+        204.""",
+            operationId = "NodeRestServiceDELETEMetaDataByNodeIdAndContextAndKey")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The entry was removed."),
+            @ApiResponse(responseCode = "400", description = "No such node.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "deleteMetaData: Can't find node 999999"))),
+            @ApiResponse(responseCode = "403", description = "The context does not start with `X-`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Only metadata in contexts starting with 'X-' can be modified"))),
+            @ApiResponse(responseCode = "500", description = "The node path segment is neither a number nor `foreignSource:foreignId`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    public Response deleteMetaData(
+            @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                    description = "Node database id, or `foreignSource:foreignId`.", example = "257")
+            @PathParam("nodeCriteria") final String nodeCriteria,
+            @Parameter(in = ParameterIn.PATH, name = "context",
+                    description = "Metadata context. Must start with `X-`.", example = "X-ApiDoc")
+            @PathParam("context") final String context,
+            @Parameter(in = ParameterIn.PATH, name = "key",
+                    description = "Metadata key to remove.", example = "owner")
+            @PathParam("key") final String key) {
         checkUserDefinedMetadataContext(context);
 
         writeLock();
@@ -628,7 +1313,46 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
     @POST
     @Path("{nodeCriteria}/metadata")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
-    public Response postMetaData(@PathParam("nodeCriteria") final String nodeCriteria, final OnmsMetaData entity) {
+    @Operation(
+            summary = "Add or replace a metadata entry of a node",
+            description = """
+        Set one metadata entry from the request body. An existing entry with the same context and key is
+        overwritten, so this is an upsert rather than an append. No `@Consumes` is declared, so both
+        JSON and XML bodies are accepted; the XML root element is `meta-data`. The context is checked
+        before the node is looked up, so a non-`X-` context is answered with 403 even for a node that
+        does not exist.""",
+            operationId = "NodeRestServicePOSTMetaDataByNodeId")
+    @RequestBody(required = true, description = "The metadata entry to set. The context must start with `X-`.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsMetaData.class),
+                            examples = @ExampleObject(value = """
+                    {"context": "X-ApiDoc", "key": "owner", "value": "noc-team"}""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = OnmsMetaData.class),
+                            examples = @ExampleObject(value = """
+                    <meta-data><context>X-ApiDoc</context><key>owner</key><value>noc-team</value></meta-data>"""))
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The entry was stored."),
+            @ApiResponse(responseCode = "400", description = "No such node.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "postMetaData: Can't find node 999999"))),
+            @ApiResponse(responseCode = "403", description = "The context does not start with `X-`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Only metadata in contexts starting with 'X-' can be modified"))),
+            @ApiResponse(responseCode = "500", description = "The node path segment is neither a number nor `foreignSource:foreignId`, or the body could not be deserialised.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    public Response postMetaData(
+            @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                    description = "Node database id, or `foreignSource:foreignId`.", example = "257")
+            @PathParam("nodeCriteria") final String nodeCriteria,
+            final OnmsMetaData entity) {
         checkUserDefinedMetadataContext(entity.getContext());
 
         writeLock();
@@ -648,7 +1372,41 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
     @PUT
     @Path("{nodeCriteria}/metadata/{context}/{key}/{value}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
-    public Response putMetaData(@PathParam("nodeCriteria") final String nodeCriteria, @PathParam("context") final String context, @PathParam("key") final String key, @PathParam("value") final String value) {
+    @Operation(
+            summary = "Set a metadata entry of a node from the path",
+            description = """
+        Set one metadata entry with context, key and value all taken from the path. An existing entry
+        with the same context and key is overwritten. A value containing `/` has to be percent-encoded,
+        and an empty value cannot be expressed this way; use the `POST` form for those.""",
+            operationId = "NodeRestServicePUTMetaDataByNodeId")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The entry was stored."),
+            @ApiResponse(responseCode = "400", description = "No such node.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "putMetaData: Can't find node 999999"))),
+            @ApiResponse(responseCode = "403", description = "The context does not start with `X-`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Only metadata in contexts starting with 'X-' can be modified"))),
+            @ApiResponse(responseCode = "500", description = "The node path segment is neither a number nor `foreignSource:foreignId`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    public Response putMetaData(
+            @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                    description = "Node database id, or `foreignSource:foreignId`.", example = "257")
+            @PathParam("nodeCriteria") final String nodeCriteria,
+            @Parameter(in = ParameterIn.PATH, name = "context",
+                    description = "Metadata context. Must start with `X-`.", example = "X-ApiDoc")
+            @PathParam("context") final String context,
+            @Parameter(in = ParameterIn.PATH, name = "key",
+                    description = "Metadata key.", example = "owner")
+            @PathParam("key") final String key,
+            @Parameter(in = ParameterIn.PATH, name = "value",
+                    description = "Metadata value.", example = "noc-team")
+            @PathParam("value") final String value) {
         checkUserDefinedMetadataContext(context);
 
         writeLock();

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
@@ -509,9 +509,8 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
         a 200. Nodes with `type` of `D` (deleted) are not excluded.
 
         In JSON, `id` is a string and `createTime`, `lastIngressFlow`, `lastEgressFlow` and the asset
-        record timestamps are epoch milliseconds; the auto-derived `string/date-time` schema for those
-        fields does not describe the JSON wire format. The XML representation of the same fields is
-        ISO-8601 with an offset.
+        record timestamps are epoch milliseconds, although the derived schema for those fields shows
+        `string`/`date-time`. The XML representation of the same fields is ISO-8601 with an offset.
 
         Example query: `_s=node.foreignSource==Servers;category.name==Production&orderBy=label`.""",
             operationId = "NodeRestServiceGETNodes")
@@ -747,7 +746,7 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
     @Path("{id}")
     @Operation(
             summary = "Rejected: create a node at a caller-chosen id",
-            description = "Always answered with 404. Node ids are assigned by the server; post to `/nodes` instead.",
+            description = "Always answered with 404, whether or not the id exists.",
             operationId = "NodeRestServicePOSTNodeSpecific",
             parameters = @Parameter(in = ParameterIn.PATH, name = "id", required = true,
                     description = "Node database id, or `foreignSource:foreignId`. The value is not read: every request to this path is answered with 404.",
@@ -763,14 +762,10 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
     @Operation(
             summary = "Create a node",
             description = """
-        Create a node and send a `nodeAdded` event. `label` is the only field worth supplying in
-        practice; when `location` is omitted the default monitoring location is used. The new node's
-        URI is returned in the `Location` header. Provisiond does not own a node created this way, so a
-        requisition synchronisation will not preserve it unless the matching `foreignSource` and
-        `foreignId` also exist in a requisition.
-
-        JSON is read by Jackson with a JAXB introspector and XML by JAXB; the two representations are
-        not interchangeable. A body that fails to parse is answered with 500, not 400.""",
+        Create a node and send a `nodeAdded` event. When `location` is omitted the default monitoring
+        location is used, and the new node's URI is returned in the `Location` header. A requisition
+        synchronisation does not preserve the node unless the matching `foreignSource` and `foreignId`
+        also exist in a requisition. A body that fails to parse is answered with 500, not 400.""",
             operationId = "NodeRestServicePOSTNode")
     @RequestBody(required = true, description = "The node to create.",
             content = {
@@ -819,9 +814,8 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
             summary = "Update properties of several nodes",
             description = """
         Apply the form parameters as bean properties to every node matching `_s`. The default `limit`
-        of 10 applies to the selection, so a call without an explicit `limit` updates at most 10 nodes;
-        pass a filter narrow enough to describe the set you mean. The whole call runs in one
-        transaction, so a per-node failure aborts the batch.
+        of 10 applies to the selection, so a call without an explicit `limit` updates at most 10 nodes.
+        The whole call runs in one transaction, so a per-node failure aborts the batch.
 
         Example query: `_s=node.foreignSource==ApiDoc&limit=100`.""",
             operationId = "NodeRestServicePUTNodes")
@@ -848,10 +842,8 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
     @Operation(
             summary = "Not implemented: replace a node from a document",
             description = """
-        Answered with 501. `AbstractDaoRestServiceWithDTO.doUpdate` is not overridden for nodes. Use
-        the form-encoded `PUT /nodes/{id}` to change individual properties. Because this variant binds
-        `{id}` as an integer, a non-numeric path segment is answered with 404 before the handler
-        runs.""",
+        Answered with 501. This variant binds `{id}` as an integer, so a non-numeric path segment is
+        answered with 404 before the handler runs.""",
             operationId = "NodeRestServicePUTNodeDocument")
     @RequestBody(description = "Ignored.",
             content = {
@@ -881,7 +873,7 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
             summary = "Update properties of a node",
             description = """
         Apply the form parameters as bean properties to one node. Only the properties present in the
-        body are touched. No event is sent, so daemons holding the previous value are not notified.""",
+        body are touched. No event is sent.""",
             operationId = "NodeRestServicePUTNodeProperties")
     @RequestBody(required = true, description = "Node bean properties to set, form-encoded.",
             content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
@@ -912,7 +904,6 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
             description = """
         Delete every node matching `_s` and send a `deleteNode` event for each. The default `limit` of
         10 applies to the selection, so a call without an explicit `limit` deletes at most 10 nodes.
-        There is no confirmation step: pass a filter that describes exactly the nodes you mean.
 
         Example query: `_s=node.foreignSource==ApiDoc&limit=100`.""",
             operationId = "NodeRestServiceDELETENodes")
@@ -970,16 +961,22 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
         and falls through to `GET /nodes/{id}` with an id of `service-types`, which is answered with
         500.""",
             operationId = "NodeRestServiceGETServiceTypes")
-    @ApiResponse(responseCode = "200", description = "All service types, sorted by name.",
-            content = @Content(mediaType = MediaType.APPLICATION_JSON,
-                    array = @ArraySchema(schema = @Schema(implementation = NodeServiceTypeDto.class)),
-                    examples = @ExampleObject(value = """
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "All service types, sorted by name.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            array = @ArraySchema(schema = @Schema(implementation = NodeServiceTypeDto.class)),
+                            examples = @ExampleObject(value = """
                     [
                       {"name": "DNS", "id": 4},
                       {"name": "HTTP-8080", "id": 2},
                       {"name": "ICMP", "id": 1},
                       {"name": "SNMP", "id": 3}
-                    ]""")))
+                    ]"""))),
+            @ApiResponse(responseCode = "500", description = "The request asked for `application/xml`, so it matched `GET /nodes/{id}` with an id of `service-types` instead.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"service-types\"")))
+    })
     public Response getServiceTypes() {
         final List<Map<String,Object>> result = m_serviceTypeDao.findAll().stream()
             .sorted(Comparator.comparing(OnmsServiceType::getName))
@@ -1026,9 +1023,8 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
             summary = "Request a rescan of a node",
             description = """
         Send a `forceRescan` event for the node and return as soon as the event is queued. The 200 says
-        the event was accepted, not that the scan has run or succeeded; watch provisiond for the
-        outcome. The request body is not read, although the operation is declared as consuming
-        `application/x-www-form-urlencoded`.""",
+        the event was accepted, not that the scan has run or succeeded. The request body is not read,
+        although the operation is declared as consuming `application/x-www-form-urlencoded`.""",
             operationId = "NodeRestServicePUTRescanNodeByNodeId")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "The rescan event was sent. No body is returned."),
@@ -1317,7 +1313,7 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
             summary = "Add or replace a metadata entry of a node",
             description = """
         Set one metadata entry from the request body. An existing entry with the same context and key is
-        overwritten, so this is an upsert rather than an append. No `@Consumes` is declared, so both
+        overwritten. No `@Consumes` is declared, so both
         JSON and XML bodies are accepted; the XML root element is `meta-data`. The context is checked
         before the node is looked up, so a non-`X-` context is answered with 403 even for a node that
         does not exist.""",
@@ -1377,7 +1373,7 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
             description = """
         Set one metadata entry with context, key and value all taken from the path. An existing entry
         with the same context and key is overwritten. A value containing `/` has to be percent-encoded,
-        and an empty value cannot be expressed this way; use the `POST` form for those.""",
+        and an empty value cannot be expressed this way.""",
             operationId = "NodeRestServicePUTMetaDataByNodeId")
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "The entry was stored."),

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeSnmpInterfacesRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeSnmpInterfacesRestService.java
@@ -160,8 +160,8 @@ public class NodeSnmpInterfacesRestService extends AbstractNodeDependentRestServ
         narrows within the node rather than across the system. `limit` defaults to 10, and the response
         carries a `Content-Range` header of the form `items <offset>-<last>/<totalCount>`.
 
-        This endpoint declares no search-property set, so its `properties` operation answers 204 and
-        cannot be used to discover names. A `_s` term is still resolved against the bean properties of
+        This endpoint declares no search-property set, so its `properties` operation answers 204. A
+        `_s` term is still resolved against the bean properties of
         the SNMP interface and, under the `node.` prefix, against the joined node, for example
         `_s=ifName==eth0` or `_s=node.label==router-1`. A name that cannot be resolved is answered with
         500.
@@ -286,7 +286,7 @@ public class NodeSnmpInterfacesRestService extends AbstractNodeDependentRestServ
     @Operation(
             summary = "Get SNMP interface search properties",
             description = """
-        Intended to list the properties usable in `_s` and `orderBy`. This endpoint does not declare a
+        Lists the properties usable in `_s` and `orderBy`. This endpoint does not declare a
         search-property set, so the list is empty and the operation answers 204 for every request,
         including one with a `q` filter. `_s` and `orderBy` still work: they resolve against the bean
         properties of the SNMP interface and of the joined node under the `node.` prefix. The
@@ -306,7 +306,7 @@ public class NodeSnmpInterfacesRestService extends AbstractNodeDependentRestServ
     @Operation(
             summary = "Get values of an SNMP interface search property",
             description = """
-        Intended to return the distinct values a search property takes. Because this endpoint declares
+        Returns the distinct values a search property takes. Because this endpoint declares
         no search properties, no `propertyId` can match and the operation answers 404 for every
         request. The equivalent operation on `/snmpinterfaces` does return values.""",
             operationId = "NodeSnmpInterfacesRestServiceGETSnmpInterfaceSearchPropertyValues",
@@ -395,7 +395,7 @@ public class NodeSnmpInterfacesRestService extends AbstractNodeDependentRestServ
     @Path("{id}")
     @Operation(
             summary = "Rejected: create an SNMP interface at a caller-chosen path",
-            description = "Always answered with 404. Post the interface to the collection instead; its `ifIndex` travels in the body.",
+            description = "Always answered with 404, whether or not the `ifIndex` exists.",
             operationId = "NodeSnmpInterfacesRestServicePOSTSnmpInterfaceSpecific",
             parameters = {
                     @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
@@ -415,8 +415,7 @@ public class NodeSnmpInterfacesRestService extends AbstractNodeDependentRestServ
     @Operation(
             summary = "Add an SNMP interface to a node",
             description = """
-        Attach an SNMP interface to the node. `ifIndex` is the only required field. No event is sent, so
-        daemons already holding the node's interface list are not notified.
+        Attach an SNMP interface to the node. `ifIndex` is the only required field. No event is sent.
 
         `collectFlag` and `pollFlag` are the stored collection and polling flags. `collectFlag` of `C`
         or `N` records the choice without a source, `UC` and `UN` mark it user specified, and `PC` and
@@ -425,8 +424,7 @@ public class NodeSnmpInterfacesRestService extends AbstractNodeDependentRestServ
         the response follow from them. In XML `ifIndex`, `collectFlag` and `pollFlag` are attributes
         rather than elements, and sending them as elements leaves them unset.
 
-        The `Location` header of the 201 addresses the interface by `ifIndex`, matching the identifier
-        the item operations expect.""",
+        The `Location` header of the 201 addresses the interface by `ifIndex`.""",
             operationId = "NodeSnmpInterfacesRestServicePOSTSnmpInterface",
             parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
                     description = "Node database id, or `foreignSource:foreignId`.", example = "274"))
@@ -544,11 +542,10 @@ public class NodeSnmpInterfacesRestService extends AbstractNodeDependentRestServ
         Parameter names are normalised, so the wire names differ from the JSON and XML field names:
         `if-alias` or `if_alias` reaches `ifAlias` while the camel-case `ifAlias` does not, and the
         stored collection and polling flags are reached as `collect` and `poll` rather than as
-        `collectFlag` and `pollFlag`. `ifIndex` is rejected, under any spelling: delete the interface
-        and add it again to change its index.
+        `collectFlag` and `pollFlag`. `ifIndex` is rejected with 400 under any spelling.
 
-        Sending a JSON or XML body to the same path selects a different operation, which answers 501
-        because replacing an SNMP interface from a document is not implemented here.""",
+        Sending a JSON or XML body to the same path selects a different operation, which answers
+        501.""",
             operationId = "NodeSnmpInterfacesRestServicePUTSnmpInterfaceProperties",
             parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
                     description = "Node database id, or `foreignSource:foreignId`.", example = "274"))
@@ -605,8 +602,7 @@ public class NodeSnmpInterfacesRestService extends AbstractNodeDependentRestServ
     @Operation(
             summary = "Delete an SNMP interface",
             description = """
-        Delete one SNMP interface of the node, addressed by `ifIndex`. No event is sent, so daemons
-        already holding the node's interface list are not notified.""",
+        Delete one SNMP interface of the node, addressed by `ifIndex`. No event is sent.""",
             operationId = "NodeSnmpInterfacesRestServiceDELETESnmpInterfaceByIfIndex",
             parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
                     description = "Node database id, or `foreignSource:foreignId`.", example = "274"))

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeSnmpInterfacesRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeSnmpInterfacesRestService.java
@@ -23,10 +23,35 @@ package org.opennms.web.rest.v2;
 
 import java.util.Collection;
 
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import org.apache.cxf.jaxrs.ext.search.SearchContext;
 
 import org.opennms.core.config.api.JaxbListWrapper;
 import org.opennms.core.criteria.CriteriaBuilder;
@@ -121,6 +146,481 @@ public class NodeSnmpInterfacesRestService extends AbstractNodeDependentRestServ
     protected OnmsSnmpInterface doGet(UriInfo uriInfo, Integer ifIndex) {
         final OnmsNode node = getNode(uriInfo);
         return node == null ? null : node.getSnmpInterfaceWithIfIndex(ifIndex);
+    }
+
+    // The generic collection and item operations below are inherited from AbstractDaoRestServiceWithDTO.
+    // They are overridden here only so that each concrete path carries its own OpenAPI documentation;
+    // the JAX-RS annotations repeat the inherited ones and the bodies delegate unchanged.
+    @GET
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get the SNMP interfaces of a node",
+            description = """
+        Return the node's SNMP interfaces. The criteria are restricted to the node in the path, so `_s`
+        narrows within the node rather than across the system. `limit` defaults to 10, and the response
+        carries a `Content-Range` header of the form `items <offset>-<last>/<totalCount>`.
+
+        This endpoint declares no search-property set, so its `properties` operation answers 204 and
+        cannot be used to discover names. A `_s` term is still resolved against the bean properties of
+        the SNMP interface and, under the `node.` prefix, against the joined node, for example
+        `_s=ifName==eth0` or `_s=node.label==router-1`. A name that cannot be resolved is answered with
+        500.
+
+        `lastCapsdPoll`, `lastSnmpPoll`, `lastIngressFlow` and `lastEgressFlow` come from the same
+        fields in both representations but are rendered as epoch milliseconds in JSON and as ISO-8601
+        with an offset in XML. `collect`, `poll`, `hasFlows`, `hasIngressFlows`, `hasEgressFlows`,
+        `collectionPolicySpecified` and `collectionUserSpecified` are derived from the stored
+        `collectFlag` and `pollFlag` values.
+
+        `application/atom+xml` is also accepted and returns the same document as `application/xml`.""",
+            operationId = "NodeSnmpInterfacesRestServiceGETSnmpInterfaces",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                    description = "Node database id, or `foreignSource:foreignId`. A value that is neither is answered with 500.",
+                    example = "274"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Matching SNMP interfaces.",
+                    headers = @Header(name = "Content-Range", description = "`items <offset>-<last>/<totalCount>` for this page.",
+                            schema = @Schema(type = "string")),
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsSnmpInterfaceList.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 1,
+                      "count": 1,
+                      "offset": 0,
+                      "snmpInterface": [
+                        {
+                          "id": 23745,
+                          "ifIndex": 11,
+                          "ifDescr": "ApiDoc11-eth0",
+                          "ifName": "ApiDoc11-eth0",
+                          "ifAlias": "uplink",
+                          "ifType": 6,
+                          "ifSpeed": 100000000,
+                          "ifAdminStatus": 1,
+                          "ifOperStatus": 1,
+                          "physAddr": "02004c4f4f11",
+                          "collectFlag": "C",
+                          "collect": true,
+                          "collectionPolicySpecified": false,
+                          "collectionUserSpecified": false,
+                          "pollFlag": "P",
+                          "poll": true,
+                          "hasFlows": false,
+                          "hasIngressFlows": false,
+                          "hasEgressFlows": false,
+                          "lastIngressFlow": null,
+                          "lastEgressFlow": null,
+                          "lastCapsdPoll": 1787235330000,
+                          "lastSnmpPoll": null,
+                          "nodeId": 274
+                        }
+                      ]
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsSnmpInterfaceList.class),
+                                    examples = @ExampleObject(value = """
+                    <snmpInterfaces count="1" offset="0" totalCount="1">
+                      <snmpInterface collectFlag="C" collect="true" id="23745" ifIndex="11" pollFlag="P" poll="true">
+                        <ifAdminStatus>1</ifAdminStatus>
+                        <ifAlias>uplink</ifAlias>
+                        <ifDescr>ApiDoc11-eth0</ifDescr>
+                        <ifName>ApiDoc11-eth0</ifName>
+                        <ifOperStatus>1</ifOperStatus>
+                        <ifSpeed>100000000</ifSpeed>
+                        <ifType>6</ifType>
+                        <lastCapsdPoll>2026-08-20T10:15:30-04:00</lastCapsdPoll>
+                        <nodeId>274</nodeId>
+                        <physAddr>02004c4f4f11</physAddr>
+                      </snmpInterface>
+                    </snmpInterfaces>"""))
+                    }),
+            @ApiResponse(responseCode = "204", description = "The node has no matching SNMP interface, or no node has that id. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The node path segment could not be parsed, or the FIQL expression could not be parsed or resolved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "badSearch", value = "Error parsing FIQL search"),
+                                    @ExampleObject(name = "badNodeCriteria", value = "For input string: \"notanode\"")
+                            }))
+    })
+    @Override
+    public Response get(@Context final UriInfo uriInfo, @Context final SearchContext searchContext) {
+        return super.get(uriInfo, searchContext);
+    }
+
+    @GET
+    @Path("count")
+    @Produces({MediaType.TEXT_PLAIN})
+    @Operation(
+            summary = "Count the SNMP interfaces of a node",
+            description = """
+        Return the number of the node's SNMP interfaces matching `_s` as a bare decimal string.
+
+        Only `text/plain` is produced. A request that sends `Accept: application/json` does not match
+        this operation, falls through to the single-interface GET with `count` as the identifier, and is
+        answered with 404.""",
+            operationId = "NodeSnmpInterfacesRestServiceGETSnmpInterfaceCount",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                    description = "Node database id, or `foreignSource:foreignId`.", example = "274"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Number of matching SNMP interfaces.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "13"))),
+            @ApiResponse(responseCode = "404", description = "The request asked for a media type this operation does not produce. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The node path segment could not be parsed, or the FIQL expression could not be parsed or resolved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    @Override
+    public Response getCount(@Context final UriInfo uriInfo, @Context final SearchContext searchContext) {
+        return super.getCount(uriInfo, searchContext);
+    }
+
+    @GET
+    @Path("properties")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Operation(
+            summary = "Get SNMP interface search properties",
+            description = """
+        Intended to list the properties usable in `_s` and `orderBy`. This endpoint does not declare a
+        search-property set, so the list is empty and the operation answers 204 for every request,
+        including one with a `q` filter. `_s` and `orderBy` still work: they resolve against the bean
+        properties of the SNMP interface and of the joined node under the `node.` prefix. The
+        equivalent operation on `/snmpinterfaces` does return a property list.""",
+            operationId = "NodeSnmpInterfacesRestServiceGETSnmpInterfaceSearchProperties",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                    description = "Node database id, or `foreignSource:foreignId`. The result does not depend on it.", example = "274"))
+    @ApiResponse(responseCode = "204", description = "No search properties are declared for this endpoint. No body is returned.")
+    @Override
+    public Response getProperties(@QueryParam("q") final String query) {
+        return super.getProperties(query);
+    }
+
+    @GET
+    @Path("properties/{propertyId}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Operation(
+            summary = "Get values of an SNMP interface search property",
+            description = """
+        Intended to return the distinct values a search property takes. Because this endpoint declares
+        no search properties, no `propertyId` can match and the operation answers 404 for every
+        request. The equivalent operation on `/snmpinterfaces` does return values.""",
+            operationId = "NodeSnmpInterfacesRestServiceGETSnmpInterfaceSearchPropertyValues",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                    description = "Node database id, or `foreignSource:foreignId`. The result does not depend on it.", example = "274"))
+    @ApiResponse(responseCode = "404", description = "No search property has that id, which is the case for every id here. No body is returned.")
+    @Override
+    public Response getPropertyValues(@PathParam("propertyId") final String propertyId, @QueryParam("q") final String query, @QueryParam("limit") final Integer limit) {
+        return super.getPropertyValues(propertyId, query, limit);
+    }
+
+    @GET
+    @Path("{id}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
+    @Operation(
+            summary = "Get an SNMP interface of a node",
+            description = """
+        Return one SNMP interface of the node. The path identifier is the interface's `ifIndex`, not its
+        database `id`; passing a database id normally yields 404. A value that is not an integer is
+        rejected by path-parameter conversion, also with 404.
+
+        Timestamps are epoch milliseconds in JSON and ISO-8601 with an offset in XML.""",
+            operationId = "NodeSnmpInterfacesRestServiceGETSnmpInterfaceByIfIndex",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                    description = "Node database id, or `foreignSource:foreignId`.", example = "274"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The SNMP interface.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = OnmsSnmpInterface.class),
+                                    examples = @ExampleObject(value = """
+                    {
+                      "id": 23745,
+                      "ifIndex": 11,
+                      "ifDescr": "ApiDoc11-eth0",
+                      "ifName": "ApiDoc11-eth0",
+                      "ifAlias": "uplink",
+                      "ifType": 6,
+                      "ifSpeed": 100000000,
+                      "ifAdminStatus": 1,
+                      "ifOperStatus": 1,
+                      "physAddr": "02004c4f4f11",
+                      "collectFlag": "C",
+                      "collect": true,
+                      "collectionPolicySpecified": false,
+                      "collectionUserSpecified": false,
+                      "pollFlag": "P",
+                      "poll": true,
+                      "hasFlows": false,
+                      "hasIngressFlows": false,
+                      "hasEgressFlows": false,
+                      "lastIngressFlow": null,
+                      "lastEgressFlow": null,
+                      "lastCapsdPoll": 1787235330000,
+                      "lastSnmpPoll": null,
+                      "nodeId": 274
+                    }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = OnmsSnmpInterface.class),
+                                    examples = @ExampleObject(value = """
+                    <snmpInterface collectFlag="C" collect="true" id="23745" ifIndex="11" pollFlag="P" poll="true">
+                      <ifAdminStatus>1</ifAdminStatus>
+                      <ifAlias>uplink</ifAlias>
+                      <ifDescr>ApiDoc11-eth0</ifDescr>
+                      <ifName>ApiDoc11-eth0</ifName>
+                      <ifOperStatus>1</ifOperStatus>
+                      <ifSpeed>100000000</ifSpeed>
+                      <ifType>6</ifType>
+                      <lastCapsdPoll>2026-08-20T10:15:30-04:00</lastCapsdPoll>
+                      <nodeId>274</nodeId>
+                      <physAddr>02004c4f4f11</physAddr>
+                    </snmpInterface>"""))
+                    }),
+            @ApiResponse(responseCode = "404", description = "The node has no interface with that `ifIndex`, or the identifier is not an integer. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The node path segment is neither a number nor `foreignSource:foreignId`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanode\"")))
+    })
+    @Override
+    public Response get(@Context final UriInfo uriInfo, @Parameter(description = "`ifIndex` of the interface, not its database id.", example = "11") @PathParam("id") final Integer id) {
+        return super.get(uriInfo, id);
+    }
+
+    @POST
+    @Path("{id}")
+    @Operation(
+            summary = "Rejected: create an SNMP interface at a caller-chosen path",
+            description = "Always answered with 404. Post the interface to the collection instead; its `ifIndex` travels in the body.",
+            operationId = "NodeSnmpInterfacesRestServicePOSTSnmpInterfaceSpecific",
+            parameters = {
+                    @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                            description = "Node database id, or `foreignSource:foreignId`. The result does not depend on it.", example = "274"),
+                    @Parameter(in = ParameterIn.PATH, name = "id",
+                            description = "Ignored. Any value produces the same response.",
+                            schema = @Schema(type = "string"), example = "11")
+            })
+    @ApiResponse(responseCode = "404", description = "Not supported. No body is returned.")
+    @Override
+    public Response createSpecific() {
+        return super.createSpecific();
+    }
+
+    @POST
+    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Operation(
+            summary = "Add an SNMP interface to a node",
+            description = """
+        Attach an SNMP interface to the node. `ifIndex` is the only required field. No event is sent, so
+        daemons already holding the node's interface list are not notified.
+
+        `collectFlag` and `pollFlag` are the stored collection and polling flags. `collectFlag` of `C`
+        or `N` records the choice without a source, `UC` and `UN` mark it user specified, and `PC` and
+        `PN` mark it policy specified; `pollFlag` of `P` enables service polling on the interface. The
+        derived `collect`, `poll`, `collectionUserSpecified` and `collectionPolicySpecified` values in
+        the response follow from them. In XML `ifIndex`, `collectFlag` and `pollFlag` are attributes
+        rather than elements, and sending them as elements leaves them unset.
+
+        The `Location` header of the 201 addresses the interface by `ifIndex`, matching the identifier
+        the item operations expect.""",
+            operationId = "NodeSnmpInterfacesRestServicePOSTSnmpInterface",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                    description = "Node database id, or `foreignSource:foreignId`.", example = "274"))
+    @RequestBody(required = true, description = "The SNMP interface to add.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = OnmsSnmpInterface.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "ifIndex": 11,
+                      "ifDescr": "ApiDoc11-eth0",
+                      "ifName": "ApiDoc11-eth0",
+                      "ifAlias": "uplink",
+                      "ifType": 6,
+                      "ifSpeed": 1000000000,
+                      "ifAdminStatus": 1,
+                      "ifOperStatus": 1,
+                      "physAddr": "02004c4f4f11",
+                      "collectFlag": "C",
+                      "pollFlag": "P"
+                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(implementation = OnmsSnmpInterface.class),
+                            examples = @ExampleObject(value = """
+                    <snmpInterface ifIndex="11" collectFlag="C" pollFlag="P">
+                      <ifDescr>ApiDoc11-eth0</ifDescr>
+                      <ifName>ApiDoc11-eth0</ifName>
+                      <ifAlias>uplink</ifAlias>
+                      <ifType>6</ifType>
+                      <ifSpeed>1000000000</ifSpeed>
+                    </snmpInterface>"""))
+            })
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "The interface was added. `Location` carries its URI.",
+                    headers = @Header(name = "Location", description = "URI of the created SNMP interface, keyed by `ifIndex`.",
+                            schema = @Schema(type = "string", example = "http://localhost:8980/opennms/api/v2/nodes/274/snmpinterfaces/11"))),
+            @ApiResponse(responseCode = "400", description = "The node was not found, or the body carried no `ifIndex`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "noIfIndex", value = "SNMP Interface's ifIndex cannot be null"),
+                                    @ExampleObject(name = "noNode", value = "Node was not found.")
+                            })),
+            @ApiResponse(responseCode = "415", description = "The body was form-encoded. Send JSON or XML. No body is returned."),
+            @ApiResponse(responseCode = "500", description = """
+                    The node path segment could not be parsed, the body could not be deserialised, or the node \
+                    already has an interface with that `ifIndex`: the unique index on `(nodeid, ifindex)` is \
+                    reported as a constraint violation rather than as a conflict.""",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "duplicateIfIndex", value = "could not execute statement; SQL [n/a]; constraint [snmpinterface_nodeid_ifindex_unique_idx]; nested exception is org.hibernate.exception.ConstraintViolationException: could not execute statement"),
+                                    @ExampleObject(name = "badNodeCriteria", value = "For input string: \"notanode\"")
+                            }))
+    })
+    @Override
+    public Response create(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo, final OnmsSnmpInterface object) {
+        return super.create(securityContext, uriInfo, object);
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Operation(
+            summary = "Update properties of several SNMP interfaces of a node",
+            description = """
+        Apply the form parameters as bean properties to every SNMP interface of the node matching `_s`.
+        The default `limit` of 10 bounds the selection, so a call without an explicit `limit` touches at
+        most ten interfaces; `limit=0` removes the bound. `ifIndex` cannot be set this way. The whole
+        call runs in one transaction, so a per-interface failure aborts the batch.""",
+            operationId = "NodeSnmpInterfacesRestServicePUTSnmpInterfaces",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                    description = "Node database id, or `foreignSource:foreignId`.", example = "274"))
+    @RequestBody(required = true, description = DOC_FORM_BODY,
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "object"),
+                    examples = @ExampleObject(value = "if-alias=ApiDoc11-bulk&collect=N")))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "All selected interfaces were updated."),
+            @ApiResponse(responseCode = "400", description = "The body tried to change `ifIndex`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot change ifIndex."))),
+            @ApiResponse(responseCode = "404", description = "No interface matched. No body is returned."),
+            @ApiResponse(responseCode = "415", description = "The body was not form-encoded. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The node path segment could not be parsed, or the FIQL expression could not be parsed or resolved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    @Override
+    public Response updateMany(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo, @Context final SearchContext searchContext, final MultivaluedMapImpl params) {
+        return super.updateMany(securityContext, uriInfo, searchContext, params);
+    }
+
+    // Hidden because OpenAPI holds one operation per path and method: the form-encoded PUT on
+    // {id} is the one that works, and its description records that a document body answers 501.
+    @Hidden
+    @PUT
+    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Path("{id}")
+    @Override
+    public Response update(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo, @PathParam("id") final Integer id, final OnmsSnmpInterface object) {
+        return super.update(securityContext, uriInfo, id, object);
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Path("{id}")
+    @Operation(
+            summary = "Update properties of an SNMP interface",
+            description = """
+        Apply the form parameters as bean properties to one SNMP interface of the node, addressed by
+        `ifIndex`. Only the properties named in the body are touched, and no event is sent.
+
+        Parameter names are normalised, so the wire names differ from the JSON and XML field names:
+        `if-alias` or `if_alias` reaches `ifAlias` while the camel-case `ifAlias` does not, and the
+        stored collection and polling flags are reached as `collect` and `poll` rather than as
+        `collectFlag` and `pollFlag`. `ifIndex` is rejected, under any spelling: delete the interface
+        and add it again to change its index.
+
+        Sending a JSON or XML body to the same path selects a different operation, which answers 501
+        because replacing an SNMP interface from a document is not implemented here.""",
+            operationId = "NodeSnmpInterfacesRestServicePUTSnmpInterfaceProperties",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                    description = "Node database id, or `foreignSource:foreignId`.", example = "274"))
+    @RequestBody(required = true, description = DOC_FORM_BODY,
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(type = "object"),
+                    examples = {
+                            @ExampleObject(name = "description", value = "if-alias=uplink&if-speed=100000000"),
+                            @ExampleObject(name = "flags", value = "collect=C&poll=P"),
+                            @ExampleObject(name = "timestamp", value = "last-capsd-poll=2026-08-20T10:15:30.000-0400")
+                    }))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The interface was updated. Returned even when no parameter resolved to a writable property."),
+            @ApiResponse(responseCode = "400", description = "The body tried to change `ifIndex`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot change ifIndex."))),
+            @ApiResponse(responseCode = "404", description = "The node has no interface with that `ifIndex`, or the identifier is not an integer. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The node path segment could not be parsed, or a value could not be converted to the property's type.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanode\"")))
+    })
+    @Override
+    public Response updateProperties(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo, @Parameter(description = "`ifIndex` of the interface, not its database id.", example = "11") @PathParam("id") final Integer id, final MultivaluedMapImpl params) {
+        return super.updateProperties(securityContext, uriInfo, id, params);
+    }
+
+    @DELETE
+    @Operation(
+            summary = "Delete several SNMP interfaces of a node",
+            description = """
+        Delete every SNMP interface of the node matching `_s`. The default `limit` of 10 bounds the
+        selection, so a call without an explicit `limit` deletes at most ten interfaces; `limit=0`
+        removes the bound. No event is sent.""",
+            operationId = "NodeSnmpInterfacesRestServiceDELETESnmpInterfaces",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                    description = "Node database id, or `foreignSource:foreignId`.", example = "274"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The selected interfaces were deleted."),
+            @ApiResponse(responseCode = "404", description = "No interface matched. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The node path segment could not be parsed, or the FIQL expression could not be parsed or resolved.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    @Override
+    public Response deleteMany(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo, @Context final SearchContext searchContext) {
+        return super.deleteMany(securityContext, uriInfo, searchContext);
+    }
+
+    @DELETE
+    @Path("{id}")
+    @Operation(
+            summary = "Delete an SNMP interface",
+            description = """
+        Delete one SNMP interface of the node, addressed by `ifIndex`. No event is sent, so daemons
+        already holding the node's interface list are not notified.""",
+            operationId = "NodeSnmpInterfacesRestServiceDELETESnmpInterfaceByIfIndex",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                    description = "Node database id, or `foreignSource:foreignId`.", example = "274"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The interface was deleted."),
+            @ApiResponse(responseCode = "404", description = "The node has no interface with that `ifIndex`, or the identifier is not an integer. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The node path segment is neither a number nor `foreignSource:foreignId`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanode\"")))
+    })
+    @Override
+    public Response delete(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo, @Parameter(description = "`ifIndex` of the interface, not its database id.", example = "11") @PathParam("id") final Integer id) {
+        return super.delete(securityContext, uriInfo, id);
     }
 
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NotificationRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NotificationRestService.java
@@ -450,9 +450,11 @@ public class NotificationRestService extends AbstractDaoRestService<OnmsNotifica
             operationId = "notificationsUpdate")
     @ApiResponses({
             @ApiResponse(responseCode = "404", description = """
-                    No notification has that identifier. The response has no body."""),
+                    The form variant answers 404 when nothing matches the identifier; the JSON or XML
+                    variant answers 404 only for an absent body and does not look the identifier up."""),
             @ApiResponse(responseCode = "501", description = """
-                    Notifications do not support update. The response has no body.""")
+                    Notifications do not support update. Returned by the JSON or XML variant whether or not the
+                    identifier exists. The response has no body.""")
     })
     public Response updateProperties(final SecurityContext securityContext, final UriInfo uriInfo,
             @Parameter(description = """

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NotificationRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NotificationRestService.java
@@ -47,6 +47,24 @@ import org.opennms.web.rest.support.SearchProperty;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+import org.apache.cxf.jaxrs.ext.search.SearchContext;
+import org.opennms.web.rest.support.MultivaluedMapImpl;
+import org.opennms.web.rest.support.SearchPropertyCollection;
+import org.opennms.web.rest.support.StringCollection;
 
 /**
  * Basic Web Service using REST for {@link OnmsNotification} entity.
@@ -146,4 +164,353 @@ public class NotificationRestService extends AbstractDaoRestService<OnmsNotifica
         return getDao().get(id);
     }
 
+    @Override
+    @Operation(summary = "List notifications",
+            description = """
+                    Notifications matching the query. The query joins the triggering event, the node and its asset record, location and categories, the IP interface, the SNMP interface, the service type and the notification destinations, so properties of all of those are searchable.
+
+                    Timestamps are epoch milliseconds in JSON and ISO-8601 with a UTC offset in XML.
+
+                    `application/atom+xml` is also accepted and returns the same document as `application/xml`.
+
+                    For example, `_s=notifyId=gt=1` or `_s=node.label==loopback-001`. The key property is `notifyId`; `_s=id==...` fails with 500.""",
+            operationId = "notificationsList")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "One page of matching notifications.",
+                    headers = @Header(name = "Content-Range", description = "`items <offset>-<last>/<totalCount>` for this page.",
+                            schema = @Schema(type = "string")),
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsNotificationCollection.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "totalCount": 2613,
+                              "count": 1,
+                              "offset": 0,
+                              "notification": [ {
+                                "id": 2615,
+                                "uei": "uei.opennms.org/nodes/nodeUp",
+                                "notificationName": "nodeUp",
+                                "subject": "Notice #2615: Node loopback-001 has been cleared.",
+                                "numericMessage": "111-2615",
+                                "severity": "NORMAL",
+                                "type": "NOTIFICATION",
+                                "queueId": "default",
+                                "pageTime": 1787074522047,
+                                "eventId": 9650,
+                                "nodeId": 2,
+                                "nodeLabel": "loopback-001",
+                                "serviceType": null,
+                                "ackUser": null,
+                                "ackTime": null,
+                                "ackId": 2615,
+                                "destinations": [ {
+                                  "id": 4738,
+                                  "userId": "admin",
+                                  "media": "javaEmail",
+                                  "contactInfo": "",
+                                  "autoNotify": "C",
+                                  "notifyTime": 1787074527313
+                                } ]
+                              } ]
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsNotificationCollection.class),
+                                    examples = @ExampleObject(value = """
+                            <notifications count="1" offset="0" totalCount="2613">
+                              <notification id="2615" severity="NORMAL">
+                                <eventId>9650</eventId>
+                                <uei>uei.opennms.org/nodes/nodeUp</uei>
+                                <nodeId>2</nodeId>
+                                <nodeLabel>loopback-001</nodeLabel>
+                                <notificationName>nodeUp</notificationName>
+                                <numericMessage>111-2615</numericMessage>
+                                <pageTime>2026-08-18T13:35:22.047-04:00</pageTime>
+                                <queueId>default</queueId>
+                                <subject>Notice #2615: Node loopback-001 has been cleared.</subject>
+                                <destinations>
+                                  <destination autoNotify="C" id="4738">
+                                    <contactInfo></contactInfo>
+                                    <media>javaEmail</media>
+                                    <notifyTime>2026-08-18T13:35:27.313-04:00</notifyTime>
+                                    <userId>admin</userId>
+                                  </destination>
+                                </destinations>
+                              </notification>
+                            </notifications>"""))
+                    }),
+            @ApiResponse(responseCode = "204", description = "No notification matched the query. The response has no body."),
+            @ApiResponse(responseCode = "500", description = DOC_SEARCH_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    public Response get(final UriInfo uriInfo, final SearchContext searchContext) {
+        return super.get(uriInfo, searchContext);
+    }
+
+    @Override
+    @Operation(summary = "Count notifications",
+            description = """
+                    Number of notifications matching the query.
+
+                    Only `text/plain` is produced. A request that sends `Accept: application/json` does not match this operation and falls through to the single-entity GET with `count` as the identifier.
+
+                    For example, `_s=notifyId=gt=1` or `_s=node.label==loopback-001`. The key property is `notifyId`; `_s=id==...` fails with 500.""",
+            operationId = "notificationsCount")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The number of matching notifications, as a decimal string.",
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "2613"))),
+            @ApiResponse(responseCode = "500", description = DOC_COUNT_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    public Response getCount(final UriInfo uriInfo, final SearchContext searchContext) {
+        return super.getCount(uriInfo, searchContext);
+    }
+
+    @Override
+    @Operation(summary = "List the queryable properties of notifications",
+            description = """
+                    The properties a notification query can filter and sort on, including the joined event, node and interface properties.""",
+            operationId = "notificationsSearchProperties")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The properties this endpoint can search and sort on.",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = SearchPropertyCollection.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "totalCount": 1,
+                              "count": 1,
+                              "offset": 0,
+                              "searchProperty": [
+                                { "id": "queueId", "name": "Queue Name", "type": "STRING", "orderBy": true, "iplike": false }
+                              ]
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = SearchPropertyCollection.class),
+                                    examples = @ExampleObject(value = """
+                            <searchProperties count="1" offset="0" totalCount="1">
+                              <searchProperty type="STRING" orderBy="true" iplike="false" id="queueId" name="Queue Name"/>
+                            </searchProperties>"""))
+                    })
+    })
+    public Response getProperties(final String query) {
+        return super.getProperties(query);
+    }
+
+    @Override
+    @Operation(summary = "List the values a queryable property takes",
+            description = """
+                    Distinct values held by one notification property. The `value` entries are typed after the property: numbers for `INTEGER`, `LONG` and `FLOAT`, epoch milliseconds for `TIMESTAMP`, strings otherwise.""",
+            operationId = "notificationsSearchPropertyValues")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The distinct values, typed after the property.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = StringCollection.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "totalCount": 1,
+                              "count": 1,
+                              "offset": 0,
+                              "value": [ "default" ]
+                            }"""))),
+            @ApiResponse(responseCode = "404", description = "No property with that `id` is queryable here. The response has no body.")
+    })
+    public Response getPropertyValues(final String propertyId, final String query, final Integer limit) {
+        return super.getPropertyValues(propertyId, query, limit);
+    }
+
+    @Override
+    @Operation(summary = "Get one notification",
+            description = """
+                    One notification by database identifier.
+
+                    Timestamps are epoch milliseconds in JSON and ISO-8601 with a UTC offset in XML.
+
+                    `application/atom+xml` is also accepted and returns the same document as `application/xml`.""",
+            operationId = "notificationsGet")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The requested notification.",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsNotification.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "id": 2615,
+                              "uei": "uei.opennms.org/nodes/nodeUp",
+                              "notificationName": "nodeUp",
+                              "subject": "Notice #2615: Node loopback-001 has been cleared.",
+                              "numericMessage": "111-2615",
+                              "severity": "NORMAL",
+                              "type": "NOTIFICATION",
+                              "queueId": "default",
+                              "pageTime": 1787074522047,
+                              "eventId": 9650,
+                              "nodeId": 2,
+                              "nodeLabel": "loopback-001",
+                              "ackUser": null,
+                              "ackTime": null,
+                              "ackId": 2615
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsNotification.class),
+                                    examples = @ExampleObject(value = """
+                            <notification id="2615" severity="NORMAL">
+                              <eventId>9650</eventId>
+                              <uei>uei.opennms.org/nodes/nodeUp</uei>
+                              <nodeId>2</nodeId>
+                              <nodeLabel>loopback-001</nodeLabel>
+                              <notificationName>nodeUp</notificationName>
+                              <numericMessage>111-2615</numericMessage>
+                              <pageTime>2026-08-18T13:35:22.047-04:00</pageTime>
+                              <queueId>default</queueId>
+                              <subject>Notice #2615: Node loopback-001 has been cleared.</subject>
+                            </notification>"""))
+                    }),
+            @ApiResponse(responseCode = "404", description = """
+                    No notification has that identifier, or the identifier is not an integer. The response has no body.""")
+    })
+    public Response get(final UriInfo uriInfo,
+            @Parameter(description = """
+                    Database identifier of the notification.""",
+                    required = true, example = "2615")
+            final Integer id) {
+        return super.get(uriInfo, id);
+    }
+
+    @Override
+    @Operation(summary = "Create a notification",
+            description = """
+                    Not supported: notifications are created by notifd, not through this API.""",
+            operationId = "notificationsCreate")
+    @ApiResponses({
+            @ApiResponse(responseCode = "501", description = DOC_NOT_IMPLEMENTED)
+    })
+    public Response create(final SecurityContext securityContext, final UriInfo uriInfo,
+            @RequestBody(description = """
+                    Accepted but not acted on: the endpoint answers 501 for every body.""",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsNotification.class),
+                                    examples = @ExampleObject(value = """
+                            { }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsNotification.class),
+                                    examples = @ExampleObject(value = """
+                            <notification/>"""))
+                    })
+            final OnmsNotification object) {
+        return super.create(securityContext, uriInfo, object);
+    }
+
+    @Override
+    @Operation(summary = "Rejected: create a notification at a caller-chosen identifier",
+            description = DOC_POST_WITH_ID,
+            operationId = "notificationsCreateWithId")
+    @Parameters({
+            @Parameter(name = "id", in = ParameterIn.PATH, required = true,
+                    description = "Ignored. Any value produces the same response.",
+                    schema = @Schema(type = "string"), example = "2615")
+    })
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = "Always. The response has no body.")
+    })
+    public Response createSpecific() {
+        return super.createSpecific();
+    }
+
+    @Override
+    @Operation(summary = "Update the notifications matching a query",
+            description = """
+                    Not supported for notifications: the endpoint answers 501 once it has found at least one match, and 404 when nothing matches.
+
+                    For example, `_s=notifyId=gt=1` or `_s=node.label==loopback-001`. The key property is `notifyId`; `_s=id==...` fails with 500.""",
+            operationId = "notificationsUpdateMany")
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = DOC_NO_MATCH),
+            @ApiResponse(responseCode = "500", description = DOC_SEARCH_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search"))),
+            @ApiResponse(responseCode = "501", description = DOC_NOT_IMPLEMENTED)
+    })
+    public Response updateMany(final SecurityContext securityContext, final UriInfo uriInfo, final SearchContext searchContext,
+            @RequestBody(description = DOC_FORM_BODY,
+                    content = @Content(mediaType = "application/x-www-form-urlencoded",
+                            schema = @Schema(type = "object"),
+                            examples = @ExampleObject(value = """
+                            ackUser=admin""")))
+            final MultivaluedMapImpl params) {
+        return super.updateMany(securityContext, uriInfo, searchContext, params);
+    }
+
+    @Override
+    @Hidden
+    public Response update(final SecurityContext securityContext, final UriInfo uriInfo, final Integer id,
+            final OnmsNotification object) {
+        return super.update(securityContext, uriInfo, id, object);
+    }
+
+    @Override
+    @Operation(summary = "Update one notification",
+            description = """
+                    Not supported here. Both the JSON or XML replacement form and the form-parameter form answer 501; acknowledge notifications through `/acks` instead.""",
+            operationId = "notificationsUpdate")
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = """
+                    No notification has that identifier. The response has no body."""),
+            @ApiResponse(responseCode = "501", description = """
+                    Notifications do not support update. The response has no body.""")
+    })
+    public Response updateProperties(final SecurityContext securityContext, final UriInfo uriInfo,
+            @Parameter(description = """
+                    Database identifier of the notification.""",
+                    required = true, example = "2615")
+            final Integer id,
+            @RequestBody(description = """
+                    Accepted but not acted on: the endpoint answers 501 for every body.""",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsNotification.class),
+                                    examples = @ExampleObject(value = """
+                            { }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsNotification.class),
+                                    examples = @ExampleObject(value = """
+                            <notification/>""")),
+                            @Content(mediaType = "application/x-www-form-urlencoded",
+                                    schema = @Schema(type = "object"),
+                                    examples = @ExampleObject(value = """
+                            ackUser=admin"""))
+                    })
+            final MultivaluedMapImpl params) {
+        return super.updateProperties(securityContext, uriInfo, id, params);
+    }
+
+    @Override
+    @Operation(summary = "Delete the notifications matching a query",
+            description = """
+                    Not supported for notifications: the endpoint answers 501 once it has found at least one match, and 404 when nothing matches.
+
+                    For example, `_s=notifyId=gt=1` or `_s=node.label==loopback-001`. The key property is `notifyId`; `_s=id==...` fails with 500.""",
+            operationId = "notificationsDeleteMany")
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = DOC_NO_MATCH),
+            @ApiResponse(responseCode = "500", description = DOC_SEARCH_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search"))),
+            @ApiResponse(responseCode = "501", description = DOC_NOT_IMPLEMENTED)
+    })
+    public Response deleteMany(final SecurityContext securityContext, final UriInfo uriInfo, final SearchContext searchContext) {
+        return super.deleteMany(securityContext, uriInfo, searchContext);
+    }
+
+    @Override
+    @Operation(summary = "Delete one notification",
+            description = """
+                    Not supported for notifications.""",
+            operationId = "notificationsDelete")
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = """
+                    No notification has that identifier. The response has no body."""),
+            @ApiResponse(responseCode = "501", description = """
+                    Notifications do not support deletion. The response has no body.""")
+    })
+    public Response delete(final SecurityContext securityContext, final UriInfo uriInfo,
+            @Parameter(description = """
+                    Database identifier of the notification.""",
+                    required = true, example = "2615")
+            final Integer id) {
+        return super.delete(securityContext, uriInfo, id);
+    }
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NotificationRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NotificationRestService.java
@@ -376,7 +376,7 @@ public class NotificationRestService extends AbstractDaoRestService<OnmsNotifica
     @Override
     @Operation(summary = "Create a notification",
             description = """
-                    Not supported: notifications are created by notifd, not through this API.""",
+                    Answered with 501 for every body.""",
             operationId = "notificationsCreate")
     @ApiResponses({
             @ApiResponse(responseCode = "501", description = DOC_NOT_IMPLEMENTED)
@@ -446,7 +446,7 @@ public class NotificationRestService extends AbstractDaoRestService<OnmsNotifica
     @Override
     @Operation(summary = "Update one notification",
             description = """
-                    Not supported here. Both the JSON or XML replacement form and the form-parameter form answer 501; acknowledge notifications through `/acks` instead.""",
+                    Both the JSON or XML replacement form and the form-parameter form answer 501.""",
             operationId = "notificationsUpdate")
     @ApiResponses({
             @ApiResponse(responseCode = "404", description = """
@@ -498,7 +498,7 @@ public class NotificationRestService extends AbstractDaoRestService<OnmsNotifica
     @Override
     @Operation(summary = "Delete one notification",
             description = """
-                    Not supported for notifications.""",
+                    Answered with 501 once the identifier resolves, and 404 when it does not.""",
             operationId = "notificationsDelete")
     @ApiResponses({
             @ApiResponse(responseCode = "404", description = """

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/OutageRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/OutageRestService.java
@@ -446,9 +446,11 @@ public class OutageRestService extends AbstractDaoRestService<OnmsOutage,SearchB
             operationId = "outagesUpdate")
     @ApiResponses({
             @ApiResponse(responseCode = "404", description = """
-                    No outage has that identifier. The response has no body."""),
+                    The form variant answers 404 when nothing matches the identifier; the JSON or XML
+                    variant answers 404 only for an absent body and does not look the identifier up."""),
             @ApiResponse(responseCode = "501", description = """
-                    Outages do not support update. The response has no body.""")
+                    Outages do not support update. Returned by the JSON or XML variant whether or not the
+                    identifier exists. The response has no body.""")
     })
     public Response updateProperties(final SecurityContext securityContext, final UriInfo uriInfo,
             @Parameter(description = """

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/OutageRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/OutageRestService.java
@@ -272,7 +272,7 @@ public class OutageRestService extends AbstractDaoRestService<OnmsOutage,SearchB
     @Override
     @Operation(summary = "List the queryable properties of outages",
             description = """
-                    The properties an outage query can filter and sort on, including the joined node, interface, service, event and asset properties. The unfiltered list is long, so `q` is usually worth passing.""",
+                    The properties an outage query can filter and sort on, including the joined node, interface, service, event and asset properties.""",
             operationId = "outagesSearchProperties")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "The properties this endpoint can search and sort on.",
@@ -370,9 +370,9 @@ public class OutageRestService extends AbstractDaoRestService<OnmsOutage,SearchB
     }
 
     @Override
-    @Operation(summary = "Create a outage",
+    @Operation(summary = "Create an outage",
             description = """
-                    Not supported: outages are created by the poller, not through this API.""",
+                    Answered with 501 for every body.""",
             operationId = "outagesCreate")
     @ApiResponses({
             @ApiResponse(responseCode = "501", description = DOC_NOT_IMPLEMENTED)
@@ -393,7 +393,7 @@ public class OutageRestService extends AbstractDaoRestService<OnmsOutage,SearchB
     }
 
     @Override
-    @Operation(summary = "Rejected: create a outage at a caller-chosen identifier",
+    @Operation(summary = "Rejected: create an outage at a caller-chosen identifier",
             description = DOC_POST_WITH_ID,
             operationId = "outagesCreateWithId")
     @Parameters({
@@ -442,7 +442,7 @@ public class OutageRestService extends AbstractDaoRestService<OnmsOutage,SearchB
     @Override
     @Operation(summary = "Update one outage",
             description = """
-                    Not supported for outages. Both the JSON or XML replacement form and the form-parameter form answer 501.""",
+                    Both the JSON or XML replacement form and the form-parameter form answer 501.""",
             operationId = "outagesUpdate")
     @ApiResponses({
             @ApiResponse(responseCode = "404", description = """
@@ -494,7 +494,7 @@ public class OutageRestService extends AbstractDaoRestService<OnmsOutage,SearchB
     @Override
     @Operation(summary = "Delete one outage",
             description = """
-                    Not supported for outages.""",
+                    Answered with 501 once the identifier resolves, and 404 when it does not.""",
             operationId = "outagesDelete")
     @ApiResponses({
             @ApiResponse(responseCode = "404", description = """

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/OutageRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/OutageRestService.java
@@ -45,6 +45,24 @@ import org.opennms.web.rest.support.SearchProperty;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+import org.apache.cxf.jaxrs.ext.search.SearchContext;
+import org.opennms.web.rest.support.MultivaluedMapImpl;
+import org.opennms.web.rest.support.SearchPropertyCollection;
+import org.opennms.web.rest.support.StringCollection;
 
 /**
  * Basic Web Service using REST for {@link OnmsOutage} entity.
@@ -153,4 +171,342 @@ public class OutageRestService extends AbstractDaoRestService<OnmsOutage,SearchB
         return getDao().get(id);
     }
 
+    @Override
+    @Operation(summary = "List outages",
+            description = """
+                    Outages matching the query, newest identifier first unless `orderBy` says otherwise. The query joins the monitored service, its IP interface, node, SNMP interface, asset record and location, the lost and regained service events and the perspective location, so properties of all of those are searchable.
+
+                    Timestamps are epoch milliseconds in JSON and ISO-8601 with a UTC offset in XML.
+
+                    `application/atom+xml` is also accepted and returns the same document as `application/xml`.
+
+                    For example, `_s=ifRegainedService=gt=2026-08-01T00:00:00.000-0400;node.label==loopback-009`.""",
+            operationId = "outagesList")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "One page of matching outages.",
+                    headers = @Header(name = "Content-Range", description = "`items <offset>-<last>/<totalCount>` for this page.",
+                            schema = @Schema(type = "string")),
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsOutageCollection.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "totalCount": 4077,
+                              "count": 1,
+                              "offset": 0,
+                              "outage": [ {
+                                "id": 900009,
+                                "nodeId": 7,
+                                "nodeLabel": "loopback-009",
+                                "foreignSource": "loopback-lab",
+                                "foreignId": "lb-009",
+                                "locationName": "Default",
+                                "ipAddress": "127.0.0.9",
+                                "serviceId": 2,
+                                "monitoredService": {
+                                  "id": 1025,
+                                  "status": "A",
+                                  "statusLong": "Managed",
+                                  "down": false,
+                                  "lastGood": 1787727479370,
+                                  "lastFail": 1787685424755,
+                                  "serviceType": { "id": 2, "name": "HTTP-8080" },
+                                  "ipInterfaceId": 17
+                                },
+                                "ifLostService": 1787052190798,
+                                "ifRegainedService": 1787073778565,
+                                "suppressTime": null,
+                                "suppressedBy": null,
+                                "perspective": "Default"
+                              } ]
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsOutageCollection.class),
+                                    examples = @ExampleObject(value = """
+                            <outages count="1" offset="0" totalCount="4077">
+                              <outage id="900009">
+                                <foreignId>lb-009</foreignId>
+                                <foreignSource>loopback-lab</foreignSource>
+                                <ifLostService>2026-08-18T07:23:10.798-04:00</ifLostService>
+                                <ifRegainedService>2026-08-18T13:22:58.565-04:00</ifRegainedService>
+                                <ipAddress>127.0.0.9</ipAddress>
+                                <locationName>Default</locationName>
+                                <monitoredService down="false" status="A" statusLong="Managed" id="1025">
+                                  <ipInterfaceId>17</ipInterfaceId>
+                                  <serviceType id="2"><name>HTTP-8080</name></serviceType>
+                                </monitoredService>
+                                <nodeId>7</nodeId>
+                                <nodeLabel>loopback-009</nodeLabel>
+                                <perspective>Default</perspective>
+                              </outage>
+                            </outages>"""))
+                    }),
+            @ApiResponse(responseCode = "204", description = "No outage matched the query. The response has no body."),
+            @ApiResponse(responseCode = "500", description = DOC_SEARCH_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    public Response get(final UriInfo uriInfo, final SearchContext searchContext) {
+        return super.get(uriInfo, searchContext);
+    }
+
+    @Override
+    @Operation(summary = "Count outages",
+            description = """
+                    Number of outages matching the query.
+
+                    Only `text/plain` is produced. A request that sends `Accept: application/json` does not match this operation and falls through to the single-entity GET with `count` as the identifier.
+
+                    For example, `_s=ifRegainedService=gt=2026-08-01T00:00:00.000-0400;node.label==loopback-009`.""",
+            operationId = "outagesCount")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The number of matching outages, as a decimal string.",
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "4077"))),
+            @ApiResponse(responseCode = "500", description = DOC_COUNT_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    public Response getCount(final UriInfo uriInfo, final SearchContext searchContext) {
+        return super.getCount(uriInfo, searchContext);
+    }
+
+    @Override
+    @Operation(summary = "List the queryable properties of outages",
+            description = """
+                    The properties an outage query can filter and sort on, including the joined node, interface, service, event and asset properties. The unfiltered list is long, so `q` is usually worth passing.""",
+            operationId = "outagesSearchProperties")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The properties this endpoint can search and sort on.",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = SearchPropertyCollection.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "totalCount": 1,
+                              "count": 1,
+                              "offset": 0,
+                              "searchProperty": [
+                                { "id": "ifLostService", "name": "Lost Service Time", "type": "TIMESTAMP", "orderBy": true, "iplike": false }
+                              ]
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = SearchPropertyCollection.class),
+                                    examples = @ExampleObject(value = """
+                            <searchProperties count="1" offset="0" totalCount="1">
+                              <searchProperty type="TIMESTAMP" orderBy="true" iplike="false" id="ifLostService" name="Lost Service Time"/>
+                            </searchProperties>"""))
+                    })
+    })
+    public Response getProperties(final String query) {
+        return super.getProperties(query);
+    }
+
+    @Override
+    @Operation(summary = "List the values a queryable property takes",
+            description = """
+                    Distinct values held by one outage property. The `value` entries are typed after the property: numbers for `INTEGER`, `LONG` and `FLOAT`, epoch milliseconds for `TIMESTAMP`, strings otherwise.""",
+            operationId = "outagesSearchPropertyValues")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The distinct values, typed after the property.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = StringCollection.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "totalCount": 2,
+                              "count": 2,
+                              "offset": 0,
+                              "value": [ 1786382635102, 1786382635105 ]
+                            }"""))),
+            @ApiResponse(responseCode = "404", description = "No property with that `id` is queryable here. The response has no body.")
+    })
+    public Response getPropertyValues(final String propertyId, final String query, final Integer limit) {
+        return super.getPropertyValues(propertyId, query, limit);
+    }
+
+    @Override
+    @Operation(summary = "Get one outage",
+            description = """
+                    One outage by database identifier.
+
+                    Timestamps are epoch milliseconds in JSON and ISO-8601 with a UTC offset in XML.
+
+                    `application/atom+xml` is also accepted and returns the same document as `application/xml`.""",
+            operationId = "outagesGet")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The requested outage.",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsOutage.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "id": 900009,
+                              "nodeId": 7,
+                              "nodeLabel": "loopback-009",
+                              "locationName": "Default",
+                              "ipAddress": "127.0.0.9",
+                              "serviceId": 2,
+                              "ifLostService": 1787052190798,
+                              "ifRegainedService": 1787073778565,
+                              "suppressTime": null,
+                              "suppressedBy": null,
+                              "perspective": "Default"
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsOutage.class),
+                                    examples = @ExampleObject(value = """
+                            <outage id="900009">
+                              <ifLostService>2026-08-18T07:23:10.798-04:00</ifLostService>
+                              <ifRegainedService>2026-08-18T13:22:58.565-04:00</ifRegainedService>
+                              <ipAddress>127.0.0.9</ipAddress>
+                              <locationName>Default</locationName>
+                              <nodeId>7</nodeId>
+                              <nodeLabel>loopback-009</nodeLabel>
+                              <perspective>Default</perspective>
+                            </outage>"""))
+                    }),
+            @ApiResponse(responseCode = "404", description = """
+                    No outage has that identifier, or the identifier is not an integer. The response has no body.""")
+    })
+    public Response get(final UriInfo uriInfo,
+            @Parameter(description = """
+                    Database identifier of the outage.""",
+                    required = true, example = "900009")
+            final Integer id) {
+        return super.get(uriInfo, id);
+    }
+
+    @Override
+    @Operation(summary = "Create a outage",
+            description = """
+                    Not supported: outages are created by the poller, not through this API.""",
+            operationId = "outagesCreate")
+    @ApiResponses({
+            @ApiResponse(responseCode = "501", description = DOC_NOT_IMPLEMENTED)
+    })
+    public Response create(final SecurityContext securityContext, final UriInfo uriInfo,
+            @RequestBody(description = """
+                    Accepted but not acted on: the endpoint answers 501 for every body.""",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsOutage.class),
+                                    examples = @ExampleObject(value = """
+                            { }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsOutage.class),
+                                    examples = @ExampleObject(value = """
+                            <outage/>"""))
+                    })
+            final OnmsOutage object) {
+        return super.create(securityContext, uriInfo, object);
+    }
+
+    @Override
+    @Operation(summary = "Rejected: create a outage at a caller-chosen identifier",
+            description = DOC_POST_WITH_ID,
+            operationId = "outagesCreateWithId")
+    @Parameters({
+            @Parameter(name = "id", in = ParameterIn.PATH, required = true,
+                    description = "Ignored. Any value produces the same response.",
+                    schema = @Schema(type = "string"), example = "900009")
+    })
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = "Always. The response has no body.")
+    })
+    public Response createSpecific() {
+        return super.createSpecific();
+    }
+
+    @Override
+    @Operation(summary = "Update the outages matching a query",
+            description = """
+                    Not supported for outages: the endpoint answers 501 once it has found at least one match, and 404 when nothing matches.
+
+                    For example, `_s=ifRegainedService=gt=2026-08-01T00:00:00.000-0400;node.label==loopback-009`.""",
+            operationId = "outagesUpdateMany")
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = DOC_NO_MATCH),
+            @ApiResponse(responseCode = "500", description = DOC_SEARCH_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search"))),
+            @ApiResponse(responseCode = "501", description = DOC_NOT_IMPLEMENTED)
+    })
+    public Response updateMany(final SecurityContext securityContext, final UriInfo uriInfo, final SearchContext searchContext,
+            @RequestBody(description = DOC_FORM_BODY,
+                    content = @Content(mediaType = "application/x-www-form-urlencoded",
+                            schema = @Schema(type = "object"),
+                            examples = @ExampleObject(value = """
+                            suppressedBy=admin""")))
+            final MultivaluedMapImpl params) {
+        return super.updateMany(securityContext, uriInfo, searchContext, params);
+    }
+
+    @Override
+    @Hidden
+    public Response update(final SecurityContext securityContext, final UriInfo uriInfo, final Integer id,
+            final OnmsOutage object) {
+        return super.update(securityContext, uriInfo, id, object);
+    }
+
+    @Override
+    @Operation(summary = "Update one outage",
+            description = """
+                    Not supported for outages. Both the JSON or XML replacement form and the form-parameter form answer 501.""",
+            operationId = "outagesUpdate")
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = """
+                    No outage has that identifier. The response has no body."""),
+            @ApiResponse(responseCode = "501", description = """
+                    Outages do not support update. The response has no body.""")
+    })
+    public Response updateProperties(final SecurityContext securityContext, final UriInfo uriInfo,
+            @Parameter(description = """
+                    Database identifier of the outage.""",
+                    required = true, example = "900009")
+            final Integer id,
+            @RequestBody(description = """
+                    Accepted but not acted on: the endpoint answers 501 for every body.""",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsOutage.class),
+                                    examples = @ExampleObject(value = """
+                            { }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsOutage.class),
+                                    examples = @ExampleObject(value = """
+                            <outage/>""")),
+                            @Content(mediaType = "application/x-www-form-urlencoded",
+                                    schema = @Schema(type = "object"),
+                                    examples = @ExampleObject(value = """
+                            suppressedBy=admin"""))
+                    })
+            final MultivaluedMapImpl params) {
+        return super.updateProperties(securityContext, uriInfo, id, params);
+    }
+
+    @Override
+    @Operation(summary = "Delete the outages matching a query",
+            description = """
+                    Not supported for outages: the endpoint answers 501 once it has found at least one match, and 404 when nothing matches.
+
+                    For example, `_s=ifRegainedService=gt=2026-08-01T00:00:00.000-0400;node.label==loopback-009`.""",
+            operationId = "outagesDeleteMany")
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = DOC_NO_MATCH),
+            @ApiResponse(responseCode = "500", description = DOC_SEARCH_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search"))),
+            @ApiResponse(responseCode = "501", description = DOC_NOT_IMPLEMENTED)
+    })
+    public Response deleteMany(final SecurityContext securityContext, final UriInfo uriInfo, final SearchContext searchContext) {
+        return super.deleteMany(securityContext, uriInfo, searchContext);
+    }
+
+    @Override
+    @Operation(summary = "Delete one outage",
+            description = """
+                    Not supported for outages.""",
+            operationId = "outagesDelete")
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = """
+                    No outage has that identifier. The response has no body."""),
+            @ApiResponse(responseCode = "501", description = """
+                    Outages do not support deletion. The response has no body.""")
+    })
+    public Response delete(final SecurityContext securityContext, final UriInfo uriInfo,
+            @Parameter(description = """
+                    Database identifier of the outage.""",
+                    required = true, example = "900009")
+            final Integer id) {
+        return super.delete(securityContext, uriInfo, id);
+    }
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/ProvisiondStatusRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/ProvisiondStatusRestService.java
@@ -123,8 +123,7 @@ public class ProvisiondStatusRestService {
 
         Real job ids are metric names derived from the requisition URL and so contain `/` characters.
         A JAX-RS path template does not match across `/`, and percent-encoding the separator as `%2F`
-        does not reach the handler either, so such an id cannot be addressed here. Read the job out of
-        the map returned by `GET /provisiond/status` instead.""",
+        does not reach the handler either, so such an id cannot be addressed here.""",
             operationId = "ProvisiondStatusRestServiceGETStatusOfJobByJobId")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "The job monitor. Same shape as one value of the all-jobs map.",

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/ProvisiondStatusRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/ProvisiondStatusRestService.java
@@ -134,9 +134,11 @@ public class ProvisiondStatusRestService {
                     expired out of the cache. The body is empty.""")
     })
     public Response getJobStatus(@Parameter(description = """
-                    A key from `GET /provisiond/status`. Ids containing `/` cannot be expressed in this
-                    path segment.""",
-                    required = true, example = "Routers.xml.20260826025715")
+                    A key from `GET /provisiond/status`. URL-triggered import jobs are keyed by their
+                    `file:/...` URL, which contains `/` and cannot be expressed in this path segment, so
+                    those jobs are not reachable here; only keys without `/`, such as a scheduled
+                    requisition's job name, can be looked up.""",
+                    required = true, example = "Routers")
                                  @PathParam("jobId") String jobId) {
         MonitorHolder monitorHolder = getMonitorHolder();
         ProvisionMonitor monitor = monitorHolder.getMonitors().get(jobId);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/ProvisiondStatusRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/ProvisiondStatusRestService.java
@@ -23,7 +23,9 @@ package org.opennms.web.rest.v2;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -54,9 +56,58 @@ public class ProvisiondStatusRestService {
     @GET
     @Path("status")
     @Produces({MediaType.APPLICATION_JSON})
-    @Operation(summary = "Get all jobs status", description = "Get all recent provisiond jobs status.", operationId = "ProvisiondStatusRestServiceGETStatusOfJobs")
+    @Operation(summary = "Get all jobs status",
+            description = """
+        Every provisioning job monitor provisiond still holds, keyed by job id. The set is a bounded,
+        expiring cache rather than a history: old entries fall out, so an id that worked earlier can
+        stop resolving.
+
+        Each value is a Dropwizard-metrics snapshot: nine timers (`loadingTimer`, `auditTimer`,
+        `importTimer`, `schedulingTimer`, `relateTimer`, `scanEventTimer`, `scanningTimer`,
+        `persistingTimer`, `eventTimer`), each with a percentile snapshot and one/five/fifteen-minute
+        and mean rates, plus `nodeCount`, `name`, `startTime`, `endTime` and `currentNodes`. Timer
+        values are nanoseconds; `startTime` and `endTime` are epoch milliseconds, with `endTime` unset
+        until the job finishes.
+
+        The keys are metric names built from the requisition URL plus a timestamp, so they contain `/`
+        and `:` characters.""",
+            operationId = "ProvisiondStatusRestServiceGETStatusOfJobs")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "all jobs current monitor object.", content = @Content(schema = @Schema(type = "Map<String, TimeTrackingMonitor>")))
+            @ApiResponse(responseCode = "200", description = "Job monitors keyed by job id, empty when provisiond has run nothing recently.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            // The handler returns a Map, so the document can only
+                            // carry a free-form object plus this example.
+                            schema = @Schema(type = "object"),
+                            examples = @ExampleObject(value = """
+                    {
+                      "file:/opt/opennms/etc/imports/pending/Routers.xml.20260826025715": {
+                        "loadingTimer": {
+                          "snapshot": {
+                            "values": [9353170],
+                            "mean": 9353170.0,
+                            "stdDev": 0.0,
+                            "min": 9353170,
+                            "max": 9353170,
+                            "median": 9353170.0,
+                            "75thPercentile": 9353170.0,
+                            "95thPercentile": 9353170.0,
+                            "98thPercentile": 9353170.0,
+                            "99thPercentile": 9353170.0,
+                            "999thPercentile": 9353170.0
+                          },
+                          "fifteenMinuteRate": 0.1945208954232697,
+                          "fiveMinuteRate": 0.18400888292586465,
+                          "meanRate": 0.031371987477271615,
+                          "oneMinuteRate": 0.1318481260400888,
+                          "count": 1
+                        },
+                        "nodeCount": 3,
+                        "name": "file:/opt/opennms/etc/imports/pending/Routers.xml.20260826025715",
+                        "startTime": 1787727435506,
+                        "endTime": 1787727442797,
+                        "currentNodes": {}
+                      }
+                    }""")))
     })
     public Response getAllJobStatus() {
         MonitorHolder monitorHolder = getMonitorHolder();
@@ -66,14 +117,28 @@ public class ProvisiondStatusRestService {
     @GET
     @Path("status/{jobId}")
     @Produces({MediaType.APPLICATION_JSON})
-    @Operation(summary = "Get single job status", description = "Get single provisiond job status by jobId", operationId = "ProvisiondStatusRestServiceGETStatusOfJobByJobId")
+    @Operation(summary = "Get single job status",
+            description = """
+        One job's monitor, looked up by the same key `GET /provisiond/status` uses.
+
+        Real job ids are metric names derived from the requisition URL and so contain `/` characters.
+        A JAX-RS path template does not match across `/`, and percent-encoding the separator as `%2F`
+        does not reach the handler either, so such an id cannot be addressed here. Read the job out of
+        the map returned by `GET /provisiond/status` instead.""",
+            operationId = "ProvisiondStatusRestServiceGETStatusOfJobByJobId")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "The current job status.",
-                    content = @Content(schema = @Schema(implementation = TimeTrackingMonitor.class))),
-            @ApiResponse(responseCode = "404", description = "jobId not exist.",
-                    content = @Content)
+            @ApiResponse(responseCode = "200", description = "The job monitor. Same shape as one value of the all-jobs map.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = TimeTrackingMonitor.class))),
+            @ApiResponse(responseCode = "404", description = """
+                    No monitor is held under that id, either because it never existed or because it has
+                    expired out of the cache. The body is empty.""")
     })
-    public Response getJobStatus(@PathParam("jobId") String jobId) {
+    public Response getJobStatus(@Parameter(description = """
+                    A key from `GET /provisiond/status`. Ids containing `/` cannot be expressed in this
+                    path segment.""",
+                    required = true, example = "Routers.xml.20260826025715")
+                                 @PathParam("jobId") String jobId) {
         MonitorHolder monitorHolder = getMonitorHolder();
         ProvisionMonitor monitor = monitorHolder.getMonitors().get(jobId);
         if (monitor != null) {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SituationsRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SituationsRestService.java
@@ -106,11 +106,11 @@ import java.util.stream.Collectors;
         to situations: they resolve any alarm id. Acting on a situation alarm does not cascade to its
         members, so acknowledging or clearing a situation leaves the correlated alarms as they were.
 
-        Four operations here are the inherited alarm operations, and they carry the alarm wording and
+        Five operations here are the inherited alarm operations, and they carry the alarm wording and
         an `_1`-suffixed operationId: `GET /situations/{id}` (`getAlarmById_1`), `POST /situations`
-        (`createAlarm_1`), `PUT /situations/{id}` (`updateAlarmProperties_1`) and
-        `DELETE /situations/{id}` (`deleteAlarm_1`). Creating and deleting are not implemented on
-        either path.""")
+        (`createAlarm_1`), the form and JSON variants of `PUT /situations/{id}`
+        (`updateAlarmProperties_1`, `replaceAlarm_1`) and `DELETE /situations/{id}` (`deleteAlarm_1`).
+        Creating and deleting are not implemented on either path.""")
 public class SituationsRestService extends AlarmRestService {
 
     private static final Logger LOG = LoggerFactory.getLogger(SituationsRestService.class);
@@ -141,8 +141,9 @@ public class SituationsRestService extends AlarmRestService {
             description = """
         Return a page of alarms whose `isSituation` is true. The restriction is added to whatever `_s`
         supplies, so `_s` narrows the set of situations rather than widening it to ordinary alarms.
-        Only `isSituation` is registered as a query behaviour on this resource, so an `_s` naming any
-        other property is rejected with 500.
+        Only `isSituation` has a registered query behaviour on this resource. Other `alarm.*` properties
+        still pass through to the criteria and filter normally; only terms that need a registered type
+        conversion, such as `alarm.severity`, fail with 500.
 
         `relatedAlarms` holds a summary of each member alarm. The situation itself carries the highest
         severity of its members at the time the correlating event was sent.
@@ -207,8 +208,9 @@ public class SituationsRestService extends AlarmRestService {
         and appears in the reduction key of the situation alarm as
         `uei.opennms.org/alarms/situation:<uuid>`.
 
-        Ids that name no alarm, and ids whose alarm already belongs to another situation, are dropped
-        from the set. If fewer than two alarms survive, nothing is created and the call answers 204.
+        An id that names no alarm fails the whole call with 500 when the loaded proxy is first touched.
+        Ids whose alarm already belongs to another situation are dropped from the set; if fewer than two
+        alarms survive, nothing is created and the call answers 204.
 
         The situation is created by publishing an event, so the call returns before the situation alarm
         exists. `description` is stored as given and `diagnosticText`, when present, is appended to it
@@ -251,8 +253,9 @@ public class SituationsRestService extends AlarmRestService {
         Add the alarms in `alarmIdList` to the situation named by `situationId`. The new membership is
         the union of the current members and the ids that resolved, so this never removes anything.
 
-        Ids that name no alarm, and ids whose alarm already belongs to another situation, are dropped.
-        When the union equals the current membership the call answers 204 and no event is published.
+        An id that names no alarm fails the whole call with 500 when the loaded proxy is first touched.
+        Ids whose alarm already belongs to another situation are dropped. When the union equals the
+        current membership the call answers 204 and no event is published.
 
         The change is applied by publishing an event, so the call returns before the membership is
         visible. `feedback` is accepted and not used.""",
@@ -370,11 +373,11 @@ public class SituationsRestService extends AlarmRestService {
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
                             examples = {
                                     @ExampleObject(name = "absent", value = "Unable to determine alarm ID to update based on query path."),
-                                    @ExampleObject(name = "unknown", value = "Unable to locate alarm with ID 999999")
+                                    @ExampleObject(name = "unknown", value = "Unable to locate alarm with ID '999999'")
                             })),
             @ApiResponse(responseCode = "403", description = "The authenticated user may not clear alarms.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "User operator cannot act on behalf of user admin")))
+                            examples = @ExampleObject(value = "User 'operator', is not allowed to perform updates to alarms as user 'admin'")))
     })
     public Response doAction(
             AlarmAddRemoveRequest req,
@@ -439,7 +442,7 @@ public class SituationsRestService extends AlarmRestService {
                             examples = @ExampleObject(value = "Invalid situation ID: 999999"))),
             @ApiResponse(responseCode = "403", description = "The authenticated user may not clear alarms.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "User operator cannot act on behalf of user admin")))
+                            examples = @ExampleObject(value = "User 'operator', is not allowed to perform updates to alarms as user 'admin'")))
     })
     public Response removeAndClear(
             AlarmAddRemoveRequest req,
@@ -550,7 +553,7 @@ public class SituationsRestService extends AlarmRestService {
             description = """
         Return the number of alarms whose `isSituation` is true, as a plain-text integer. The response
         is `text/plain` only, so a request that asks solely for `application/json` is answered with
-        404. `limit` and `offset` are ignored: the count covers the whole match.
+        404. `limit` is ignored, but a non-zero `offset` reaches the count query and fails with 500.
 
         Example query: `_s=alarm.isSituation==true`.""",
             operationId = "getSituationCount")
@@ -637,7 +640,7 @@ public class SituationsRestService extends AlarmRestService {
                     description = "Unprefixed property id from `GET /situations/properties`.", example = "severity")
             @PathParam("propertyId") final String propertyId,
             @Parameter(in = ParameterIn.QUERY, name = "q",
-                    description = "Case-sensitive substring the value must contain.", example = "situation")
+                    description = "Substring the value must contain. Database-backed properties match case-insensitively; only fixed value lists are case-sensitive.", example = "situation")
             @QueryParam("q") final String query,
             @Parameter(in = ParameterIn.QUERY, name = "limit",
                     description = "Maximum number of values returned. Applies only to values read from the database.",
@@ -682,7 +685,10 @@ public class SituationsRestService extends AlarmRestService {
             @ApiResponse(responseCode = "404", description = "No situation matched `_s`. No body is returned."),
             @ApiResponse(responseCode = "500", description = "`_s` named a property that is not registered on this resource.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "could not resolve property: bogusprop of: org.opennms.netmgt.model.OnmsAlarm")))
+                            examples = @ExampleObject(value = "could not resolve property: bogusprop of: org.opennms.netmgt.model.OnmsAlarm"))),
+            @ApiResponse(responseCode = "403", description = "The caller holds `ROLE_READONLY`, or named somebody other than themselves in `ackUser` without holding `ROLE_ADMIN` or `ROLE_DELEGATE`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User 'operator', is not allowed to perform updates to alarms as user 'admin'")))
     })
     @Override
     public Response updateMany(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo,
@@ -729,7 +735,10 @@ public class SituationsRestService extends AlarmRestService {
                             examples = @ExampleObject(value = "Body cannot be null."))),
             @ApiResponse(responseCode = "404", description = "No alarm has that id.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "Alarm not found.")))
+                            examples = @ExampleObject(value = "Alarm not found."))),
+            @ApiResponse(responseCode = "403", description = "The caller holds `ROLE_READONLY`, or named somebody other than themselves in `ackUser` without holding `ROLE_ADMIN` or `ROLE_DELEGATE`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User 'operator', is not allowed to perform updates to alarms as user 'admin'")))
     })
     @Override
     public Response updateMemo(@Context final SecurityContext securityContext,
@@ -760,7 +769,10 @@ public class SituationsRestService extends AlarmRestService {
                             examples = @ExampleObject(value = "Body cannot be null."))),
             @ApiResponse(responseCode = "404", description = "No alarm has that id.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "Alarm not found.")))
+                            examples = @ExampleObject(value = "Alarm not found."))),
+            @ApiResponse(responseCode = "403", description = "The caller holds `ROLE_READONLY`, or named somebody other than themselves in `ackUser` without holding `ROLE_ADMIN` or `ROLE_DELEGATE`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User 'operator', is not allowed to perform updates to alarms as user 'admin'")))
     })
     @Override
     public Response updateJournal(@Context final SecurityContext securityContext,
@@ -784,7 +796,10 @@ public class SituationsRestService extends AlarmRestService {
             @ApiResponse(responseCode = "204", description = "The sticky memo is gone, whether or not one was set. No body is returned."),
             @ApiResponse(responseCode = "404", description = "No alarm has that id.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "Alarm not found.")))
+                            examples = @ExampleObject(value = "Alarm not found."))),
+            @ApiResponse(responseCode = "403", description = "The caller holds `ROLE_READONLY`, or named somebody other than themselves in `ackUser` without holding `ROLE_ADMIN` or `ROLE_DELEGATE`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User 'operator', is not allowed to perform updates to alarms as user 'admin'")))
     })
     @Override
     public Response removeMemo(@Context final SecurityContext securityContext,
@@ -808,7 +823,10 @@ public class SituationsRestService extends AlarmRestService {
             @ApiResponse(responseCode = "204", description = "The journal note is gone, whether or not one was set. No body is returned."),
             @ApiResponse(responseCode = "404", description = "No alarm has that id.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "Alarm not found.")))
+                            examples = @ExampleObject(value = "Alarm not found."))),
+            @ApiResponse(responseCode = "403", description = "The caller holds `ROLE_READONLY`, or named somebody other than themselves in `ackUser` without holding `ROLE_ADMIN` or `ROLE_DELEGATE`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User 'operator', is not allowed to perform updates to alarms as user 'admin'")))
     })
     @Override
     public Response removeJournal(@Context final SecurityContext securityContext,
@@ -834,7 +852,10 @@ public class SituationsRestService extends AlarmRestService {
             @ApiResponse(responseCode = "202", description = "The request was handed to the ticketer plugin. No body is returned."),
             @ApiResponse(responseCode = "501", description = "The ticketer plugin is disabled.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "AlarmTroubleTicketer is not enabled. Cannot perform operation")))
+                            examples = @ExampleObject(value = "AlarmTroubleTicketer is not enabled. Cannot perform operation"))),
+            @ApiResponse(responseCode = "403", description = "The caller holds `ROLE_READONLY`, or named somebody other than themselves in `ackUser` without holding `ROLE_ADMIN` or `ROLE_DELEGATE`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User 'operator', is not allowed to perform updates to alarms as user 'admin'")))
     })
     @Override
     public Response createTicket(@Context final SecurityContext securityContext,
@@ -859,7 +880,10 @@ public class SituationsRestService extends AlarmRestService {
             @ApiResponse(responseCode = "202", description = "The request was handed to the ticketer plugin. No body is returned."),
             @ApiResponse(responseCode = "501", description = "The ticketer plugin is disabled.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "AlarmTroubleTicketer is not enabled. Cannot perform operation")))
+                            examples = @ExampleObject(value = "AlarmTroubleTicketer is not enabled. Cannot perform operation"))),
+            @ApiResponse(responseCode = "403", description = "The caller holds `ROLE_READONLY`, or named somebody other than themselves in `ackUser` without holding `ROLE_ADMIN` or `ROLE_DELEGATE`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User 'operator', is not allowed to perform updates to alarms as user 'admin'")))
     })
     @Override
     public Response updateTicket(@Context final SecurityContext securityContext,
@@ -883,7 +907,10 @@ public class SituationsRestService extends AlarmRestService {
             @ApiResponse(responseCode = "202", description = "The request was handed to the ticketer plugin. No body is returned."),
             @ApiResponse(responseCode = "501", description = "The ticketer plugin is disabled.",
                     content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "AlarmTroubleTicketer is not enabled. Cannot perform operation")))
+                            examples = @ExampleObject(value = "AlarmTroubleTicketer is not enabled. Cannot perform operation"))),
+            @ApiResponse(responseCode = "403", description = "The caller holds `ROLE_READONLY`, or named somebody other than themselves in `ackUser` without holding `ROLE_ADMIN` or `ROLE_DELEGATE`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User 'operator', is not allowed to perform updates to alarms as user 'admin'")))
     })
     @Override
     public Response closeTicket(@Context final SecurityContext securityContext,

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SituationsRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SituationsRestService.java
@@ -89,10 +89,8 @@ import java.util.stream.Collectors;
 @Path("situations")
 @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
 @Tag(name = "Situation", description = """
-        Situations API.
-
-        A situation is an alarm that correlates other alarms. It carries `isSituation` and a
-        `relatedAlarms` list, and it lives in the same table as ordinary alarms, so every alarm
+        Situations API. A situation is an alarm that correlates other alarms: it carries `isSituation`
+        and a `relatedAlarms` list and lives in the same table as ordinary alarms, so every alarm
         operation applies to it as well. This resource narrows the collection reads to alarms where
         `isSituation` is true and adds the membership and workflow actions.
 
@@ -109,11 +107,10 @@ import java.util.stream.Collectors;
         members, so acknowledging or clearing a situation leaves the correlated alarms as they were.
 
         Four operations here are the inherited alarm operations, and they carry the alarm wording and
-        an `_1`-suffixed operationId because a single annotation serves both paths: `GET
-        /situations/{id}` (`getAlarmById_1`), `POST /situations` (`createAlarm_1`), `PUT
-        /situations/{id}` (`updateAlarmProperties_1`) and `DELETE /situations/{id}`
-        (`deleteAlarm_1`). Creating and deleting are not implemented on either path; use
-        `POST /situations/create` and the membership endpoints instead.""")
+        an `_1`-suffixed operationId: `GET /situations/{id}` (`getAlarmById_1`), `POST /situations`
+        (`createAlarm_1`), `PUT /situations/{id}` (`updateAlarmProperties_1`) and
+        `DELETE /situations/{id}` (`deleteAlarm_1`). Creating and deleting are not implemented on
+        either path.""")
 public class SituationsRestService extends AlarmRestService {
 
     private static final Logger LOG = LoggerFactory.getLogger(SituationsRestService.class);
@@ -317,8 +314,7 @@ public class SituationsRestService extends AlarmRestService {
         would change nothing.
 
         The change is applied by publishing an event, so the call returns before the membership is
-        visible. The request body is read from a DELETE, which some HTTP clients will not send.
-        `feedback` is accepted and not used.""",
+        visible. The request body is read from a DELETE. `feedback` is accepted and not used.""",
             operationId = "removeSituationAlarms")
     @RequestBody(required = true, description = "Situation to remove from, and the alarms to remove.",
             content = @Content(mediaType = MediaType.APPLICATION_JSON,
@@ -578,11 +574,10 @@ public class SituationsRestService extends AlarmRestService {
     @Operation(
             summary = "List the properties situations can be queried on",
             description = """
-        Return the same property list as `GET /alarms/properties`, because a situation is an alarm. Note
-        that only `alarm.isSituation` is registered as a query behaviour on this resource, so most of
-        the listed properties cannot in fact be used in `_s` here. `q` filters the list by a
-        case-insensitive substring of the name and a `q` that matches nothing yields 200 with an empty
-        list.""",
+        Return the same property list as `GET /alarms/properties`. Only `alarm.isSituation` is
+        registered as a query behaviour on this resource, so most of the listed properties cannot be
+        used in `_s` here. `q` filters the list by a case-insensitive substring of the name and a `q`
+        that matches nothing yields 200 with an empty list.""",
             operationId = "getSituationProperties")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "The matching query properties.",
@@ -655,7 +650,7 @@ public class SituationsRestService extends AlarmRestService {
     @Path("{id}")
     @Operation(
             summary = "Rejected: situations cannot be created at a chosen id",
-            description = "Always answers 404. Use `POST /situations/create` to correlate alarms into a situation.",
+            description = "Always answers 404.",
             operationId = "createSituationWithId",
             parameters = @Parameter(in = ParameterIn.PATH, name = "id", required = true,
                     description = "Alarm database id. The value is not read: every request to this path is answered with 404.",
@@ -700,8 +695,7 @@ public class SituationsRestService extends AlarmRestService {
             summary = "Not implemented: delete several situations",
             description = """
         Deleting alarms is not implemented. When `_s` selects at least one situation the handler answers
-        501 without deleting anything; when nothing matches it answers 404 instead. To dissolve a
-        correlation, remove its members with `DELETE /situations/removeAlarm`.
+        501 without deleting anything; when nothing matches it answers 404 instead.
 
         Example query: `_s=alarm.isSituation==true`.""",
             operationId = "deleteSituations")

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SituationsRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SituationsRestService.java
@@ -21,6 +21,16 @@
  */
 package org.opennms.web.rest.v2;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.commons.lang.StringUtils;
 import org.apache.cxf.jaxrs.ext.search.ConditionType;
@@ -34,18 +44,27 @@ import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.web.rest.support.Aliases;
 import org.opennms.web.rest.support.CriteriaBehavior;
 import org.opennms.web.rest.support.CriteriaBehaviors;
+import org.opennms.web.rest.model.v2.AlarmCollectionDTO;
+import org.opennms.web.rest.support.MultivaluedMapImpl;
+import org.opennms.web.rest.support.SearchPropertyCollection;
 import org.opennms.web.rest.support.SecurityHelper;
+import org.opennms.web.rest.support.StringCollection;
+import org.opennms.web.rest.v2.model.AlarmMemoRequest;
+import org.opennms.web.rest.v2.model.AlarmPropertyUpdateRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.GET;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Context;
@@ -69,7 +88,32 @@ import java.util.stream.Collectors;
 @Component
 @Path("situations")
 @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-@Tag(name = "Situation", description = "Alarms API")
+@Tag(name = "Situation", description = """
+        Situations API.
+
+        A situation is an alarm that correlates other alarms. It carries `isSituation` and a
+        `relatedAlarms` list, and it lives in the same table as ordinary alarms, so every alarm
+        operation applies to it as well. This resource narrows the collection reads to alarms where
+        `isSituation` is true and adds the membership and workflow actions.
+
+        Membership changes are applied by publishing a `uei.opennms.org/alarms/situation` event and
+        letting alarmd act on it, so the handler returns before the change is visible. A read issued
+        immediately afterwards can still show the previous membership.
+
+        An alarm may belong to at most one situation. Alarms already held by another situation are
+        silently skipped rather than reported, so a 200 does not by itself mean every id in
+        `alarmIdList` was taken.
+
+        `GET /situations/{id}` and the per-alarm actions under `/situations/{id}` are not restricted
+        to situations: they resolve any alarm id. Acting on a situation alarm does not cascade to its
+        members, so acknowledging or clearing a situation leaves the correlated alarms as they were.
+
+        Four operations here are the inherited alarm operations, and they carry the alarm wording and
+        an `_1`-suffixed operationId because a single annotation serves both paths: `GET
+        /situations/{id}` (`getAlarmById_1`), `POST /situations` (`createAlarm_1`), `PUT
+        /situations/{id}` (`updateAlarmProperties_1`) and `DELETE /situations/{id}`
+        (`deleteAlarm_1`). Creating and deleting are not implemented on either path; use
+        `POST /situations/create` and the membership endpoints instead.""")
 public class SituationsRestService extends AlarmRestService {
 
     private static final Logger LOG = LoggerFactory.getLogger(SituationsRestService.class);
@@ -95,6 +139,62 @@ public class SituationsRestService extends AlarmRestService {
 
     @GET
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Operation(
+            summary = "List situations",
+            description = """
+        Return a page of alarms whose `isSituation` is true. The restriction is added to whatever `_s`
+        supplies, so `_s` narrows the set of situations rather than widening it to ordinary alarms.
+        Only `isSituation` is registered as a query behaviour on this resource, so an `_s` naming any
+        other property is rejected with 500.
+
+        `relatedAlarms` holds a summary of each member alarm. The situation itself carries the highest
+        severity of its members at the time the correlating event was sent.
+
+        Example query: `_s=alarm.isSituation==true&orderBy=lastEventTime&order=desc`.""",
+            operationId = "getSituations")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "A page of situations.",
+                    headers = @Header(name = "Content-Range", description = "Range of rows returned and the total, as `items <from>-<to>/<total>`.",
+                            schema = @Schema(type = "string", example = "items 0-0/1")),
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = AlarmCollectionDTO.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 1,
+                      "count": 1,
+                      "offset": 0,
+                      "alarm": [
+                        {
+                          "id": 4552,
+                          "uei": "uei.opennms.org/alarms/situation",
+                          "location": "Default",
+                          "reductionKey": "uei.opennms.org/alarms/situation:de4b1c3d-e028-4712-aafc-ea5304d61b7b",
+                          "type": 3,
+                          "count": 1,
+                          "severity": "NORMAL",
+                          "firstEventTime": 1787727667348,
+                          "lastEventTime": 1787727667348,
+                          "description": "Link flapping on the north uplink",
+                          "logMessage": "Created situation with 2 alarms",
+                          "relatedAlarms": [
+                            {
+                              "id": 4549,
+                              "type": 2,
+                              "severity": "NORMAL",
+                              "reductionKey": "uei.opennms.org/nodes/nodeDown::4",
+                              "label": "OpenNMS-defined node event: nodeDown"
+                            }
+                          ],
+                          "affectedNodeCount": 1
+                        }
+                      ]
+                    }"""))),
+            @ApiResponse(responseCode = "204", description = "No situation matched. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "`_s` named a property that is not registered on this resource.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "could not resolve property: bogusprop of: org.opennms.netmgt.model.OnmsAlarm")))
+    })
+    @Override
     public Response get(@Context UriInfo uriInfo,
                         @Context SearchContext searchContext) {
         return super.get(uriInfo, searchContext);
@@ -103,6 +203,37 @@ public class SituationsRestService extends AlarmRestService {
     @POST
     @Path("create")
     @Transactional
+    @Operation(
+            summary = "Create a situation from a set of alarms",
+            description = """
+        Correlate two or more alarms into a new situation. A random UUID is used as the situation id
+        and appears in the reduction key of the situation alarm as
+        `uei.opennms.org/alarms/situation:<uuid>`.
+
+        Ids that name no alarm, and ids whose alarm already belongs to another situation, are dropped
+        from the set. If fewer than two alarms survive, nothing is created and the call answers 204.
+
+        The situation is created by publishing an event, so the call returns before the situation alarm
+        exists. `description` is stored as given and `diagnosticText`, when present, is appended to it
+        wrapped in a `<p>Diagnostic: ...</p>` element. `feedback` is accepted and not used.""",
+            operationId = "createSituation")
+    @RequestBody(required = true, description = "Alarms to correlate, plus the text to describe the situation with.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = SituationPayload.class),
+                    examples = @ExampleObject(value = """
+                    {
+                      "alarmIdList": [4549, 4550],
+                      "diagnosticText": "Both alarms follow the same uplink flap.",
+                      "description": "Link flapping on the north uplink",
+                      "feedback": null
+                    }""")))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The correlating event was published. The situation alarm appears shortly afterwards."),
+            @ApiResponse(responseCode = "204", description = "Fewer than two of the ids resolved to an alarm that is free to correlate. Nothing was created."),
+            @ApiResponse(responseCode = "500", description = "The body could not be deserialised.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "No content to map to Object due to end of input")))
+    })
     public Response create(@Context UriInfo uriInfo, SituationPayload payload) throws InterruptedException {
         String situationId = UUID.randomUUID().toString();
         return handleAssociation(
@@ -117,6 +248,34 @@ public class SituationsRestService extends AlarmRestService {
     @POST
     @Path("associateAlarm")
     @Transactional
+    @Operation(
+            summary = "Add alarms to an existing situation",
+            description = """
+        Add the alarms in `alarmIdList` to the situation named by `situationId`. The new membership is
+        the union of the current members and the ids that resolved, so this never removes anything.
+
+        Ids that name no alarm, and ids whose alarm already belongs to another situation, are dropped.
+        When the union equals the current membership the call answers 204 and no event is published.
+
+        The change is applied by publishing an event, so the call returns before the membership is
+        visible. `feedback` is accepted and not used.""",
+            operationId = "associateSituationAlarms")
+    @RequestBody(required = true, description = "Situation to add to, and the alarms to add.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = AlarmAddRemoveRequest.class),
+                    examples = @ExampleObject(value = """
+                    {
+                      "situationId": 4552,
+                      "alarmIdList": [4551],
+                      "feedback": null
+                    }""")))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The membership event was published."),
+            @ApiResponse(responseCode = "204", description = "The membership would not change. No event was published."),
+            @ApiResponse(responseCode = "400", description = "`situationId` names no alarm, or names an alarm that is not a situation.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Invalid situation ID: 999999")))
+    })
     public Response associateAlarm(@Context UriInfo uriInfo,
                                    AlarmAddRemoveRequest request) throws InterruptedException {
 
@@ -147,6 +306,33 @@ public class SituationsRestService extends AlarmRestService {
     @DELETE
     @Path("removeAlarm")
     @Transactional
+    @Operation(
+            summary = "Remove alarms from a situation",
+            description = """
+        Drop the alarms in `alarmIdList` from the situation named by `situationId`. Removing every
+        member is allowed and leaves the situation alarm in place with no members.
+
+        Unlike the add operation this does not report an unusable `situationId`: an id that names no
+        alarm, or names an alarm that is not a situation, answers 204 in the same way as a request that
+        would change nothing.
+
+        The change is applied by publishing an event, so the call returns before the membership is
+        visible. The request body is read from a DELETE, which some HTTP clients will not send.
+        `feedback` is accepted and not used.""",
+            operationId = "removeSituationAlarms")
+    @RequestBody(required = true, description = "Situation to remove from, and the alarms to remove.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = AlarmAddRemoveRequest.class),
+                    examples = @ExampleObject(value = """
+                    {
+                      "situationId": 4552,
+                      "alarmIdList": [4551],
+                      "feedback": null
+                    }""")))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The membership event was published."),
+            @ApiResponse(responseCode = "204", description = "The membership would not change, or `situationId` does not name a situation. No event was published.")
+    })
     public Response removeAlarm(@Context UriInfo uriInfo,
                                 AlarmAddRemoveRequest request) {
         OnmsAlarm situationAlarm = getDao().get(request.getSituationId());
@@ -164,6 +350,36 @@ public class SituationsRestService extends AlarmRestService {
     @POST
     @Path("clear")
     @Transactional
+    @Operation(
+            summary = "Clear one alarm",
+            description = """
+        Set the severity of a single alarm to Cleared through the acknowledgement DAO. Despite the
+        path and the field name, `situationId` is read as the id of the alarm to clear: any alarm id is
+        accepted, and the alarm does not have to be a situation. `alarmIdList` is ignored here.
+
+        The acknowledgement is recorded against the authenticated user.""",
+            operationId = "clearSituationAlarm")
+    @RequestBody(required = true, description = "The alarm to clear, in `situationId`.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = AlarmAddRemoveRequest.class),
+                    examples = @ExampleObject(value = """
+                    {
+                      "situationId": 4552,
+                      "alarmIdList": [],
+                      "feedback": null
+                    }""")))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The alarm was cleared."),
+            @ApiResponse(responseCode = "400", description = "`situationId` was absent or named no alarm.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "absent", value = "Unable to determine alarm ID to update based on query path."),
+                                    @ExampleObject(name = "unknown", value = "Unable to locate alarm with ID 999999")
+                            })),
+            @ApiResponse(responseCode = "403", description = "The authenticated user may not clear alarms.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User operator cannot act on behalf of user admin")))
+    })
     public Response doAction(
             AlarmAddRemoveRequest req,
             @Context SecurityContext secCtx) {
@@ -196,6 +412,39 @@ public class SituationsRestService extends AlarmRestService {
     @Path("alarms/clear")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     @Transactional
+    @Operation(
+            summary = "Remove alarms from a situation and clear them",
+            description = """
+        Drop the alarms in `alarmIdList` from the situation named by `situationId`, then set each of
+        those alarms to Cleared.
+
+        The removal runs first and decides whether the clear happens at all: when the removal would
+        change nothing the call answers 204 and no alarm is cleared. Ids in `alarmIdList` that are not
+        members of the situation are still cleared, as long as at least one id causes the membership to
+        change.
+
+        The removal is published as an event while the clear is applied directly, so the two halves do
+        not become visible at the same time.""",
+            operationId = "removeAndClearSituationAlarms")
+    @RequestBody(required = true, description = "Situation to remove from, and the alarms to remove and clear.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = AlarmAddRemoveRequest.class),
+                    examples = @ExampleObject(value = """
+                    {
+                      "situationId": 4552,
+                      "alarmIdList": [4550],
+                      "feedback": null
+                    }""")))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The removal event was published and the listed alarms were cleared."),
+            @ApiResponse(responseCode = "204", description = "The membership would not change. Nothing was removed and nothing was cleared."),
+            @ApiResponse(responseCode = "400", description = "`situationId` names no alarm, or names an alarm that is not a situation.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Invalid situation ID: 999999"))),
+            @ApiResponse(responseCode = "403", description = "The authenticated user may not clear alarms.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "User operator cannot act on behalf of user admin")))
+    })
     public Response removeAndClear(
             AlarmAddRemoveRequest req,
             @Context SecurityContext secCtx,
@@ -233,7 +482,27 @@ public class SituationsRestService extends AlarmRestService {
 
     @POST
     @Path("accepted/{id}")
-    public Response acceptSituation(@PathParam("id") Integer id) {
+    @Operation(
+            summary = "Mark a situation accepted",
+            description = """
+        Record that an operator accepts the correlation, by publishing a situation event whose
+        `situationStatus` parameter is `ACCEPTED`. The membership is republished unchanged.
+
+        Acceptance is read back from the `situationStatus` parameter of the last event on the
+        situation, so a later membership change overwrites it and the situation can be accepted again.
+        Calling this on an already accepted situation answers 304.""",
+            operationId = "acceptSituation")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The acceptance event was published."),
+            @ApiResponse(responseCode = "304", description = "The last event on the situation already reports it accepted. No body is returned."),
+            @ApiResponse(responseCode = "404", description = "The id names no alarm, or names an alarm that is not a situation.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Situation not found: 999999")))
+    })
+    public Response acceptSituation(
+            @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                    description = "Database id of the situation alarm.", example = "4552")
+            @PathParam("id") Integer id) {
         if (id == null) {
             return Response.status(Response.Status.BAD_REQUEST)
                     .entity("Situation ID is required")
@@ -274,6 +543,360 @@ public class SituationsRestService extends AlarmRestService {
         );
 
         return Response.ok().build();
+    }
+
+
+    @GET
+    @Path("count")
+    @Produces({MediaType.TEXT_PLAIN})
+    @Operation(
+            summary = "Count situations",
+            description = """
+        Return the number of alarms whose `isSituation` is true, as a plain-text integer. The response
+        is `text/plain` only, so a request that asks solely for `application/json` is answered with
+        404. `limit` and `offset` are ignored: the count covers the whole match.
+
+        Example query: `_s=alarm.isSituation==true`.""",
+            operationId = "getSituationCount")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The number of matching situations.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "1"))),
+            @ApiResponse(responseCode = "404", description = "The request did not accept `text/plain`. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "`_s` named a property that is not registered on this resource.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "could not resolve property: bogusprop of: org.opennms.netmgt.model.OnmsAlarm")))
+    })
+    @Override
+    public Response getCount(@Context final UriInfo uriInfo, @Context final SearchContext searchContext) {
+        return super.getCount(uriInfo, searchContext);
+    }
+
+    @GET
+    @Path("properties")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Operation(
+            summary = "List the properties situations can be queried on",
+            description = """
+        Return the same property list as `GET /alarms/properties`, because a situation is an alarm. Note
+        that only `alarm.isSituation` is registered as a query behaviour on this resource, so most of
+        the listed properties cannot in fact be used in `_s` here. `q` filters the list by a
+        case-insensitive substring of the name and a `q` that matches nothing yields 200 with an empty
+        list.""",
+            operationId = "getSituationProperties")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The matching query properties.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = SearchPropertyCollection.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 1,
+                      "count": 1,
+                      "offset": 0,
+                      "searchProperty": [
+                        {
+                          "id": "isSituation",
+                          "name": "Is Situation",
+                          "type": "BOOLEAN",
+                          "orderBy": true,
+                          "iplike": false
+                        }
+                      ]
+                    }""")))
+    })
+    @Override
+    public Response getProperties(@Parameter(in = ParameterIn.QUERY, name = "q",
+            description = "Case-insensitive substring of the property name.", example = "situation")
+                                  @QueryParam("q") final String query) {
+        return super.getProperties(query);
+    }
+
+    @GET
+    @Path("properties/{propertyId}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Operation(
+            summary = "List the values a query property takes",
+            description = """
+        Return the distinct values of one query property over the alarm table, not restricted to
+        situations. The element type follows the property type, and a property whose type has no value
+        listing, such as `isSituation`, answers 204. `propertyId` is the unprefixed id from
+        `GET /situations/properties`.""",
+            operationId = "getSituationPropertyValues")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The distinct values of the property.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = StringCollection.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "totalCount": 7,
+                      "count": 7,
+                      "offset": 0,
+                      "value": [1, 2, 3, 4, 5, 6, 7]
+                    }"""))),
+            @ApiResponse(responseCode = "204", description = "The property has a type with no value listing, such as BOOLEAN. No body is returned."),
+            @ApiResponse(responseCode = "404", description = "No query property has that id. No body is returned.")
+    })
+    @Override
+    public Response getPropertyValues(
+            @Parameter(in = ParameterIn.PATH, name = "propertyId", required = true,
+                    description = "Unprefixed property id from `GET /situations/properties`.", example = "severity")
+            @PathParam("propertyId") final String propertyId,
+            @Parameter(in = ParameterIn.QUERY, name = "q",
+                    description = "Case-sensitive substring the value must contain.", example = "situation")
+            @QueryParam("q") final String query,
+            @Parameter(in = ParameterIn.QUERY, name = "limit",
+                    description = "Maximum number of values returned. Applies only to values read from the database.",
+                    example = "25")
+            @QueryParam("limit") final Integer limit) {
+        return super.getPropertyValues(propertyId, query, limit);
+    }
+
+    @POST
+    @Path("{id}")
+    @Operation(
+            summary = "Rejected: situations cannot be created at a chosen id",
+            description = "Always answers 404. Use `POST /situations/create` to correlate alarms into a situation.",
+            operationId = "createSituationWithId",
+            parameters = @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                    description = "Alarm database id. The value is not read: every request to this path is answered with 404.",
+                    example = "4241"))
+    @ApiResponses(@ApiResponse(responseCode = "404", description = "Always. No body is returned."))
+    @Override
+    public Response createSpecific() {
+        return super.createSpecific();
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Operation(
+            summary = "Update properties of several situations",
+            description = """
+        Apply the form parameters to every situation matching `_s`. The default `limit` of 10 applies to
+        the selection, so a call without an explicit `limit` touches at most 10 situations. The batch
+        runs in one transaction and stops at the first failure, leaving earlier situations already
+        changed.
+
+        Example query: `_s=alarm.isSituation==true`.""",
+            operationId = "updateSituations")
+    @RequestBody(required = true, description = "Alarm properties to apply, form-encoded.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(implementation = AlarmPropertyUpdateRequest.class),
+                    examples = @ExampleObject(value = "ack=true")))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Every selected situation was updated. No body is returned."),
+            @ApiResponse(responseCode = "404", description = "No situation matched `_s`. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "`_s` named a property that is not registered on this resource.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "could not resolve property: bogusprop of: org.opennms.netmgt.model.OnmsAlarm")))
+    })
+    @Override
+    public Response updateMany(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo,
+                               @Context final SearchContext searchContext, final MultivaluedMapImpl params) {
+        return super.updateMany(securityContext, uriInfo, searchContext, params);
+    }
+
+    @DELETE
+    @Operation(
+            summary = "Not implemented: delete several situations",
+            description = """
+        Deleting alarms is not implemented. When `_s` selects at least one situation the handler answers
+        501 without deleting anything; when nothing matches it answers 404 instead. To dissolve a
+        correlation, remove its members with `DELETE /situations/removeAlarm`.
+
+        Example query: `_s=alarm.isSituation==true`.""",
+            operationId = "deleteSituations")
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = "No situation matched `_s`. No body is returned."),
+            @ApiResponse(responseCode = "501", description = "Delete is not implemented. No body is returned.")
+    })
+    @Override
+    public Response deleteMany(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo,
+                               @Context final SearchContext searchContext) {
+        return super.deleteMany(securityContext, uriInfo, searchContext);
+    }
+
+    @PUT
+    @Path("{id}/memo")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Operation(
+            summary = "Set the sticky memo on a situation",
+            description = """
+        Replace the sticky memo on the alarm row. The lookup is not restricted to situations. `body` is
+        required; when `user` is omitted the authenticated user is recorded as the author.""",
+            operationId = "updateSituationMemo")
+    @RequestBody(required = true, description = "Memo text and optional author, form-encoded.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(implementation = AlarmMemoRequest.class),
+                    examples = @ExampleObject(value = "body=Correlation+confirmed+by+the+NOC.&user=admin")))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The memo was written. No body is returned."),
+            @ApiResponse(responseCode = "400", description = "`body` was absent.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Body cannot be null."))),
+            @ApiResponse(responseCode = "404", description = "No alarm has that id.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Alarm not found.")))
+    })
+    @Override
+    public Response updateMemo(@Context final SecurityContext securityContext,
+                               @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                                       description = "Database id of the situation alarm.", example = "4552")
+                               @PathParam("id") final Integer alarmId, final MultivaluedMapImpl params) {
+        return super.updateMemo(securityContext, alarmId, params);
+    }
+
+    @PUT
+    @Path("{id}/journal")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Operation(
+            summary = "Set the journal note on a situation",
+            description = """
+        Replace the journal note, which is keyed on the reduction key rather than on the alarm row. A
+        situation reduction key contains the situation UUID, so the note follows that situation only.
+        `body` is required.""",
+            operationId = "updateSituationJournal")
+    @RequestBody(required = true, description = "Journal text and optional author, form-encoded.",
+            content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+                    schema = @Schema(implementation = AlarmMemoRequest.class),
+                    examples = @ExampleObject(value = "body=Escalated+to+the+transport+team.&user=admin")))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The journal note was written. No body is returned."),
+            @ApiResponse(responseCode = "400", description = "`body` was absent.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Body cannot be null."))),
+            @ApiResponse(responseCode = "404", description = "No alarm has that id.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Alarm not found.")))
+    })
+    @Override
+    public Response updateJournal(@Context final SecurityContext securityContext,
+                                  @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                                          description = "Database id of the situation alarm.", example = "4552")
+                                  @PathParam("id") final Integer alarmId, final MultivaluedMapImpl params) {
+        return super.updateJournal(securityContext, alarmId, params);
+    }
+
+    @DELETE
+    @Path("{id}/memo")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Operation(
+            summary = "Remove the sticky memo from a situation",
+            description = """
+        Remove the note attached to the alarm row. Removing one that is not set still answers 204. No
+        request body is read, although the handler declares
+        `application/x-www-form-urlencoded`.""",
+            operationId = "deleteSituationMemo")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The sticky memo is gone, whether or not one was set. No body is returned."),
+            @ApiResponse(responseCode = "404", description = "No alarm has that id.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Alarm not found.")))
+    })
+    @Override
+    public Response removeMemo(@Context final SecurityContext securityContext,
+                               @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                                       description = "Database id of the situation alarm.", example = "4552")
+                               @PathParam("id") final Integer alarmId) {
+        return super.removeMemo(securityContext, alarmId);
+    }
+
+    @DELETE
+    @Path("{id}/journal")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Operation(
+            summary = "Remove the journal note from a situation",
+            description = """
+        Remove the note keyed on the reduction key. Removing one that is not set still answers 204. No
+        request body is read, although the handler declares
+        `application/x-www-form-urlencoded`.""",
+            operationId = "deleteSituationJournal")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The journal note is gone, whether or not one was set. No body is returned."),
+            @ApiResponse(responseCode = "404", description = "No alarm has that id.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Alarm not found.")))
+    })
+    @Override
+    public Response removeJournal(@Context final SecurityContext securityContext,
+                                  @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                                          description = "Database id of the situation alarm.", example = "4552")
+                                  @PathParam("id") final Integer alarmId) {
+        return super.removeJournal(securityContext, alarmId);
+    }
+
+    @POST
+    @Path("{id}/ticket/create")
+    @Operation(
+            summary = "Create the trouble ticket for a situation",
+            description = """
+        Ask the configured ticketer plugin to raise a ticket for the alarm, asynchronously. Members of
+        the situation are not ticketed.
+
+        Gated on `opennms.alarmTroubleTicketEnabled` being `true`. With the ticketer disabled every
+        call answers 501, including a call naming an alarm that does not exist, because the gate is
+        checked before the alarm is looked up.""",
+            operationId = "createSituationTicket")
+    @ApiResponses({
+            @ApiResponse(responseCode = "202", description = "The request was handed to the ticketer plugin. No body is returned."),
+            @ApiResponse(responseCode = "501", description = "The ticketer plugin is disabled.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "AlarmTroubleTicketer is not enabled. Cannot perform operation")))
+    })
+    @Override
+    public Response createTicket(@Context final SecurityContext securityContext,
+                                 @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                                         description = "Database id of the situation alarm.", example = "4552")
+                                 @PathParam("id") final Integer alarmId) throws Exception {
+        return super.createTicket(securityContext, alarmId);
+    }
+
+    @POST
+    @Path("{id}/ticket/update")
+    @Operation(
+            summary = "Refresh the trouble ticket for a situation",
+            description = """
+        Ask the configured ticketer plugin to re-read the ticket from the helpdesk system and write the
+        current state back onto the alarm, asynchronously.
+
+        Gated on `opennms.alarmTroubleTicketEnabled` being `true`; with the ticketer disabled every
+        call answers 501.""",
+            operationId = "updateSituationTicket")
+    @ApiResponses({
+            @ApiResponse(responseCode = "202", description = "The request was handed to the ticketer plugin. No body is returned."),
+            @ApiResponse(responseCode = "501", description = "The ticketer plugin is disabled.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "AlarmTroubleTicketer is not enabled. Cannot perform operation")))
+    })
+    @Override
+    public Response updateTicket(@Context final SecurityContext securityContext,
+                                 @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                                         description = "Database id of the situation alarm.", example = "4552")
+                                 @PathParam("id") final Integer alarmId) throws Exception {
+        return super.updateTicket(securityContext, alarmId);
+    }
+
+    @POST
+    @Path("{id}/ticket/close")
+    @Operation(
+            summary = "Close the trouble ticket for a situation",
+            description = """
+        Ask the configured ticketer plugin to close the ticket recorded on the alarm, asynchronously.
+
+        Gated on `opennms.alarmTroubleTicketEnabled` being `true`; with the ticketer disabled every
+        call answers 501.""",
+            operationId = "closeSituationTicket")
+    @ApiResponses({
+            @ApiResponse(responseCode = "202", description = "The request was handed to the ticketer plugin. No body is returned."),
+            @ApiResponse(responseCode = "501", description = "The ticketer plugin is disabled.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "AlarmTroubleTicketer is not enabled. Cannot perform operation")))
+    })
+    @Override
+    public Response closeTicket(@Context final SecurityContext securityContext,
+                                @Parameter(in = ParameterIn.PATH, name = "id", required = true,
+                                        description = "Database id of the situation alarm.", example = "4552")
+                                @PathParam("id") final Integer alarmId) throws Exception {
+        return super.closeTicket(securityContext, alarmId);
     }
 
     private void clearAlarm(OnmsAlarm alarm, String user) {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SnmpInterfaceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SnmpInterfaceRestService.java
@@ -147,7 +147,7 @@ public class SnmpInterfaceRestService extends AbstractDaoRestService<OnmsSnmpInt
     @Override
     @Operation(summary = "List SNMP interfaces",
             description = """
-                    SNMP interfaces matching the query. The query joins the node, its asset record, location and categories, and the IP interfaces, so properties of all of those are searchable. Duplicate rows produced by those joins are collapsed before the page is built, which can make the returned `count` smaller than the requested `limit`.
+                    SNMP interfaces matching the query. The query joins the node, its asset record and location, and the IP interfaces, so properties of those are searchable; `category.*` terms are not joined here and fail with 500. Duplicate rows produced by those joins are collapsed before the page is built, which can make the returned `count` smaller than the requested `limit`.
 
                     Timestamps are epoch milliseconds in JSON and ISO-8601 with a UTC offset in XML.
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SnmpInterfaceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SnmpInterfaceRestService.java
@@ -46,6 +46,24 @@ import org.opennms.web.rest.support.SearchProperty;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+import org.apache.cxf.jaxrs.ext.search.SearchContext;
+import org.opennms.web.rest.support.MultivaluedMapImpl;
+import org.opennms.web.rest.support.SearchPropertyCollection;
+import org.opennms.web.rest.support.StringCollection;
 
 /**
  * Basic Web Service using REST for {@link OnmsSnmpInterface} entity.
@@ -124,5 +142,352 @@ public class SnmpInterfaceRestService extends AbstractDaoRestService<OnmsSnmpInt
     @Override
     protected final OnmsSnmpInterface doGet(final UriInfo uriInfo, final String id) {
         return getDao().get(Integer.valueOf(id));
+    }
+
+    @Override
+    @Operation(summary = "List SNMP interfaces",
+            description = """
+                    SNMP interfaces matching the query. The query joins the node, its asset record, location and categories, and the IP interfaces, so properties of all of those are searchable. Duplicate rows produced by those joins are collapsed before the page is built, which can make the returned `count` smaller than the requested `limit`.
+
+                    Timestamps are epoch milliseconds in JSON and ISO-8601 with a UTC offset in XML.
+
+                    `application/atom+xml` is also accepted and returns the same document as `application/xml`.
+
+                    For example, `_s=ifDescr==enp*` or `_s=node.label==loopback-001`.""",
+            operationId = "snmpInterfacesList")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "One page of matching SNMP interfaces.",
+                    headers = @Header(name = "Content-Range", description = "`items <offset>-<last>/<totalCount>` for this page.",
+                            schema = @Schema(type = "string")),
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsSnmpInterfaceList.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "totalCount": 4659,
+                              "count": 1,
+                              "offset": 0,
+                              "snmpInterface": [ {
+                                "id": 1276,
+                                "ifIndex": 2,
+                                "ifDescr": "enp113s0",
+                                "ifName": "enp113s0",
+                                "ifAlias": "",
+                                "ifType": 6,
+                                "ifSpeed": 0,
+                                "ifAdminStatus": 1,
+                                "ifOperStatus": 2,
+                                "physAddr": "1c697ad4f9d8",
+                                "collectFlag": "N",
+                                "collect": false,
+                                "collectionPolicySpecified": false,
+                                "collectionUserSpecified": false,
+                                "pollFlag": "N",
+                                "poll": false,
+                                "hasFlows": false,
+                                "hasIngressFlows": false,
+                                "hasEgressFlows": false,
+                                "lastIngressFlow": null,
+                                "lastEgressFlow": null,
+                                "lastCapsdPoll": 1786541086168,
+                                "lastSnmpPoll": null,
+                                "nodeId": 2
+                              } ]
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsSnmpInterfaceList.class),
+                                    examples = @ExampleObject(value = """
+                            <snmpInterfaces count="1" offset="0" totalCount="4659">
+                              <snmpInterface collectFlag="N" collect="false" id="1276" ifIndex="2" pollFlag="N" poll="false">
+                                <ifAdminStatus>1</ifAdminStatus>
+                                <ifAlias></ifAlias>
+                                <ifDescr>enp113s0</ifDescr>
+                                <ifName>enp113s0</ifName>
+                                <ifOperStatus>2</ifOperStatus>
+                                <ifSpeed>0</ifSpeed>
+                                <ifType>6</ifType>
+                                <lastCapsdPoll>2026-08-12T09:24:46.168-04:00</lastCapsdPoll>
+                                <nodeId>2</nodeId>
+                                <physAddr>1c697ad4f9d8</physAddr>
+                              </snmpInterface>
+                            </snmpInterfaces>"""))
+                    }),
+            @ApiResponse(responseCode = "204", description = "No SNMP interface matched the query. The response has no body."),
+            @ApiResponse(responseCode = "500", description = DOC_SEARCH_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    public Response get(final UriInfo uriInfo, final SearchContext searchContext) {
+        return super.get(uriInfo, searchContext);
+    }
+
+    @Override
+    @Operation(summary = "Count SNMP interfaces",
+            description = """
+                    Number of SNMP interfaces matching the query.
+
+                    Only `text/plain` is produced. A request that sends `Accept: application/json` does not match this operation and falls through to the single-entity GET with `count` as the identifier.
+
+                    For example, `_s=ifDescr==enp*` or `_s=node.label==loopback-001`.""",
+            operationId = "snmpInterfacesCount")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The number of matching SNMP interfaces, as a decimal string.",
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "4659"))),
+            @ApiResponse(responseCode = "500", description = DOC_COUNT_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    public Response getCount(final UriInfo uriInfo, final SearchContext searchContext) {
+        return super.getCount(uriInfo, searchContext);
+    }
+
+    @Override
+    @Operation(summary = "List the queryable properties of SNMP interfaces",
+            description = """
+                    The properties an SNMP-interface query can filter and sort on, including the joined node, IP interface and asset properties.""",
+            operationId = "snmpInterfacesSearchProperties")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The properties this endpoint can search and sort on.",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = SearchPropertyCollection.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "totalCount": 1,
+                              "count": 1,
+                              "offset": 0,
+                              "searchProperty": [
+                                { "id": "ifName", "name": "Interface Name", "type": "STRING", "orderBy": true, "iplike": false }
+                              ]
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = SearchPropertyCollection.class),
+                                    examples = @ExampleObject(value = """
+                            <searchProperties count="1" offset="0" totalCount="1">
+                              <searchProperty type="STRING" orderBy="true" iplike="false" id="ifName" name="Interface Name"/>
+                            </searchProperties>"""))
+                    })
+    })
+    public Response getProperties(final String query) {
+        return super.getProperties(query);
+    }
+
+    @Override
+    @Operation(summary = "List the values a queryable property takes",
+            description = """
+                    Distinct values held by one SNMP-interface property. The `value` entries are typed after the property: numbers for `INTEGER`, `LONG` and `FLOAT`, epoch milliseconds for `TIMESTAMP`, strings otherwise.""",
+            operationId = "snmpInterfacesSearchPropertyValues")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The distinct values, typed after the property.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = StringCollection.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "totalCount": 3,
+                              "count": 3,
+                              "offset": 0,
+                              "value": [ 1, 2, 3 ]
+                            }"""))),
+            @ApiResponse(responseCode = "404", description = "No property with that `id` is queryable here. The response has no body.")
+    })
+    public Response getPropertyValues(final String propertyId, final String query, final Integer limit) {
+        return super.getPropertyValues(propertyId, query, limit);
+    }
+
+    @Override
+    @Operation(summary = "Get one SNMP interface",
+            description = """
+                    One SNMP interface by database identifier.
+
+                    Timestamps are epoch milliseconds in JSON and ISO-8601 with a UTC offset in XML.
+
+                    `application/atom+xml` is also accepted and returns the same document as `application/xml`.""",
+            operationId = "snmpInterfacesGet")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The requested SNMP interface.",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsSnmpInterface.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "id": 1276,
+                              "ifIndex": 2,
+                              "ifDescr": "enp113s0",
+                              "ifName": "enp113s0",
+                              "ifAlias": "",
+                              "ifType": 6,
+                              "ifSpeed": 0,
+                              "ifAdminStatus": 1,
+                              "ifOperStatus": 2,
+                              "physAddr": "1c697ad4f9d8",
+                              "collectFlag": "N",
+                              "collect": false,
+                              "pollFlag": "N",
+                              "poll": false,
+                              "lastCapsdPoll": 1786541086168,
+                              "lastSnmpPoll": null,
+                              "nodeId": 2
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsSnmpInterface.class),
+                                    examples = @ExampleObject(value = """
+                            <snmpInterface collectFlag="N" collect="false" id="1276" ifIndex="2" pollFlag="N" poll="false">
+                              <ifDescr>enp113s0</ifDescr>
+                              <ifName>enp113s0</ifName>
+                              <ifSpeed>0</ifSpeed>
+                              <ifType>6</ifType>
+                              <lastCapsdPoll>2026-08-12T09:24:46.168-04:00</lastCapsdPoll>
+                              <nodeId>2</nodeId>
+                              <physAddr>1c697ad4f9d8</physAddr>
+                            </snmpInterface>"""))
+                    }),
+            @ApiResponse(responseCode = "500", description = """
+                    The identifier is not an integer. The body is a `text/plain` message.""",
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"abc\""))),
+            @ApiResponse(responseCode = "404", description = """
+                    The identifier parsed as an integer but no SNMP interface has it. The response has no body.""")
+    })
+    public Response get(final UriInfo uriInfo,
+            @Parameter(description = """
+                    Database identifier of the SNMP interface. It is read as a string and then parsed as an integer, so a non-numeric value fails with 500 rather than 404.""",
+                    required = true, example = "1276")
+            final String id) {
+        return super.get(uriInfo, id);
+    }
+
+    @Override
+    @Operation(summary = "Create a SNMP interface",
+            description = """
+                    Not supported here: create SNMP interfaces under `/nodes/{nodeCriteria}/snmpinterfaces` or let discovery create them.""",
+            operationId = "snmpInterfacesCreate")
+    @ApiResponses({
+            @ApiResponse(responseCode = "501", description = DOC_NOT_IMPLEMENTED)
+    })
+    public Response create(final SecurityContext securityContext, final UriInfo uriInfo,
+            @RequestBody(description = """
+                    Accepted but not acted on: the endpoint answers 501 for every body.""",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsSnmpInterface.class),
+                                    examples = @ExampleObject(value = """
+                            { }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsSnmpInterface.class),
+                                    examples = @ExampleObject(value = """
+                            <snmpInterface/>"""))
+                    })
+            final OnmsSnmpInterface object) {
+        return super.create(securityContext, uriInfo, object);
+    }
+
+    @Override
+    @Operation(summary = "Rejected: create a SNMP interface at a caller-chosen identifier",
+            description = DOC_POST_WITH_ID,
+            operationId = "snmpInterfacesCreateWithId")
+    @Parameters({
+            @Parameter(name = "id", in = ParameterIn.PATH, required = true,
+                    description = "Ignored. Any value produces the same response.",
+                    schema = @Schema(type = "string"), example = "1276")
+    })
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = "Always. The response has no body.")
+    })
+    public Response createSpecific() {
+        return super.createSpecific();
+    }
+
+    @Override
+    @Operation(summary = "Update the SNMP interfaces matching a query",
+            description = """
+                    Not supported here: the endpoint answers 501 once it has found at least one match, and 404 when nothing matches.
+
+                    For example, `_s=ifDescr==enp*` or `_s=node.label==loopback-001`.""",
+            operationId = "snmpInterfacesUpdateMany")
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = DOC_NO_MATCH),
+            @ApiResponse(responseCode = "500", description = DOC_SEARCH_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search"))),
+            @ApiResponse(responseCode = "501", description = DOC_NOT_IMPLEMENTED)
+    })
+    public Response updateMany(final SecurityContext securityContext, final UriInfo uriInfo, final SearchContext searchContext,
+            @RequestBody(description = DOC_FORM_BODY,
+                    content = @Content(mediaType = "application/x-www-form-urlencoded",
+                            schema = @Schema(type = "object"),
+                            examples = @ExampleObject(value = """
+                            collect=C""")))
+            final MultivaluedMapImpl params) {
+        return super.updateMany(securityContext, uriInfo, searchContext, params);
+    }
+
+    @Override
+    @Hidden
+    public Response update(final SecurityContext securityContext, final UriInfo uriInfo, final Integer id,
+            final OnmsSnmpInterface object) {
+        return super.update(securityContext, uriInfo, id, object);
+    }
+
+    @Override
+    @Operation(summary = "Update one SNMP interface",
+            description = """
+                    Not supported here. Both the JSON or XML replacement form and the form-parameter form answer 501; update SNMP interfaces under `/nodes/{nodeCriteria}/snmpinterfaces/{id}` instead.""",
+            operationId = "snmpInterfacesUpdate")
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = """
+                    No SNMP interface has that identifier. The response has no body."""),
+            @ApiResponse(responseCode = "501", description = """
+                    This endpoint does not support update. The response has no body.""")
+    })
+    public Response updateProperties(final SecurityContext securityContext, final UriInfo uriInfo,
+            @Parameter(description = """
+                    Database identifier of the SNMP interface. It is read as a string and then parsed as an integer, so a non-numeric value fails with 500 rather than 404.""",
+                    required = true, example = "1276")
+            final String id,
+            @RequestBody(description = """
+                    Accepted but not acted on: the endpoint answers 501 for every body.""",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = OnmsSnmpInterface.class),
+                                    examples = @ExampleObject(value = """
+                            { }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = OnmsSnmpInterface.class),
+                                    examples = @ExampleObject(value = """
+                            <snmpInterface/>""")),
+                            @Content(mediaType = "application/x-www-form-urlencoded",
+                                    schema = @Schema(type = "object"),
+                                    examples = @ExampleObject(value = """
+                            collect=C"""))
+                    })
+            final MultivaluedMapImpl params) {
+        return super.updateProperties(securityContext, uriInfo, id, params);
+    }
+
+    @Override
+    @Operation(summary = "Delete the SNMP interfaces matching a query",
+            description = """
+                    Not supported here: the endpoint answers 501 once it has found at least one match, and 404 when nothing matches.
+
+                    For example, `_s=ifDescr==enp*` or `_s=node.label==loopback-001`.""",
+            operationId = "snmpInterfacesDeleteMany")
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = DOC_NO_MATCH),
+            @ApiResponse(responseCode = "500", description = DOC_SEARCH_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search"))),
+            @ApiResponse(responseCode = "501", description = DOC_NOT_IMPLEMENTED)
+    })
+    public Response deleteMany(final SecurityContext securityContext, final UriInfo uriInfo, final SearchContext searchContext) {
+        return super.deleteMany(securityContext, uriInfo, searchContext);
+    }
+
+    @Override
+    @Operation(summary = "Delete one SNMP interface",
+            description = """
+                    Not supported here.""",
+            operationId = "snmpInterfacesDelete")
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = """
+                    No SNMP interface has that identifier. The response has no body."""),
+            @ApiResponse(responseCode = "501", description = """
+                    This endpoint does not support deletion. The response has no body.""")
+    })
+    public Response delete(final SecurityContext securityContext, final UriInfo uriInfo,
+            @Parameter(description = """
+                    Database identifier of the SNMP interface. It is read as a string and then parsed as an integer, so a non-numeric value fails with 500 rather than 404.""",
+                    required = true, example = "1276")
+            final String id) {
+        return super.delete(securityContext, uriInfo, id);
     }
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SnmpInterfaceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SnmpInterfaceRestService.java
@@ -351,9 +351,9 @@ public class SnmpInterfaceRestService extends AbstractDaoRestService<OnmsSnmpInt
     }
 
     @Override
-    @Operation(summary = "Create a SNMP interface",
+    @Operation(summary = "Create an SNMP interface",
             description = """
-                    Not supported here: create SNMP interfaces under `/nodes/{nodeCriteria}/snmpinterfaces` or let discovery create them.""",
+                    Answered with 501 for every body.""",
             operationId = "snmpInterfacesCreate")
     @ApiResponses({
             @ApiResponse(responseCode = "501", description = DOC_NOT_IMPLEMENTED)
@@ -374,7 +374,7 @@ public class SnmpInterfaceRestService extends AbstractDaoRestService<OnmsSnmpInt
     }
 
     @Override
-    @Operation(summary = "Rejected: create a SNMP interface at a caller-chosen identifier",
+    @Operation(summary = "Rejected: create an SNMP interface at a caller-chosen identifier",
             description = DOC_POST_WITH_ID,
             operationId = "snmpInterfacesCreateWithId")
     @Parameters({
@@ -423,7 +423,7 @@ public class SnmpInterfaceRestService extends AbstractDaoRestService<OnmsSnmpInt
     @Override
     @Operation(summary = "Update one SNMP interface",
             description = """
-                    Not supported here. Both the JSON or XML replacement form and the form-parameter form answer 501; update SNMP interfaces under `/nodes/{nodeCriteria}/snmpinterfaces/{id}` instead.""",
+                    Both the JSON or XML replacement form and the form-parameter form answer 501.""",
             operationId = "snmpInterfacesUpdate")
     @ApiResponses({
             @ApiResponse(responseCode = "404", description = """
@@ -475,7 +475,7 @@ public class SnmpInterfaceRestService extends AbstractDaoRestService<OnmsSnmpInt
     @Override
     @Operation(summary = "Delete one SNMP interface",
             description = """
-                    Not supported here.""",
+                    Answered with 501 once the identifier resolves, and 404 when it does not.""",
             operationId = "snmpInterfacesDelete")
     @ApiResponses({
             @ApiResponse(responseCode = "404", description = """

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SnmpMetadataRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SnmpMetadataRestService.java
@@ -22,6 +22,13 @@
 package org.opennms.web.rest.v2;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.model.OnmsNode;
@@ -51,8 +58,91 @@ public class SnmpMetadataRestService {
     @GET
     @Path("{nodeCriteria}")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-    @Operation(summary = "Get snmpmetadata by nodeId", description = "Get snmpmetadata by nodeId", operationId = "SnmpMetadataRestServiceGETSNMPMetaDataByNodId")
-    public Response getSnmpMetadata(@PathParam("nodeCriteria") String nodeCriteria) {
+    @Operation(
+            summary = "Get the SNMP metadata tree of a node",
+            description = """
+        Return the node's metadata entries in the `snmp` context, reshaped into a tree. The flat
+        `key = value` entries are parsed on the way out: a key of `a.b` becomes nested objects, and a
+        key of `t[i].k` becomes a table `t` with an entry indexed `i`. Nothing is stored in tree form,
+        so the result is derived on every call.
+
+        The `snmp` context is written by provisiond's SNMP metadata collection, not through the metadata
+        API, which refuses any context that does not begin with `X-`. A node with no `snmp` metadata is
+        a 200 carrying an empty tree.
+
+        The `id` field is a process-wide counter assigned while the tree is built, so the same node
+        yields different `id` values on successive calls. It is not a database identifier and the XML
+        representation omits it. Table entries come back in map iteration order rather than sorted by
+        index.""",
+            operationId = "SnmpMetadataRestServiceGETSNMPMetaDataByNodId")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The node's SNMP metadata tree, rooted at an object named `snmp`.",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = SnmpMetadataObject.class),
+                                    examples = {
+                                            @ExampleObject(name = "populated", value = """
+                    {
+                      "id": 2,
+                      "name": "snmp",
+                      "snmp-metadata-object": [
+                        {
+                          "id": 3,
+                          "name": "sysDescr",
+                          "snmp-metadata-object": [],
+                          "snmp-metadata-value": [
+                            {"id": 4, "name": "sysDescr", "value": "Linux apidoc 5.15.0"}
+                          ],
+                          "snmp-metadata-table": []
+                        }
+                      ],
+                      "snmp-metadata-value": [],
+                      "snmp-metadata-table": [
+                        {
+                          "id": 5,
+                          "name": "ifTable",
+                          "snmp-metadata-entry": [
+                            {
+                              "id": 6,
+                              "index": "2",
+                              "snmp-metadata-value": [
+                                {"id": 7, "name": "ifSpeed", "value": "1000000000"},
+                                {"id": 8, "name": "ifDescr", "value": "eth0"}
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }"""),
+                                            @ExampleObject(name = "no snmp metadata", value = """
+                    {"id": 0, "name": "snmp", "snmp-metadata-object": [], "snmp-metadata-value": [], "snmp-metadata-table": []}""")
+                                    }),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = SnmpMetadataObject.class),
+                                    examples = @ExampleObject(value = """
+                    <snmp-metadata-object name="snmp">
+                      <snmp-metadata-object name="sysDescr">
+                        <snmp-metadata-value name="sysDescr" value="Linux apidoc 5.15.0"/>
+                      </snmp-metadata-object>
+                      <snmp-metadata-table name="ifTable">
+                        <snmp-metadata-entry index="2">
+                          <snmp-metadata-value name="ifSpeed" value="1000000000"/>
+                          <snmp-metadata-value name="ifDescr" value="eth0"/>
+                        </snmp-metadata-entry>
+                      </snmp-metadata-table>
+                    </snmp-metadata-object>"""))
+                    }),
+            @ApiResponse(responseCode = "404", description = "No such node. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The path segment is neither a number nor `foreignSource:foreignId`.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"notanumber\"")))
+    })
+    public Response getSnmpMetadata(
+            @Parameter(in = ParameterIn.PATH, name = "nodeCriteria",
+                    description = "Node database id, or `foreignSource:foreignId`. A value that is neither is answered with 500.",
+                    example = "257")
+            @PathParam("nodeCriteria") String nodeCriteria) {
         final OnmsNode node = nodeDao.get(nodeCriteria);
         if (node == null) {
             return Response.status(Response.Status.NOT_FOUND).build();

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/TopologyAssetDTO.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/TopologyAssetDTO.java
@@ -23,19 +23,43 @@ package org.opennms.web.rest.v2;
 
 import java.util.Date;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * Wire shape of a topology image asset's metadata (the bytes are served
  * separately, by id). See {@link TopologyAssetRestService}.
  */
 public class TopologyAssetDTO {
 
+    @Schema(description = "Server-generated identifier, a UUID on this build. Also the path segment used to fetch the bytes.",
+            example = "defb7a91-9287-459a-ba1d-6879fee1cbfd")
     private String id;
+
+    @Schema(description = "Display name supplied at upload time, trimmed. Not unique.", example = "core-switch")
     private String name;
+
+    @Schema(description = "Which role the image plays, and therefore which size cap applies.",
+            example = "icon", allowableValues = {"background", "icon"})
     private String kind;
+
+    @Schema(description = "MIME type recorded from the upload's Content-Type header, without parameters.",
+            example = "image/png", allowableValues = {"image/png", "image/jpeg", "image/gif", "image/webp"})
     private String mimeType;
+
+    @Schema(description = "Size of the stored image in bytes.", example = "36667")
     private long sizeBytes;
+
+    @Schema(description = "Authenticated principal that uploaded the asset. Null when the upload ran without a principal.",
+            example = "admin")
     private String owner;
+
+    // Serialized as epoch milliseconds, not as the date-time string the
+    // auto-derived schema for a Date would claim.
+    @Schema(description = "Upload time, epoch milliseconds.", type = "integer", format = "int64", example = "1787727367630")
     private Date created;
+
+    @Schema(description = "Last time the bytes or metadata changed, epoch milliseconds. Backs the ETag on the byte URL.",
+            type = "integer", format = "int64", example = "1787727367630")
     private Date lastModified;
 
     public String getId() {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/TopologyAssetRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/TopologyAssetRestService.java
@@ -51,6 +51,14 @@ import org.springframework.stereotype.Component;
 
 import com.google.common.collect.ImmutableMap;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 /**
@@ -81,12 +89,50 @@ public class TopologyAssetRestService {
 
     static final String[] ALLOWED_MIME_TYPES = {"image/png", "image/jpeg", "image/gif", "image/webp"};
 
+    private static final String ASSET_ID_DESC =
+            "The asset's generated id, as returned by the upload or the listing (a UUID on this build).";
+
+    private static final String ASSET_STORE_UNAVAILABLE =
+            "The asset store bean is not present in this deployment, so no asset operation can be served.";
+
     @Autowired(required = false)
     private TopologyAssetDao m_dao;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public List<TopologyAssetDTO> list(@QueryParam("kind") final String kind) {
+    @Operation(summary = "List topology image assets",
+            description = """
+        Metadata for every stored asset, newest-first order not guaranteed. The image bytes are not
+        included; fetch them one at a time from `/topology/assets/{id}`. `created` and `lastModified`
+        are epoch milliseconds.""",
+            operationId = "listTopologyAssets")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Asset metadata, empty when nothing matches.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            array = @io.swagger.v3.oas.annotations.media.ArraySchema(schema = @Schema(implementation = TopologyAssetDTO.class)),
+                            examples = @ExampleObject(value = """
+                    [
+                      {
+                        "id": "defb7a91-9287-459a-ba1d-6879fee1cbfd",
+                        "name": "rack-elevation",
+                        "kind": "background",
+                        "mimeType": "image/png",
+                        "sizeBytes": 36667,
+                        "owner": "admin",
+                        "created": 1787727367630,
+                        "lastModified": 1787727367630
+                      }
+                    ]"""))),
+            @ApiResponse(responseCode = "503", description = ASSET_STORE_UNAVAILABLE,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "The topology asset store is not available")))
+    })
+    public List<TopologyAssetDTO> list(@Parameter(description = """
+                    Restrict the listing to one kind. An unrecognised value is not an error: it simply
+                    matches nothing and yields an empty array.""",
+                    example = "icon",
+                    schema = @Schema(allowableValues = {"background", "icon"}))
+                                       @QueryParam("kind") final String kind) {
         return getDao().findAll().stream()
                 .filter(asset -> kind == null || kind.equals(asset.getKind()))
                 .map(TopologyAssetRestService::toDto)
@@ -96,10 +142,61 @@ public class TopologyAssetRestService {
     @POST
     @Consumes({"image/png", "image/jpeg", "image/gif", "image/webp"})
     @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Upload a topology image asset",
+            description = """
+        The request body is the raw image, not a multipart form, and the `Content-Type` header is what
+        records the stored MIME type. `name` and `kind` travel as query parameters.
+
+        Size caps are per kind: 10485760 bytes for a `background`, 524288 for an `icon`. Only
+        `image/png`, `image/jpeg`, `image/gif` and `image/webp` are accepted; `image/svg+xml` is
+        rejected at the media-type layer. The `owner` recorded on the asset is the authenticated
+        principal.
+
+        Names carry no uniqueness constraint: uploading the same name twice stores two assets with
+        different ids.
+        The 201 carries a `Location` header pointing at the new asset's byte URL.""",
+            operationId = "uploadTopologyAsset")
+    @RequestBody(required = true, description = "The raw image bytes.",
+            content = {
+                    @Content(mediaType = "image/png", schema = @Schema(type = "string", format = "binary")),
+                    @Content(mediaType = "image/jpeg", schema = @Schema(type = "string", format = "binary")),
+                    @Content(mediaType = "image/gif", schema = @Schema(type = "string", format = "binary")),
+                    @Content(mediaType = "image/webp", schema = @Schema(type = "string", format = "binary"))
+            })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Asset stored. `Location` holds its byte URL.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = TopologyAssetDTO.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "id": "defb7a91-9287-459a-ba1d-6879fee1cbfd",
+                      "name": "core-switch",
+                      "kind": "icon",
+                      "mimeType": "image/png",
+                      "sizeBytes": 67,
+                      "owner": "admin",
+                      "created": 1787727367630,
+                      "lastModified": 1787727367630
+                    }"""))),
+            @ApiResponse(responseCode = "400", description = "`name` is missing or blank, `kind` is missing or unrecognised, or the body is empty.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "An asset kind is required (?kind=): one of [background, icon]"))),
+            @ApiResponse(responseCode = "413", description = "The body exceeds the cap for this kind.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "A icon asset may be at most 524288 bytes"))),
+            @ApiResponse(responseCode = "415", description = "The `Content-Type` is absent or is not one of the four accepted image types."),
+            @ApiResponse(responseCode = "503", description = ASSET_STORE_UNAVAILABLE,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "The topology asset store is not available")))
+    })
     public Response upload(@Context final UriInfo uriInfo,
                            @Context final SecurityContext securityContext,
                            @Context final javax.ws.rs.core.HttpHeaders headers,
+                           @Parameter(description = "Display name for the asset. Trimmed; must not be blank.",
+                                   required = true, example = "core-switch")
                            @QueryParam("name") final String name,
+                           @Parameter(description = "Which cap and role the asset takes on.", required = true,
+                                   example = "icon", schema = @Schema(allowableValues = {"background", "icon"}))
                            @QueryParam("kind") final String kind,
                            final byte[] bytes) {
         if (name == null || name.trim().isEmpty()) {
@@ -146,7 +243,26 @@ public class TopologyAssetRestService {
      */
     @GET
     @Path("{id}")
-    public Response getBytes(@Context final Request request, @PathParam("id") final String id) {
+    @Operation(summary = "Get a topology asset's image bytes",
+            description = """
+        Serves the stored bytes under the asset's own `Content-Type`, with `Cache-Control: max-age=3600`
+        and an `ETag` derived from the asset's last-modified time. A conditional request carrying a
+        matching `If-None-Match` answers 304 with no body.""",
+            operationId = "getTopologyAssetBytes")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The image, under its stored MIME type.",
+                    content = @Content(mediaType = "image/png", schema = @Schema(type = "string", format = "binary"))),
+            @ApiResponse(responseCode = "304", description = "`If-None-Match` matched the current ETag."),
+            @ApiResponse(responseCode = "404", description = "No such asset, or the metadata row has no bytes behind it.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "No asset with id \'defb7a91-9287-459a-ba1d-6879fee1cbfd\'"))),
+            @ApiResponse(responseCode = "503", description = ASSET_STORE_UNAVAILABLE,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
+    public Response getBytes(@Context final Request request,
+                             @Parameter(description = ASSET_ID_DESC, required = true,
+                                     example = "defb7a91-9287-459a-ba1d-6879fee1cbfd")
+                             @PathParam("id") final String id) {
         final TopologyAsset asset = require(id);
         final EntityTag etag = new EntityTag(String.valueOf(asset.getLastModified() == null ? 0L : asset.getLastModified().getTime()));
 
@@ -171,13 +287,54 @@ public class TopologyAssetRestService {
     @GET
     @Path("{id}/meta")
     @Produces(MediaType.APPLICATION_JSON)
-    public TopologyAssetDTO getMeta(@PathParam("id") final String id) {
+    @Operation(summary = "Get a topology asset's metadata",
+            description = "One asset's metadata without transferring the image. `created` and `lastModified` are epoch milliseconds.",
+            operationId = "getTopologyAssetMeta")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The asset's metadata.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = TopologyAssetDTO.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "id": "defb7a91-9287-459a-ba1d-6879fee1cbfd",
+                      "name": "core-switch",
+                      "kind": "icon",
+                      "mimeType": "image/png",
+                      "sizeBytes": 67,
+                      "owner": "admin",
+                      "created": 1787727367630,
+                      "lastModified": 1787727367630
+                    }"""))),
+            @ApiResponse(responseCode = "404", description = "No asset with that id.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "No asset with id \'defb7a91-9287-459a-ba1d-6879fee1cbfd\'"))),
+            @ApiResponse(responseCode = "503", description = ASSET_STORE_UNAVAILABLE,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
+    public TopologyAssetDTO getMeta(@Parameter(description = ASSET_ID_DESC, required = true,
+                                            example = "defb7a91-9287-459a-ba1d-6879fee1cbfd")
+                                    @PathParam("id") final String id) {
         return toDto(require(id));
     }
 
     @DELETE
     @Path("{id}")
-    public Response delete(@PathParam("id") final String id) {
+    @Operation(summary = "Delete a topology asset",
+            description = """
+        Removes the metadata and the bytes together. Views that referenced the asset are not rewritten,
+        so a background or icon reference can be left dangling.""",
+            operationId = "deleteTopologyAsset")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Asset deleted."),
+            @ApiResponse(responseCode = "404", description = "No asset with that id.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "No asset with id \'defb7a91-9287-459a-ba1d-6879fee1cbfd\'"))),
+            @ApiResponse(responseCode = "503", description = ASSET_STORE_UNAVAILABLE,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
+    public Response delete(@Parameter(description = ASSET_ID_DESC, required = true,
+                                   example = "defb7a91-9287-459a-ba1d-6879fee1cbfd")
+                           @PathParam("id") final String id) {
         if (!getDao().delete(id)) {
             throw webException(Response.Status.NOT_FOUND, "No asset with id '" + id + "'");
         }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/TopologyAssetRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/TopologyAssetRestService.java
@@ -93,7 +93,7 @@ public class TopologyAssetRestService {
             "The asset's generated id, as returned by the upload or the listing (a UUID on this build).";
 
     private static final String ASSET_STORE_UNAVAILABLE =
-            "The asset store bean is not present in this deployment, so no asset operation can be served.";
+            "The asset store bean is not present in this deployment.";
 
     @Autowired(required = false)
     private TopologyAssetDao m_dao;
@@ -102,9 +102,8 @@ public class TopologyAssetRestService {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "List topology image assets",
             description = """
-        Metadata for every stored asset, newest-first order not guaranteed. The image bytes are not
-        included; fetch them one at a time from `/topology/assets/{id}`. `created` and `lastModified`
-        are epoch milliseconds.""",
+        Metadata for every stored asset. The image bytes are not included; they are served from
+        `/topology/assets/{id}`. `created` and `lastModified` are epoch milliseconds.""",
             operationId = "listTopologyAssets")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Asset metadata, empty when nothing matches.",
@@ -128,8 +127,8 @@ public class TopologyAssetRestService {
                             examples = @ExampleObject(value = "The topology asset store is not available")))
     })
     public List<TopologyAssetDTO> list(@Parameter(description = """
-                    Restrict the listing to one kind. An unrecognised value is not an error: it simply
-                    matches nothing and yields an empty array.""",
+                    Restrict the listing to one kind. An unrecognised value matches nothing and
+                    yields an empty array.""",
                     example = "icon",
                     schema = @Schema(allowableValues = {"background", "icon"}))
                                        @QueryParam("kind") final String kind) {
@@ -144,8 +143,8 @@ public class TopologyAssetRestService {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Upload a topology image asset",
             description = """
-        The request body is the raw image, not a multipart form, and the `Content-Type` header is what
-        records the stored MIME type. `name` and `kind` travel as query parameters.
+        The request body is the raw image, not a multipart form; the `Content-Type` header records the
+        stored MIME type. `name` and `kind` travel as query parameters.
 
         Size caps are per kind: 10485760 bytes for a `background`, 524288 for an `icon`. Only
         `image/png`, `image/jpeg`, `image/gif` and `image/webp` are accepted; `image/svg+xml` is

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/TopologyViewDTO.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/TopologyViewDTO.java
@@ -26,6 +26,8 @@ import java.util.Date;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.annotate.JsonProperty;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * Wire representation of a custom topology view.
  *
@@ -37,21 +39,46 @@ import org.codehaus.jackson.annotate.JsonProperty;
  */
 public class TopologyViewDTO {
 
+    @Schema(description = "Server-generated identifier, a UUID on this build. Ignored on input.",
+            example = "1e3df566-9268-4ab2-92d0-2c6877fde67d")
     @JsonProperty("id")
     private String id;
 
+    @Schema(description = """
+            Display name, trimmed. Required on create and unique across views; a colliding create or
+            rename is refused with 409.""",
+            required = true, example = "Core and distribution")
     @JsonProperty("name")
     private String name;
 
+    @Schema(description = """
+            The canvas, as free-form JSON. The server stores it verbatim as a string and does not
+            validate its shape, so the keys are whatever the client that wrote the view used. Required
+            on create; omitted on update it leaves the stored definition alone.""",
+            required = true, type = "object")
     @JsonProperty("definition")
     private JsonNode definition;
 
+    @Schema(description = """
+            Authenticated principal that created the view. Set by the server from the request's
+            principal; a value sent in the body is ignored.""",
+            example = "admin", accessMode = Schema.AccessMode.READ_ONLY)
     @JsonProperty("owner")
     private String owner;
 
+    // Serialized as epoch milliseconds, not as the date-time string the
+    // auto-derived schema for a Date would claim.
+    @Schema(description = "Creation time, epoch milliseconds. Set by the server.",
+            type = "integer", format = "int64", example = "1787727339697",
+            accessMode = Schema.AccessMode.READ_ONLY)
     @JsonProperty("created")
     private Date created;
 
+    @Schema(description = """
+            Time of the last update, epoch milliseconds. Null until the view has been updated at least
+            once. Set by the server.""",
+            type = "integer", format = "int64", example = "1787727349607", nullable = true,
+            accessMode = Schema.AccessMode.READ_ONLY)
     @JsonProperty("lastModified")
     private Date lastModified;
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/TopologyViewDTO.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/TopologyViewDTO.java
@@ -46,8 +46,8 @@ public class TopologyViewDTO {
 
     @Schema(description = """
             Display name, trimmed. Required on create and unique across views; a colliding create or
-            rename is refused with 409.""",
-            required = true, example = "Core and distribution")
+            rename is refused with 409. Optional on update.""",
+            example = "Core and distribution")
     @JsonProperty("name")
     private String name;
 
@@ -55,7 +55,7 @@ public class TopologyViewDTO {
             The canvas, as free-form JSON. The server stores it verbatim as a string and does not
             validate its shape. Required on create; omitted on update it leaves the stored definition
             alone.""",
-            required = true, type = "object")
+            type = "object")
     @JsonProperty("definition")
     private JsonNode definition;
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/TopologyViewDTO.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/TopologyViewDTO.java
@@ -53,8 +53,8 @@ public class TopologyViewDTO {
 
     @Schema(description = """
             The canvas, as free-form JSON. The server stores it verbatim as a string and does not
-            validate its shape, so the keys are whatever the client that wrote the view used. Required
-            on create; omitted on update it leaves the stored definition alone.""",
+            validate its shape. Required on create; omitted on update it leaves the stored definition
+            alone.""",
             required = true, type = "object")
     @JsonProperty("definition")
     private JsonNode definition;

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/TopologyViewRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/TopologyViewRestService.java
@@ -49,6 +49,15 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 /**
@@ -77,12 +86,51 @@ public class TopologyViewRestService {
     /** Serializes the name-uniqueness check-then-write; see {@link #create}. */
     private static final Object WRITE_LOCK = new Object();
 
+    private static final String VIEW_ID_DESC =
+            "The view's generated id, as returned by the listing or the create's Location header (a UUID on this build).";
+
+    private static final String VIEW_STORE_UNAVAILABLE =
+            "The topology view store bean is not present in this deployment, so no view operation can be served.";
+
+    private static final String VIEW_EXAMPLE = """
+            {
+              "id": "1e3df566-9268-4ab2-92d0-2c6877fde67d",
+              "name": "Core and distribution",
+              "definition": {
+                "nodes": [
+                  {"id": "placed-1011", "nodeId": 1011, "label": "scale-dist-001", "x": 120.0, "y": 80.0, "color": "#1f5fb0"}
+                ],
+                "links": [
+                  {"id": "link-1", "sourceId": "placed-1011", "targetId": "placed-1001", "origin": "user"}
+                ],
+                "viewport": {"zoom": 1.0, "x": 0, "y": 0}
+              },
+              "owner": "admin",
+              "created": 1787727339697,
+              "lastModified": 1787727349607
+            }""";
+
     @Autowired(required = false)
     private TopologyViewDao m_dao;
 
     private final ObjectMapper m_mapper = new ObjectMapper();
 
     @GET
+    @Operation(summary = "List custom topology views",
+            description = """
+        Every view in the shared catalog, with its full `definition` inlined. The catalog is shared
+        rather than per-user, so this returns views other users created as well. A stored definition
+        that is no longer parseable as JSON comes back as `null` rather than failing the listing.""",
+            operationId = "listTopologyViews")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "All views, empty when the catalog is empty.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            array = @ArraySchema(schema = @Schema(implementation = TopologyViewDTO.class)),
+                            examples = @ExampleObject(value = "[" + VIEW_EXAMPLE + "]"))),
+            @ApiResponse(responseCode = "503", description = VIEW_STORE_UNAVAILABLE,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Topology view persistence is not available")))
+    })
     public List<TopologyViewDTO> list() {
         final List<TopologyView> views = getDao().findAll();
         final List<TopologyViewDTO> dtos = new ArrayList<>(views.size());
@@ -94,11 +142,65 @@ public class TopologyViewRestService {
 
     @GET
     @Path("{id}")
-    public TopologyViewDTO get(@PathParam("id") final String id) {
+    @Operation(summary = "Get one custom topology view", description = "One view by id, with its `definition` inlined.",
+            operationId = "getTopologyView")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The view.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = TopologyViewDTO.class),
+                            examples = @ExampleObject(value = VIEW_EXAMPLE))),
+            @ApiResponse(responseCode = "404", description = "No view with that id.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "No topology view with id 1e3df566-9268-4ab2-92d0-2c6877fde67d"))),
+            @ApiResponse(responseCode = "503", description = VIEW_STORE_UNAVAILABLE,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
+    public TopologyViewDTO get(@Parameter(description = VIEW_ID_DESC, required = true,
+                                       example = "1e3df566-9268-4ab2-92d0-2c6877fde67d")
+                               @PathParam("id") final String id) {
         return toDto(require(id));
     }
 
     @POST
+    @Operation(summary = "Create a custom topology view",
+            description = """
+        `name` and `definition` are both required. The name has to be free: a collision is refused with
+        409 rather than merged. `owner` is taken from the authenticated principal and `created` from the
+        server clock, so values sent for either are ignored.
+
+        The 201 has no body. Its `Location` header carries the new view's URL; read the view back from
+        there if the client needs the generated id.""",
+            operationId = "createTopologyView")
+    @RequestBody(required = true, description = "The view to create. Only `name` and `definition` are read.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = TopologyViewDTO.class),
+                    examples = @ExampleObject(value = """
+                    {
+                      "name": "Core and distribution",
+                      "definition": {
+                        "nodes": [
+                          {"id": "placed-1011", "nodeId": 1011, "label": "scale-dist-001", "x": 120.0, "y": 80.0}
+                        ],
+                        "links": [
+                          {"id": "link-1", "sourceId": "placed-1011", "targetId": "placed-1001", "origin": "user"}
+                        ],
+                        "viewport": {"zoom": 1.0, "x": 0, "y": 0}
+                      }
+                    }""")))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "View created. `Location` holds its URL; no body is returned."),
+            @ApiResponse(responseCode = "400", description = "The body is absent, `name` is missing or blank, or `definition` is missing.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "A view definition is required"))),
+            @ApiResponse(responseCode = "401", description = "The request carries no authenticated principal, so no owner can be recorded.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "An authenticated user is required"))),
+            @ApiResponse(responseCode = "409", description = "A view already holds that name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "A view named \'Core and distribution\' already exists"))),
+            @ApiResponse(responseCode = "503", description = VIEW_STORE_UNAVAILABLE,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
     public Response create(@Context final UriInfo uriInfo, @Context final SecurityContext securityContext, final TopologyViewDTO dto) {
         if (dto == null || dto.getName() == null || dto.getName().trim().isEmpty()) {
             throw webException(Response.Status.BAD_REQUEST, "A view name is required");
@@ -128,7 +230,38 @@ public class TopologyViewRestService {
 
     @PUT
     @Path("{id}")
-    public Response update(@PathParam("id") final String id, final TopologyViewDTO dto) {
+    @Operation(summary = "Update a custom topology view",
+            description = """
+        A partial update rather than a full replacement: a null or blank `name` leaves the name alone,
+        and an absent `definition` leaves the stored canvas alone. `lastModified` is refreshed on every
+        call, whether or not anything else changed. Renaming onto a name another view holds is refused
+        with 409.""",
+            operationId = "updateTopologyView")
+    @RequestBody(required = true, description = "The fields to change. Only `name` and `definition` are read.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = TopologyViewDTO.class),
+                    examples = @ExampleObject(value = """
+                    {
+                      "name": "Core and distribution",
+                      "definition": {"nodes": [], "links": [], "viewport": {"zoom": 1.0, "x": 0, "y": 0}}
+                    }""")))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "View updated. No body is returned."),
+            @ApiResponse(responseCode = "400", description = "The body is absent.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "A view body is required"))),
+            @ApiResponse(responseCode = "404", description = "No view with that id.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "No topology view with id 1e3df566-9268-4ab2-92d0-2c6877fde67d"))),
+            @ApiResponse(responseCode = "409", description = "Another view already holds the requested name.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "A view named \'Core and distribution\' already exists"))),
+            @ApiResponse(responseCode = "503", description = VIEW_STORE_UNAVAILABLE,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
+    public Response update(@Parameter(description = VIEW_ID_DESC, required = true,
+                                   example = "1e3df566-9268-4ab2-92d0-2c6877fde67d")
+                           @PathParam("id") final String id, final TopologyViewDTO dto) {
         final TopologyView view = require(id);
         if (dto == null) {
             throw webException(Response.Status.BAD_REQUEST, "A view body is required");
@@ -159,7 +292,20 @@ public class TopologyViewRestService {
 
     @DELETE
     @Path("{id}")
-    public Response delete(@PathParam("id") final String id) {
+    @Operation(summary = "Delete a custom topology view",
+            description = "Removes the view from the shared catalog. Any image assets it referenced are left in place.",
+            operationId = "deleteTopologyView")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "View deleted."),
+            @ApiResponse(responseCode = "404", description = "No view with that id.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "No topology view with id 1e3df566-9268-4ab2-92d0-2c6877fde67d"))),
+            @ApiResponse(responseCode = "503", description = VIEW_STORE_UNAVAILABLE,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
+    })
+    public Response delete(@Parameter(description = VIEW_ID_DESC, required = true,
+                                   example = "1e3df566-9268-4ab2-92d0-2c6877fde67d")
+                           @PathParam("id") final String id) {
         getDao().delete(require(id));
         return Response.noContent().build();
     }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/TopologyViewRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/TopologyViewRestService.java
@@ -90,7 +90,7 @@ public class TopologyViewRestService {
             "The view's generated id, as returned by the listing or the create's Location header (a UUID on this build).";
 
     private static final String VIEW_STORE_UNAVAILABLE =
-            "The topology view store bean is not present in this deployment, so no view operation can be served.";
+            "The topology view store bean is not present in this deployment.";
 
     private static final String VIEW_EXAMPLE = """
             {
@@ -118,9 +118,9 @@ public class TopologyViewRestService {
     @GET
     @Operation(summary = "List custom topology views",
             description = """
-        Every view in the shared catalog, with its full `definition` inlined. The catalog is shared
-        rather than per-user, so this returns views other users created as well. A stored definition
-        that is no longer parseable as JSON comes back as `null` rather than failing the listing.""",
+        Every view in the shared catalog, with its full `definition` inlined. The catalog is shared,
+        so views other users created are included. A stored definition that is no longer parseable as
+        JSON comes back as `null` rather than failing the listing.""",
             operationId = "listTopologyViews")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "All views, empty when the catalog is empty.",
@@ -164,12 +164,11 @@ public class TopologyViewRestService {
     @POST
     @Operation(summary = "Create a custom topology view",
             description = """
-        `name` and `definition` are both required. The name has to be free: a collision is refused with
-        409 rather than merged. `owner` is taken from the authenticated principal and `created` from the
-        server clock, so values sent for either are ignored.
+        `name` and `definition` are both required. A name collision is refused with 409 rather than
+        merged. `owner` is taken from the authenticated principal and `created` from the server clock,
+        so values sent for either are ignored.
 
-        The 201 has no body. Its `Location` header carries the new view's URL; read the view back from
-        there if the client needs the generated id.""",
+        The 201 has no body; its `Location` header carries the new view's URL.""",
             operationId = "createTopologyView")
     @RequestBody(required = true, description = "The view to create. Only `name` and `definition` are read.",
             content = @Content(mediaType = MediaType.APPLICATION_JSON,

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/UserDefinedLinkRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/UserDefinedLinkRestService.java
@@ -367,7 +367,7 @@ public class UserDefinedLinkRestService extends AbstractDaoRestService<UserDefin
     @Override
     @Operation(summary = "Update the user-defined links matching a query",
             description = """
-                    Sets the same named properties on every link matching the query. At most `limit` entities are affected, so this touches ten entities per call unless a larger `limit` is given.
+                    Sets the same named properties on every link matching the query. At most `limit` entities are affected, ten by default.
 
                     For example, `_s=owner==review-seed`.""",
             operationId = "userDefinedLinksUpdateMany")
@@ -448,7 +448,7 @@ public class UserDefinedLinkRestService extends AbstractDaoRestService<UserDefin
     @Override
     @Operation(summary = "Delete the user-defined links matching a query",
             description = """
-                    Deletes every user-defined link matching the query. At most `limit` entities are affected, so this touches ten entities per call unless a larger `limit` is given.
+                    Deletes every user-defined link matching the query. At most `limit` entities are affected, ten by default.
 
                     For example, `_s=owner==review-seed`.""",
             operationId = "userDefinedLinksDeleteMany")

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/UserDefinedLinkRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/UserDefinedLinkRestService.java
@@ -48,6 +48,21 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.apache.cxf.jaxrs.ext.search.SearchContext;
+import org.opennms.web.rest.support.SearchPropertyCollection;
+import org.opennms.web.rest.support.StringCollection;
 
 @Component
 @Path("userdefinedlinks")
@@ -133,4 +148,336 @@ public class UserDefinedLinkRestService extends AbstractDaoRestService<UserDefin
 
     }
 
+    @Override
+    @Operation(summary = "List user-defined links",
+            description = """
+                    User-defined links matching the query. These are topology links entered by an operator rather than discovered by enlinkd, and each one names its two endpoints by node identifier.
+
+                    This endpoint declares no search properties, so `_s` and `orderBy` fall back to the bean property names of `UserDefinedLink`: `dbId`, `linkId`, `linkLabel`, `owner`, `nodeIdA`, `nodeIdZ`, `componentLabelA` and `componentLabelZ`. Using `id` there fails to parse.
+
+                    `application/atom+xml` is also accepted and returns the same document as `application/xml`.
+
+                    For example, `_s=owner==review-seed`.""",
+            operationId = "userDefinedLinksList")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "One page of matching user-defined links.",
+                    headers = @Header(name = "Content-Range", description = "`items <offset>-<last>/<totalCount>` for this page.",
+                            schema = @Schema(type = "string")),
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = UserDefinedLinkRestService.UserDefinedLinkCollection.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "totalCount": 8,
+                              "count": 1,
+                              "offset": 0,
+                              "user_defined_link": [ {
+                                "db-id": 5,
+                                "owner": "review-seed",
+                                "link-id": "udl-13",
+                                "link-label": "cross-connect 13",
+                                "node-id-a": 13,
+                                "component-label-a": "Gi1/1",
+                                "node-id-z": 24,
+                                "component-label-z": "Gi1/2"
+                              } ]
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = UserDefinedLinkRestService.UserDefinedLinkCollection.class),
+                                    examples = @ExampleObject(value = """
+                            <user_defined_links count="1" offset="0" totalCount="8">
+                              <user_defined_link>
+                                <node-id-a>13</node-id-a>
+                                <component-label-a>Gi1/1</component-label-a>
+                                <node-id-z>24</node-id-z>
+                                <component-label-z>Gi1/2</component-label-z>
+                                <link-id>udl-13</link-id>
+                                <link-label>cross-connect 13</link-label>
+                                <owner>review-seed</owner>
+                                <db-id>5</db-id>
+                              </user_defined_link>
+                            </user_defined_links>"""))
+                    }),
+            @ApiResponse(responseCode = "204", description = "No user-defined link matched the query. The response has no body."),
+            @ApiResponse(responseCode = "500", description = DOC_SEARCH_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    public Response get(final UriInfo uriInfo, final SearchContext searchContext) {
+        return super.get(uriInfo, searchContext);
+    }
+
+    @Override
+    @Operation(summary = "Count user-defined links",
+            description = """
+                    Number of user-defined links matching the query.
+
+                    Only `text/plain` is produced. A request that sends `Accept: application/json` does not match this operation and falls through to the single-entity GET with `count` as the identifier.
+
+                    For example, `_s=owner==review-seed`.""",
+            operationId = "userDefinedLinksCount")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The number of matching user-defined links, as a decimal string.",
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "8"))),
+            @ApiResponse(responseCode = "500", description = DOC_COUNT_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    public Response getCount(final UriInfo uriInfo, final SearchContext searchContext) {
+        return super.getCount(uriInfo, searchContext);
+    }
+
+    @Override
+    @Operation(summary = "List the queryable properties of user-defined links",
+            description = """
+                    This endpoint declares no search properties.""",
+            operationId = "userDefinedLinksSearchProperties")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = """
+                    Always: no search properties are declared for user-defined links. The response has no body.""")
+    })
+    public Response getProperties(final String query) {
+        return super.getProperties(query);
+    }
+
+    @Override
+    @Operation(summary = "List the values a queryable property takes",
+            description = """
+                    No search properties are declared for user-defined links, so no property identifier resolves here.""",
+            operationId = "userDefinedLinksSearchPropertyValues")
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = """
+                    Always, for every property identifier. The response has no body.""")
+    })
+    public Response getPropertyValues(final String propertyId, final String query, final Integer limit) {
+        return super.getPropertyValues(propertyId, query, limit);
+    }
+
+    @Override
+    @Operation(summary = "Get one user-defined link",
+            description = """
+                    One user-defined link by database identifier.
+
+                    `application/atom+xml` is also accepted and returns the same document as `application/xml`.""",
+            operationId = "userDefinedLinksGet")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The requested user-defined link.",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = UserDefinedLink.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "db-id": 5,
+                              "owner": "review-seed",
+                              "link-id": "udl-13",
+                              "link-label": "cross-connect 13",
+                              "node-id-a": 13,
+                              "component-label-a": "Gi1/1",
+                              "node-id-z": 24,
+                              "component-label-z": "Gi1/2"
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = UserDefinedLink.class),
+                                    examples = @ExampleObject(value = """
+                            <user-defined-link>
+                              <node-id-a>13</node-id-a>
+                              <component-label-a>Gi1/1</component-label-a>
+                              <node-id-z>24</node-id-z>
+                              <component-label-z>Gi1/2</component-label-z>
+                              <link-id>udl-13</link-id>
+                              <link-label>cross-connect 13</link-label>
+                              <owner>review-seed</owner>
+                              <db-id>5</db-id>
+                            </user-defined-link>"""))
+                    }),
+            @ApiResponse(responseCode = "404", description = """
+                    No link has that identifier, or the identifier is not an integer. The response has no body.""")
+    })
+    public Response get(final UriInfo uriInfo,
+            @Parameter(description = """
+                    Database identifier of the link, reported as `db-id` in the entity itself.""",
+                    required = true, example = "5")
+            final Integer id) {
+        return super.get(uriInfo, id);
+    }
+
+    @Override
+    @Operation(summary = "Create a user-defined link",
+            description = """
+                    Creates a user-defined link and refreshes the topology. The identifier is assigned by the database and returned in the `Location` header.""",
+            operationId = "userDefinedLinksCreate")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = """
+                    The link was created. The response has no body.""",
+                    headers = @Header(name = "Location", description = "URI of the created user-defined link.",
+                            schema = @Schema(type = "string"))),
+            @ApiResponse(responseCode = "400", description = """
+                    The body deserialised to nothing, which a literal JSON `null` does. The body is a `text/plain` message.""",
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = """
+                            Link cannot be null"""))),
+            @ApiResponse(responseCode = "500", description = """
+                    The request carried no body at all, or the body left a not-null column unset. The body is a `text/plain` message.""",
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = """
+                            No content to map to Object due to end of input""")))
+    })
+    public Response create(final SecurityContext securityContext, final UriInfo uriInfo,
+            @RequestBody(description = """
+                    The link to create. `node-id-a`, `node-id-z`, `link-id` and `owner` are required by the schema; the component labels and `link-label` are optional. In JSON and XML alike the members carry their hyphenated names.""",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = UserDefinedLink.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "owner": "review-seed",
+                              "link-id": "udl-99",
+                              "link-label": "cross-connect 99",
+                              "node-id-a": 13,
+                              "component-label-a": "Gi1/1",
+                              "node-id-z": 24,
+                              "component-label-z": "Gi1/2"
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = UserDefinedLink.class),
+                                    examples = @ExampleObject(value = """
+                            <user-defined-link>
+                              <node-id-a>13</node-id-a>
+                              <node-id-z>24</node-id-z>
+                              <link-id>udl-99</link-id>
+                              <link-label>cross-connect 99</link-label>
+                              <owner>review-seed</owner>
+                            </user-defined-link>"""))
+                    })
+            final UserDefinedLink object) {
+        return super.create(securityContext, uriInfo, object);
+    }
+
+    @Override
+    @Operation(summary = "Rejected: create a user-defined link at a caller-chosen identifier",
+            description = DOC_POST_WITH_ID,
+            operationId = "userDefinedLinksCreateWithId")
+    @Parameters({
+            @Parameter(name = "id", in = ParameterIn.PATH, required = true,
+                    description = "Ignored. Any value produces the same response.",
+                    schema = @Schema(type = "string"), example = "5")
+    })
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", description = "Always. The response has no body.")
+    })
+    public Response createSpecific() {
+        return super.createSpecific();
+    }
+
+    @Override
+    @Operation(summary = "Update the user-defined links matching a query",
+            description = """
+                    Sets the same named properties on every link matching the query. At most `limit` entities are affected, so this touches ten entities per call unless a larger `limit` is given.
+
+                    For example, `_s=owner==review-seed`.""",
+            operationId = "userDefinedLinksUpdateMany")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = """
+                    Every matching link was updated. The response has no body."""),
+            @ApiResponse(responseCode = "404", description = DOC_NO_MATCH),
+            @ApiResponse(responseCode = "500", description = DOC_SEARCH_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    public Response updateMany(final SecurityContext securityContext, final UriInfo uriInfo, final SearchContext searchContext,
+            @RequestBody(description = DOC_FORM_BODY,
+                    content = @Content(mediaType = "application/x-www-form-urlencoded",
+                            schema = @Schema(type = "object"),
+                            examples = @ExampleObject(value = """
+                            link-label=cross-connect+13&component-label-a=Gi1%2F1""")))
+            final MultivaluedMapImpl params) {
+        return super.updateMany(securityContext, uriInfo, searchContext, params);
+    }
+
+    @Override
+    @Hidden
+    public Response update(final SecurityContext securityContext, final UriInfo uriInfo, final Integer id,
+            final UserDefinedLink object) {
+        return super.update(securityContext, uriInfo, id, object);
+    }
+
+    @Override
+    @Operation(summary = "Update one user-defined link",
+            description = """
+                    Sets named properties on one link and refreshes the topology. Only the form-parameter form is implemented; a JSON or XML body reaches the replacement handler, which answers 501.""",
+            operationId = "userDefinedLinksUpdate")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = """
+                    The named properties were applied, or were all ignored. The response has no body, and an ignored parameter is not reported."""),
+            @ApiResponse(responseCode = "404", description = """
+                    No link has that identifier. The response has no body."""),
+            @ApiResponse(responseCode = "501", description = """
+                    Reached only by a JSON or XML body: wholesale replacement is not implemented here. The response has no body.""")
+    })
+    public Response updateProperties(final SecurityContext securityContext, final UriInfo uriInfo,
+            @Parameter(description = """
+                    Database identifier of the link, reported as `db-id` in the entity itself.""",
+                    required = true, example = "5")
+            final Integer id,
+            @RequestBody(description = """
+                    Form parameters name the properties to set. A JSON or XML body is accepted by the router but answered with 501.""",
+                    content = {
+                            @Content(mediaType = "application/json", schema = @Schema(implementation = UserDefinedLink.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "db-id": 5,
+                              "owner": "review-seed",
+                              "link-id": "udl-13",
+                              "link-label": "cross-connect 13",
+                              "node-id-a": 13,
+                              "node-id-z": 24
+                            }""")),
+                            @Content(mediaType = "application/xml", schema = @Schema(implementation = UserDefinedLink.class),
+                                    examples = @ExampleObject(value = """
+                            <user-defined-link>
+                              <node-id-a>13</node-id-a>
+                              <node-id-z>24</node-id-z>
+                              <link-id>udl-13</link-id>
+                              <link-label>cross-connect 13</link-label>
+                              <owner>review-seed</owner>
+                            </user-defined-link>""")),
+                            @Content(mediaType = "application/x-www-form-urlencoded",
+                                    schema = @Schema(type = "object"),
+                                    examples = @ExampleObject(value = """
+                            link-label=cross-connect+13&component-label-a=Gi1%2F1"""))
+                    })
+            final MultivaluedMapImpl params) {
+        return super.updateProperties(securityContext, uriInfo, id, params);
+    }
+
+    @Override
+    @Operation(summary = "Delete the user-defined links matching a query",
+            description = """
+                    Deletes every user-defined link matching the query. At most `limit` entities are affected, so this touches ten entities per call unless a larger `limit` is given.
+
+                    For example, `_s=owner==review-seed`.""",
+            operationId = "userDefinedLinksDeleteMany")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Every matching user-defined link was deleted. The response has no body."),
+            @ApiResponse(responseCode = "404", description = DOC_NO_MATCH),
+            @ApiResponse(responseCode = "500", description = DOC_SEARCH_ERROR,
+                    content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error parsing FIQL search")))
+    })
+    public Response deleteMany(final SecurityContext securityContext, final UriInfo uriInfo, final SearchContext searchContext) {
+        return super.deleteMany(securityContext, uriInfo, searchContext);
+    }
+
+    @Override
+    @Operation(summary = "Delete one user-defined link",
+            description = """
+                    Deletes one user-defined link and refreshes the topology.""",
+            operationId = "userDefinedLinksDelete")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "The user-defined link was deleted. The response has no body."),
+            @ApiResponse(responseCode = "404", description = """
+                    No link has that identifier. The response has no body.""")
+    })
+    public Response delete(final SecurityContext securityContext, final UriInfo uriInfo,
+            @Parameter(description = """
+                    Database identifier of the link, reported as `db-id` in the entity itself.""",
+                    required = true, example = "5")
+            final Integer id) {
+        return super.delete(securityContext, uriInfo, id);
+    }
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/UserDefinedLinkRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/UserDefinedLinkRestService.java
@@ -61,8 +61,6 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.apache.cxf.jaxrs.ext.search.SearchContext;
-import org.opennms.web.rest.support.SearchPropertyCollection;
-import org.opennms.web.rest.support.StringCollection;
 
 @Component
 @Path("userdefinedlinks")

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/DataCollectionConfRestApi.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/DataCollectionConfRestApi.java
@@ -74,13 +74,11 @@ import java.util.List;
         `sourceNames` list is the set of `<include-collection>` entries. Only enabled profiles reach
         collectd, so a source that no enabled profile references is never scheduled.
 
-        Every write schedules a reload of the in-memory data collection config, so changes take effect
-        without a restart.
+        Every write schedules a reload of the in-memory data collection config.
 
-        Two wire-format details apply across the family. `createdTime` and `lastModified` serialize as
-        epoch milliseconds, not as the date-time strings the generated schema shows. Ids that do not
-        exist are usually ignored rather than reported: the bulk delete and the enable/disable endpoints
-        answer 200 for an unknown id.
+        `createdTime` and `lastModified` serialize as epoch milliseconds, not as the date-time strings
+        the generated schema shows. Ids that do not exist are usually ignored rather than reported: the
+        bulk delete and the enable/disable endpoints answer 200 for an unknown id.
 
         `GET /datacollectionconf/config/download` plus one
         `GET /datacollectionconf/collectsources/{id}/download` per source reproduce the on-disk file set,
@@ -169,13 +167,12 @@ public interface DataCollectionConfRestApi {
         How `profileNames` is applied depends on the batch composition:
         - **Pure-new batch** (every source is new): `profileNames` is required; new sources are attached
           to those profiles.
-        - **Pure-update batch** (every source already exists in the DB): `profileNames` is optional.
-          If non-empty, it is applied additively to every source, taken as an explicit "also associate
-          these updates with these profiles" intent.
-        - **Mixed batch** (at least one new and at least one update): `profileNames` is required (for the
-          new sources) and is applied **only to the new sources**. Updates keep their existing profile
-          memberships untouched. To change an existing source's memberships in this case, use the
-          dedicated `/profiles/{profileId}/sources` endpoints.
+        - **Pure-update batch** (every source already exists in the DB): `profileNames` is optional, and
+          when non-empty is applied additively to every source.
+        - **Mixed batch** (at least one new and at least one update): `profileNames` is required for the
+          new sources and is applied **only to the new sources**. Updates keep their existing profile
+          memberships. The `/profiles/{profileId}/sources` endpoints change an existing source's
+          memberships.
         - **`<datacollection-config>` present**: `profileNames` is ignored; the `<include-collection>`
           entries in the config drive attachment, and profiles named by `<snmp-collection>` are created
           or updated.
@@ -947,9 +944,9 @@ public interface DataCollectionConfRestApi {
             summary = "Add a new System Definition to an SnmpCollectionSources",
             description = """
         Create a system definition under the given source, the equivalent of one `<systemDef>` in a
-        `<datacollection-group>`. Supply either `sysoid` for an exact match or `sysoidMask` for a prefix
-        match. `mibGroupNames` is a JSON array carried as a string and names the MIB groups the
-        definition collects. The response body is the new system definition id as a bare integer.""",
+        `<datacollection-group>`. `sysoid` gives an exact match, `sysoidMask` a prefix match.
+        `mibGroupNames` is a JSON array carried as a string and names the MIB groups the definition
+        collects. The response body is the new system definition id as a bare integer.""",
             operationId = "addSystemDefToSnmpCollectionSources")
     @RequestBody(
             required = true,
@@ -1064,9 +1061,8 @@ public interface DataCollectionConfRestApi {
     @Operation(
             summary = "Update a System Definition in an SnmpCollectionSources",
             description = """
-        Replace the fields of an existing system definition. The body is a whole system definition, not a
-        patch: a field left out is written as null, so switching from `sysoid` to `sysoidMask` means
-        sending only the one that should survive. The system definition has to belong to the given
+        Replace the fields of an existing system definition. The body is a whole system definition, not
+        a patch: a field left out is written as null. The system definition has to belong to the given
         source.""",
             operationId = "updateSystemDefInSnmpCollectionSources")
     @RequestBody(
@@ -1108,9 +1104,9 @@ public interface DataCollectionConfRestApi {
             description = """
         Create an empty SNMP data collection source and attach it to one or more existing profiles.
         `name` and at least one entry in `profiles` are both required, every profile name has to already
-        exist, and the source name has to be unused. The source starts with no MIB groups, resource types
-        or system definitions: add those through the `/collectsources/{id}/mibgroups`,
-        `/resourcetypes` and `/systemdefs` endpoints, or upload a `<datacollection-group>` file.
+        exist, and the source name has to be unused. The source starts with no MIB groups, resource
+        types or system definitions; those are added through `/collectsources/{id}/mibgroups`,
+        `/resourcetypes` and `/systemdefs`, or by uploading a `<datacollection-group>` file.
         `vendor` is set to the source name. The response body is the new source id as a bare integer.""",
             operationId = "createSnmpDataCollectionSource"
     )
@@ -1152,7 +1148,7 @@ public interface DataCollectionConfRestApi {
             description = """
         Delete one or more sources and everything under them. Ids that do not exist are ignored, so a
         request naming only unknown ids still answers 200. The source name is left behind in any
-        profile's `sourceNames`, so remove it from the profiles as well if the reference should go.""",
+        profile's `sourceNames`.""",
             operationId = "deleteSnmpDataCollectionSources"
     )
     @ApiResponses(value = {
@@ -1526,8 +1522,8 @@ public interface DataCollectionConfRestApi {
         `sourceNames`. Disabled profiles are omitted, matching what collectd loads. The `rrdRepository`
         attribute is copied from the live in-memory config, and the upload path does not read it back.
 
-        Pair it with `/collectsources/{id}/download` to obtain the matching `<datacollection-group>`
-        files; the whole set is re-uploadable as one multipart batch via `/upload`. Defaults to XML;
+        `/collectsources/{id}/download` returns the matching `<datacollection-group>` files; the whole
+        set is re-uploadable as one multipart batch via `/upload`. Defaults to XML;
         `format=json` returns the same document using the JAXB bean field names. Error responses are
         `<error>` XML regardless of `format`.""",
             operationId = "downloadDatacollectionConfig"

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/DataCollectionConfRestApi.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/DataCollectionConfRestApi.java
@@ -190,13 +190,13 @@ public interface DataCollectionConfRestApi {
                     schema = @Schema(type = "string", format = "binary"))
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Upload processed. Per-file outcomes are split between `success` and `errors`.",
+            @ApiResponse(responseCode = "200", description = "Upload processed. Per-file outcomes are split between `success` and `errors`. For a sources-only upload each success entry carries only `file`, holding the parsed group name rather than the uploaded filename; `profile` appears only on the bulk-config path.",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON,
                             schema = @Schema(implementation = DataCollectionConfUploadResponse.class),
                             examples = @ExampleObject(value = """
                     {
                       "success": [
-                        { "file": "Cisco", "source": "Cisco" },
+                        { "file": "Cisco" },
                         { "file": "datacollection-config", "profile": "default" }
                       ],
                       "errors": [
@@ -416,7 +416,7 @@ public interface DataCollectionConfRestApi {
                             examples = @ExampleObject(value = "{\"error\":\"Unexpected error occurred\"}")))
     })
     Response enableDisableSnmpCollectionProfiles(
-            @Parameter(description = "Target state for every listed profile.", example = "false", required = true)
+            @Parameter(description = "Target state for every listed profile. Declared required, but an omitted value is read as the primitive default `false` and disables the listed profiles.", example = "false", required = true)
             @QueryParam("enabled") boolean enabled,
                                                  List<Integer> ids,
                                                  @Context SecurityContext securityContext);
@@ -505,7 +505,8 @@ public interface DataCollectionConfRestApi {
         - `filter`: case-insensitive substring match on name, vendor and description.
         - `sortBy`: `name`, `vendor`, `description`; anything else falls back to `createdTime`.
         - `order`: `asc` or `desc` (default `desc`).
-        - `limit` is **required** and has to be 1..1000; `offset` defaults to 0 when omitted.
+        - `limit` is **required** and has to be 1..1000; `offset` is effectively required too: omitting it
+          makes the DAO fail internally and the endpoint answers 204 even when rows match.
 
         `createdTime` and `lastModified` come back as epoch milliseconds.""",
             operationId = "filterSnmpCollectionSources"
@@ -560,7 +561,7 @@ public interface DataCollectionConfRestApi {
             description = """
         Page through the MIB groups belonging to one source.
         - `mibGroupFilter`: case-insensitive match on name and ifType.
-        - `sortBy`: `name` or `ifType`; anything else falls back to `createdTime`.
+        - `sortBy`: `name` or `ifType`; anything else falls back to `name`.
         - `order`: `asc` or `desc` (default `desc`).
         - `offset` and `limit` are **both required**: omitting `offset` fails with a 500 rather than
           defaulting to 0. `limit` has to be 1..1000.
@@ -604,8 +605,8 @@ public interface DataCollectionConfRestApi {
             @PathParam("collectionSourceId") Integer collectionSourceId,
             @Parameter(description = "Case-insensitive substring matched against name and ifType.", example = "cisco")
             @QueryParam("mibGroupFilter") String mibGroupFilter,
-            @Parameter(description = "Sort column. An unrecognised value falls back to `createdTime`.",
-                    example = "name", schema = @Schema(allowableValues = {"name", "ifType", "createdTime"}))
+            @Parameter(description = "Sort column. An unrecognised value falls back to `name`.",
+                    example = "name", schema = @Schema(allowableValues = {"name", "ifType"}))
             @QueryParam("sortBy") String sortBy,
             @Parameter(description = "Sort direction.", example = "asc", schema = @Schema(allowableValues = {"asc", "desc"}))
             @QueryParam("order") String order,
@@ -625,7 +626,7 @@ public interface DataCollectionConfRestApi {
             description = """
         Page through the resource types belonging to one source.
         - `resourceTypeFilter`: case-insensitive match on name and label.
-        - `sortBy`: `name` or `label`; anything else falls back to `createdTime`.
+        - `sortBy`: `name` or `label`; anything else falls back to `name`.
         - `order`: `asc` or `desc` (default `desc`).
         - `offset` and `limit` are **both required**: omitting `offset` fails with a 500 rather than
           defaulting to 0. `limit` has to be 1..1000.
@@ -671,8 +672,8 @@ public interface DataCollectionConfRestApi {
             @PathParam("collectionSourceId") Integer collectionSourceId,
             @Parameter(description = "Case-insensitive substring matched against name and label.", example = "cpq")
             @QueryParam("resourceTypeFilter") String resourceTypeFilter,
-            @Parameter(description = "Sort column. An unrecognised value falls back to `createdTime`.",
-                    example = "name", schema = @Schema(allowableValues = {"name", "label", "createdTime"}))
+            @Parameter(description = "Sort column. An unrecognised value falls back to `name`.",
+                    example = "name", schema = @Schema(allowableValues = {"name", "label"}))
             @QueryParam("sortBy") String sortBy,
             @Parameter(description = "Sort direction.", example = "asc", schema = @Schema(allowableValues = {"asc", "desc"}))
             @QueryParam("order") String order,
@@ -693,7 +694,7 @@ public interface DataCollectionConfRestApi {
             description = """
         Page through the system definitions belonging to one source.
         - `systemDefsFilter`: case-insensitive match on name.
-        - `sortBy`: `name`; anything else falls back to `createdTime`.
+        - `sortBy`: `name`; anything else also sorts by `name`.
         - `order`: `asc` or `desc` (default `desc`).
         - `offset` and `limit` are **both required**: omitting `offset` fails with a 500 rather than
           defaulting to 0. `limit` has to be 1..1000.
@@ -738,8 +739,8 @@ public interface DataCollectionConfRestApi {
             @PathParam("collectionSourceId") Integer collectionSourceId,
             @Parameter(description = "Case-insensitive substring matched against name.", example = "Cisco")
             @QueryParam("systemDefsFilter") String systemDefFilter,
-            @Parameter(description = "Sort column. An unrecognised value falls back to `createdTime`.",
-                    example = "name", schema = @Schema(allowableValues = {"name", "createdTime"}))
+            @Parameter(description = "Sort column. An unrecognised value falls back to `name`.",
+                    example = "name", schema = @Schema(allowableValues = {"name"}))
             @QueryParam("sortBy") String sortBy,
             @Parameter(description = "Sort direction.", example = "asc", schema = @Schema(allowableValues = {"asc", "desc"}))
             @QueryParam("order") String order,
@@ -891,7 +892,11 @@ public interface DataCollectionConfRestApi {
             @ApiResponse(responseCode = "404", description = "SnmpCollectionSources not found",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON,
                             schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "SnmpCollectionSource with ID 999999 not found")))})
+                            examples = @ExampleObject(value = "SnmpCollectionSource with ID 999999 not found"))),
+            @ApiResponse(responseCode = "500", description = "Unexpected failure while persisting the change",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Unexpected error occurred\"}")))})
     Response addMibGroupToSnmpCollectionSources(
             @Parameter(description = "Source id the MIB group is created under. Must be a positive integer.", example = "24", required = true)
             @PathParam("collectionSourceId") final Integer collectionSourceId,
@@ -929,7 +934,11 @@ public interface DataCollectionConfRestApi {
             @ApiResponse(responseCode = "404", description = "SnmpCollectionSources not found",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON,
                             schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "SnmpCollectionSource with ID 999999 not found")))})
+                            examples = @ExampleObject(value = "SnmpCollectionSource with ID 999999 not found"))),
+            @ApiResponse(responseCode = "500", description = "Unexpected failure while persisting the change",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Unexpected error occurred\"}")))})
     Response addResourceTypeToSnmpCollectionSources(
             @Parameter(description = "Source id the resource type is created under. Must be a positive integer.", example = "24", required = true)
             @PathParam("collectionSourceId") final Integer collectionSourceId,
@@ -967,7 +976,11 @@ public interface DataCollectionConfRestApi {
             @ApiResponse(responseCode = "404", description = "SnmpCollectionSources not found",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON,
                             schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "SnmpCollectionSource with ID 999999 not found")))})
+                            examples = @ExampleObject(value = "SnmpCollectionSource with ID 999999 not found"))),
+            @ApiResponse(responseCode = "500", description = "Unexpected failure while persisting the change",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Unexpected error occurred\"}")))})
     Response addSystemDefToSnmpCollectionSources(
             @Parameter(description = "Source id the system definition is created under. Must be a positive integer.", example = "24", required = true)
             @PathParam("collectionSourceId") final Integer collectionSourceId,
@@ -1003,7 +1016,11 @@ public interface DataCollectionConfRestApi {
             @ApiResponse(responseCode = "404", description = "SnmpCollectionSources or MibGroup not found",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON,
                             schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "MibGroup was not found: No MibGroup found for collectionSourceId=24, mibGroupId=999999")))
+                            examples = @ExampleObject(value = "MibGroup was not found: No MibGroup found for collectionSourceId=24, mibGroupId=999999"))),
+            @ApiResponse(responseCode = "500", description = "Unexpected failure while persisting the change",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Unexpected error occurred\"}")))
     })
     Response updateMibGroupInSnmpCollectionSources(
             @Parameter(description = "Source id owning the MIB group.", example = "24", required = true)
@@ -1043,7 +1060,11 @@ public interface DataCollectionConfRestApi {
             @ApiResponse(responseCode = "404", description = "SnmpCollectionSources or ResourceType not found",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON,
                             schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "ResourceType was not found: No ResourceType found for collectionSourceId=24, resourceTypeId=999999")))
+                            examples = @ExampleObject(value = "ResourceType was not found: No ResourceType found for collectionSourceId=24, resourceTypeId=999999"))),
+            @ApiResponse(responseCode = "500", description = "Unexpected failure while persisting the change",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Unexpected error occurred\"}")))
     })
     Response updateResourceTypeInSnmpCollectionSources(
             @Parameter(description = "Source id owning the resource type.", example = "24", required = true)
@@ -1084,7 +1105,11 @@ public interface DataCollectionConfRestApi {
             @ApiResponse(responseCode = "404", description = "SnmpCollectionSources or SystemDef not found",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON,
                             schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "SystemDef was not found: No SystemDef found for collectionSourceId=24, systemDefId=999999")))
+                            examples = @ExampleObject(value = "SystemDef was not found: No SystemDef found for collectionSourceId=24, systemDefId=999999"))),
+            @ApiResponse(responseCode = "500", description = "Unexpected failure while persisting the change",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Unexpected error occurred\"}")))
     })
     Response updateSystemDefInSnmpCollectionSources(
             @Parameter(description = "Source id owning the system definition.", example = "24", required = true)
@@ -1304,7 +1329,11 @@ public interface DataCollectionConfRestApi {
             @ApiResponse(responseCode = "400", description = "No `id` parameter supplied, or an id that is not a positive integer",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON,
                             schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "All ids must be non-null positive integers.")))
+                            examples = @ExampleObject(value = "All ids must be non-null positive integers."))),
+            @ApiResponse(responseCode = "500", description = "Unexpected failure while persisting the change",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Unexpected error occurred\"}")))
     })
     Response enableDisableSnmpDataCollectionSources(
             @Parameter(description = "Target state for every listed source.", example = "false", required = true,
@@ -1339,7 +1368,11 @@ public interface DataCollectionConfRestApi {
             @ApiResponse(responseCode = "404", description = "Reported when the update itself raises an entity-not-found; an unknown id on its own answers 200.",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON,
                             schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "Source or one/more ids were not found: ...")))
+                            examples = @ExampleObject(value = "Source or one/more ids were not found: ..."))),
+            @ApiResponse(responseCode = "500", description = "Unexpected failure while persisting the change",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Unexpected error occurred\"}")))
     })
     Response enableDisableSnmpMibGroups(
             @Parameter(description = "Source id owning the MIB groups.", example = "24", required = true)
@@ -1376,7 +1409,11 @@ public interface DataCollectionConfRestApi {
             @ApiResponse(responseCode = "404", description = "Reported when the update itself raises an entity-not-found; an unknown id on its own answers 200.",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON,
                             schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "Source or one/more ids were not found: ...")))
+                            examples = @ExampleObject(value = "Source or one/more ids were not found: ..."))),
+            @ApiResponse(responseCode = "500", description = "Unexpected failure while persisting the change",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Unexpected error occurred\"}")))
     })
     Response enableDisableSnmpResourceTypes(
             @Parameter(description = "Source id owning the resource types.", example = "24", required = true)
@@ -1414,7 +1451,11 @@ public interface DataCollectionConfRestApi {
             @ApiResponse(responseCode = "404", description = "Reported when the update itself raises an entity-not-found; an unknown id on its own answers 200.",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON,
                             schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "Source or one/more ids were not found: ...")))
+                            examples = @ExampleObject(value = "Source or one/more ids were not found: ..."))),
+            @ApiResponse(responseCode = "500", description = "Unexpected failure while persisting the change",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Unexpected error occurred\"}")))
     })
     Response enableDisableSnmpSystemDefs(
             @Parameter(description = "Source id owning the system definitions.", example = "24", required = true)

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/DataCollectionConfRestApi.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/DataCollectionConfRestApi.java
@@ -22,7 +22,12 @@
 package org.opennms.web.rest.v2.api;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -31,8 +36,16 @@ import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 import org.opennms.netmgt.model.SnmpCollectionMibGroupDto;
 import org.opennms.netmgt.model.SnmpCollectionProfileDto;
 import org.opennms.netmgt.model.SnmpCollectionResourceTypeDto;
+import org.opennms.netmgt.model.SnmpCollectionSourceDto;
 import org.opennms.netmgt.model.SnmpCollectionSystemDefDto;
+import org.opennms.web.rest.v2.model.DataCollectionConfErrorResponse;
+import org.opennms.web.rest.v2.model.DataCollectionConfUploadResponse;
+import org.opennms.web.rest.v2.model.DataCollectionMibGroupPageResponse;
+import org.opennms.web.rest.v2.model.DataCollectionResourceTypePageResponse;
+import org.opennms.web.rest.v2.model.DataCollectionSystemDefPageResponse;
 import org.opennms.web.rest.v2.model.SnmpCollectionCreateSourceDto;
+import org.opennms.web.rest.v2.model.SnmpCollectionSourceNamesAndIdsResponse;
+import org.opennms.web.rest.v2.model.SnmpCollectionSourcePageResponse;
 
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
@@ -51,8 +64,91 @@ import javax.ws.rs.core.SecurityContext;
 import java.util.List;
 
 @Path("datacollectionconf")
-@Tag(name = "DataCollectionConf", description = "DataCollectionConf API")
+@Tag(name = "DataCollectionConf", description = """
+        DataCollectionConf API.
+
+        SNMP data collection lives in the database rather than in `datacollection-config.xml` and the
+        `datacollection/*.xml` group files. A **source** stands for one `<datacollection-group>` and owns
+        its MIB groups, resource types and system definitions. A **profile** stands for one
+        `<snmp-collection>`: it carries the rrd step, RRAs, storage flag and `max-vars-per-pdu`, and its
+        `sourceNames` list is the set of `<include-collection>` entries. Only enabled profiles reach
+        collectd, so a source that no enabled profile references is never scheduled.
+
+        Every write schedules a reload of the in-memory data collection config, so changes take effect
+        without a restart.
+
+        Two wire-format details apply across the family. `createdTime` and `lastModified` serialize as
+        epoch milliseconds, not as the date-time strings the generated schema shows. Ids that do not
+        exist are usually ignored rather than reported: the bulk delete and the enable/disable endpoints
+        answer 200 for an unknown id.
+
+        `GET /datacollectionconf/config/download` plus one
+        `GET /datacollectionconf/collectsources/{id}/download` per source reproduce the on-disk file set,
+        and that set is accepted back as a single multipart batch by `POST /datacollectionconf/upload`.""")
 public interface DataCollectionConfRestApi {
+
+    String PROFILE_JSON_EXAMPLE = """
+            {
+              "name": "default",
+              "rrdStep": 300,
+              "rrdRras": [
+                "RRA:AVERAGE:0.5:1:2016",
+                "RRA:AVERAGE:0.5:12:1488",
+                "RRA:AVERAGE:0.5:288:366",
+                "RRA:MAX:0.5:288:366",
+                "RRA:MIN:0.5:288:366"
+              ],
+              "storageFlag": "select",
+              "sourceNames": [ "MIB2", "Cisco" ],
+              "maxVarsPerPdu": 10,
+              "enabled": true
+            }""";
+
+    String PROFILE_JSON_RESPONSE_EXAMPLE = """
+            {
+              "id": 1,
+              "name": "default",
+              "rrdStep": 300,
+              "rrdRras": [
+                "RRA:AVERAGE:0.5:1:2016",
+                "RRA:AVERAGE:0.5:12:1488",
+                "RRA:AVERAGE:0.5:288:366",
+                "RRA:MAX:0.5:288:366",
+                "RRA:MIN:0.5:288:366"
+              ],
+              "storageFlag": "select",
+              "sourceNames": [ "MIB2", "Cisco" ],
+              "maxVarsPerPdu": 10,
+              "enabled": true,
+              "createdTime": 1787727852928,
+              "lastModified": 1787727871283
+            }""";
+
+    String MIB_GROUP_JSON_EXAMPLE = """
+            {
+              "name": "cisco-router",
+              "ifType": "ignore",
+              "mibObjects": "[{\\"alias\\":\\"cpu5min\\",\\"oid\\":\\".1.3.6.1.4.1.9.2.1.58\\",\\"instance\\":\\"0\\",\\"type\\":\\"gauge\\"}]",
+              "enabled": true
+            }""";
+
+    String RESOURCE_TYPE_JSON_EXAMPLE = """
+            {
+              "name": "cpqDaPhyDrv",
+              "label": "Compaq Physical Drive",
+              "resourceLabel": "${index}",
+              "persistenceSelectorStrategy": "org.opennms.netmgt.collection.support.PersistAllSelectorStrategy",
+              "storageStrategy": "org.opennms.netmgt.dao.support.IndexStorageStrategy",
+              "enabled": true
+            }""";
+
+    String SYSTEM_DEF_JSON_EXAMPLE = """
+            {
+              "name": "Cisco Routers",
+              "sysoidMask": ".1.3.6.1.4.1.9.1.",
+              "mibGroupNames": "[\\"cisco-router\\"]",
+              "enabled": true
+            }""";
 
     @POST
     @Path("/upload")
@@ -60,30 +156,62 @@ public interface DataCollectionConfRestApi {
     @Produces("application/json")
     @Operation(
             summary = "Upload datacollectionconf files",
-            description = "Upload one or more data collection config files. Each `upload` part must "
-                    + "be an XML file whose root element is either `<datacollection-group>` (a source "
-                    + "definition) or `<datacollection-config>` (a profile-driver file with "
-                    + "`<snmp-collection>` entries). At most one `<datacollection-config>` is allowed "
-                    + "per request.\n\n"
-                    + "How `profileNames` is applied depends on the batch composition:\n"
-                    + "- **Pure-new batch** (every source is new): `profileNames` is required; new "
-                    + "sources are attached to those profiles.\n"
-                    + "- **Pure-update batch** (every source already exists in the DB): `profileNames` "
-                    + "is optional. If non-empty, it is applied additively to every source — treat as "
-                    + "an explicit \"also associate these updates with these profiles\" intent.\n"
-                    + "- **Mixed batch** (≥1 new and ≥1 update): `profileNames` is required (for the "
-                    + "new sources) and is applied **only to the new sources**. Updates keep their "
-                    + "existing profile memberships untouched. To change an existing source's "
-                    + "memberships in this case, use the dedicated `/profiles/{profileId}/sources` "
-                    + "endpoints.\n"
-                    + "- **`<datacollection-config>` present**: `profileNames` is ignored; the "
-                    + "`<include-collection>` entries in the config drive attachment.",
+            description = """
+        Upload one or more data collection config files. Each `upload` part must be an XML file whose root
+        element is either `<datacollection-group>` (a source definition) or `<datacollection-config>`
+        (a profile-driver file with `<snmp-collection>` entries). At most one `<datacollection-config>`
+        is allowed per request.
+
+        Parts are keyed by filename with the directory and extension stripped, and the first part wins
+        when two filenames reduce to the same basename, so uploading the same file twice is a no-op
+        rather than a duplicate error.
+
+        How `profileNames` is applied depends on the batch composition:
+        - **Pure-new batch** (every source is new): `profileNames` is required; new sources are attached
+          to those profiles.
+        - **Pure-update batch** (every source already exists in the DB): `profileNames` is optional.
+          If non-empty, it is applied additively to every source, taken as an explicit "also associate
+          these updates with these profiles" intent.
+        - **Mixed batch** (at least one new and at least one update): `profileNames` is required (for the
+          new sources) and is applied **only to the new sources**. Updates keep their existing profile
+          memberships untouched. To change an existing source's memberships in this case, use the
+          dedicated `/profiles/{profileId}/sources` endpoints.
+        - **`<datacollection-config>` present**: `profileNames` is ignored; the `<include-collection>`
+          entries in the config drive attachment, and profiles named by `<snmp-collection>` are created
+          or updated.
+
+        A part is capped at 16 MiB and a batch at 64 MiB. Files that fail to parse are reported in
+        `errors` while the rest are still stored, so a 200 does not by itself mean every file was
+        accepted.""",
             operationId = "uploadSnmpDataCollectionConfFiles"
     )
+    @RequestBody(
+            required = true,
+            description = "Multipart form with one `upload` part per XML file, plus zero or more "
+                    + "`profileNames` parts each holding a single profile name.",
+            content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA,
+                    schema = @Schema(type = "string", format = "binary"))
+    )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Upload processed (per-file results in success/errors arrays)"),
+            @ApiResponse(responseCode = "200", description = "Upload processed. Per-file outcomes are split between `success` and `errors`.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfUploadResponse.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "success": [
+                        { "file": "Cisco", "source": "Cisco" },
+                        { "file": "datacollection-config", "profile": "default" }
+                      ],
+                      "errors": [
+                        { "file": "Broken", "error": "UnmarshalException: null" }
+                      ]
+                    }"""))),
             @ApiResponse(responseCode = "400",
-                    description = "Invalid XML, missing required profileNames for source-only uploads, or other request error")
+                    description = "A new source was uploaded without any `profileNames` part.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                    {"error":"At least one profileNames value is required when uploading new source files."}""")))
     })
     Response uploadSnmpDataCollectionConfFiles(@Multipart("upload") List<Attachment> attachments,
                                   @Multipart(value = "profileNames", required = false) List<Attachment> profileNames,
@@ -94,11 +222,21 @@ public interface DataCollectionConfRestApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "List all SNMP collection profiles",
-            description = "Returns id, name, enabled, sourceNames, and other config for every profile.",
+            description = """
+        Returns id, name, enabled, sourceNames, and the rrd metadata for every profile.
+        `createdTime` and `lastModified` come back as epoch milliseconds; `lastModified` is null on a
+        profile that has never been updated.""",
             operationId = "listSnmpCollectionProfiles"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Profiles returned", content = @Content)
+            @ApiResponse(responseCode = "200", description = "Profiles returned",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            array = @ArraySchema(schema = @Schema(implementation = SnmpCollectionProfileDto.class)),
+                            examples = @ExampleObject(value = "[" + PROFILE_JSON_RESPONSE_EXAMPLE + "]"))),
+            @ApiResponse(responseCode = "500", description = "The profiles could not be read.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Unexpected error occurred\"}")))
     })
     Response listSnmpCollectionProfiles(@Context SecurityContext securityContext);
 
@@ -107,14 +245,33 @@ public interface DataCollectionConfRestApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Get a single SNMP collection profile",
+            description = """
+        Fetch one profile by id. `createdTime` and `lastModified` come back as epoch milliseconds.
+        The 400 and 404 bodies are bare strings served under `application/json`.""",
             operationId = "getSnmpCollectionProfile"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Profile returned"),
-            @ApiResponse(responseCode = "404", description = "Profile not found")
+            @ApiResponse(responseCode = "200", description = "Profile returned",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = SnmpCollectionProfileDto.class),
+                            examples = @ExampleObject(value = PROFILE_JSON_RESPONSE_EXAMPLE))),
+            @ApiResponse(responseCode = "400", description = "`profileId` was not a positive integer.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "profileId must be a positive integer"))),
+            @ApiResponse(responseCode = "404", description = "Profile not found",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Profile not found for id: 999999"))),
+            @ApiResponse(responseCode = "500", description = "The profile could not be read.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Unexpected error occurred\"}")))
     })
-    Response getSnmpCollectionProfile(@PathParam("profileId") Integer profileId,
-                                      @Context SecurityContext securityContext);
+    Response getSnmpCollectionProfile(
+            @Parameter(description = "Profile id. Must be a positive integer.", example = "1", required = true)
+            @PathParam("profileId") Integer profileId,
+            @Context SecurityContext securityContext);
 
     @POST
     @Path("/profiles")
@@ -122,11 +279,32 @@ public interface DataCollectionConfRestApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Create a new SNMP collection profile",
+            description = """
+        Create a profile. `name` must be non-empty and unique, and at least one RRA is required.
+        `id`, `createdTime` and `lastModified` in the body are ignored. The response body is the new
+        profile id as a bare integer.""",
             operationId = "createSnmpCollectionProfile"
     )
+    @RequestBody(
+            required = true,
+            description = "Profile to create.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = SnmpCollectionProfileDto.class),
+                    examples = @ExampleObject(value = PROFILE_JSON_EXAMPLE))
+    )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "Profile created; body contains the new id"),
-            @ApiResponse(responseCode = "400", description = "Invalid profile body or name already in use")
+            @ApiResponse(responseCode = "201", description = "Profile created; body is the new id",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "integer", format = "int32"),
+                            examples = @ExampleObject(value = "3"))),
+            @ApiResponse(responseCode = "400", description = "Missing body, empty name, no RRAs, or a name already in use",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "A profile with name 'default' already exists"))),
+            @ApiResponse(responseCode = "500", description = "The profile could not be created.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Unexpected error occurred\"}")))
     })
     Response createSnmpCollectionProfile(SnmpCollectionProfileDto profile,
                                          @Context SecurityContext securityContext);
@@ -137,14 +315,36 @@ public interface DataCollectionConfRestApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Update an SNMP collection profile",
+            description = """
+        Replace a profile's fields. The body is a whole profile, not a patch. A successful response
+        carries no body.""",
             operationId = "updateSnmpCollectionProfile"
     )
+    @RequestBody(
+            required = true,
+            description = "Replacement profile.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = SnmpCollectionProfileDto.class),
+                    examples = @ExampleObject(value = PROFILE_JSON_EXAMPLE))
+    )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Profile updated"),
-            @ApiResponse(responseCode = "400", description = "Invalid profile body or name conflict"),
-            @ApiResponse(responseCode = "404", description = "Profile not found")
+            @ApiResponse(responseCode = "200", description = "Profile updated. No response body."),
+            @ApiResponse(responseCode = "400", description = "Missing body, invalid field, or a name conflict",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Profile body must not be null"))),
+            @ApiResponse(responseCode = "404", description = "Profile not found",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Profile not found for id: 999999"))),
+            @ApiResponse(responseCode = "500", description = "The update failed.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Unexpected error occurred\"}")))
     })
-    Response updateSnmpCollectionProfile(@PathParam("profileId") Integer profileId,
+    Response updateSnmpCollectionProfile(
+            @Parameter(description = "Profile id. Must be a positive integer.", example = "3", required = true)
+            @PathParam("profileId") Integer profileId,
                                          SnmpCollectionProfileDto profile,
                                          @Context SecurityContext securityContext);
 
@@ -154,11 +354,32 @@ public interface DataCollectionConfRestApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Bulk-delete SNMP collection profiles",
+            description = """
+        Delete the profiles named by the id list in the request body. Ids that do not exist are ignored
+        rather than reported. Sources the deleted profiles referenced are not themselves deleted, so a
+        source can be left unreferenced and therefore unscheduled.""",
             operationId = "deleteSnmpCollectionProfiles"
     )
+    @RequestBody(
+            required = true,
+            description = "Profile ids to delete.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    array = @ArraySchema(schema = @Schema(type = "integer", format = "int32")),
+                    examples = @ExampleObject(value = "[3, 4]"))
+    )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Deletion complete"),
-            @ApiResponse(responseCode = "400", description = "Empty id list")
+            @ApiResponse(responseCode = "200", description = "Deletion complete",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "SNMP collection profiles deleted."))),
+            @ApiResponse(responseCode = "400", description = "Missing or empty id list",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "At least one id must be provided."))),
+            @ApiResponse(responseCode = "500", description = "The deletion failed.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Unexpected error occurred\"}")))
     })
     Response deleteSnmpCollectionProfiles(List<Integer> ids,
                                           @Context SecurityContext securityContext);
@@ -169,13 +390,37 @@ public interface DataCollectionConfRestApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Bulk enable/disable SNMP collection profiles",
+            description = """
+        Set the enabled flag on the profiles named by the id list in the request body. A disabled profile
+        is left out of the config collectd consumes and out of
+        `GET /datacollectionconf/config/download`. Ids that do not exist are ignored rather than
+        reported.""",
             operationId = "enableDisableSnmpCollectionProfiles"
     )
+    @RequestBody(
+            required = true,
+            description = "Profile ids to update.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    array = @ArraySchema(schema = @Schema(type = "integer", format = "int32")),
+                    examples = @ExampleObject(value = "[3, 4]"))
+    )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Profiles updated"),
-            @ApiResponse(responseCode = "400", description = "Empty id list")
+            @ApiResponse(responseCode = "200", description = "Profiles updated",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "SNMP collection profiles updated."))),
+            @ApiResponse(responseCode = "400", description = "Missing or empty id list",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "At least one id must be provided."))),
+            @ApiResponse(responseCode = "500", description = "The update failed.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Unexpected error occurred\"}")))
     })
-    Response enableDisableSnmpCollectionProfiles(@QueryParam("enabled") boolean enabled,
+    Response enableDisableSnmpCollectionProfiles(
+            @Parameter(description = "Target state for every listed profile.", example = "false", required = true)
+            @QueryParam("enabled") boolean enabled,
                                                  List<Integer> ids,
                                                  @Context SecurityContext securityContext);
 
@@ -185,15 +430,38 @@ public interface DataCollectionConfRestApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Add a source to a profile",
-            description = "Appends the given source name to the profile's source_names (idempotent).",
+            description = """
+        Append the given source name to the profile's `sourceNames`. The request body is the bare source
+        name, not a JSON object. The call is idempotent: a name already present is left alone and still
+        answers 200. The source has to exist; an unknown name is a 400, not a 404. A successful response
+        carries no body.""",
             operationId = "addSourceToProfile"
     )
+    @RequestBody(
+            required = true,
+            description = "Source name, as a bare string.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(type = "string"),
+                    examples = @ExampleObject(value = "Cisco"))
+    )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Source added"),
-            @ApiResponse(responseCode = "400", description = "Invalid profileId or empty sourceName"),
-            @ApiResponse(responseCode = "404", description = "Profile or source not found")
+            @ApiResponse(responseCode = "200", description = "Source added, or already present. No response body."),
+            @ApiResponse(responseCode = "400", description = "Empty body, `profileId` not a positive integer, or an unknown source name",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Unknown source name: Ciscoo"))),
+            @ApiResponse(responseCode = "404", description = "Profile not found",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Profile not found for id: 999999"))),
+            @ApiResponse(responseCode = "500", description = "The update failed.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Unexpected error occurred\"}")))
     })
-    Response addSourceToProfile(@PathParam("profileId") Integer profileId,
+    Response addSourceToProfile(
+            @Parameter(description = "Profile id. Must be a positive integer.", example = "1", required = true)
+            @PathParam("profileId") Integer profileId,
                                 String sourceName,
                                 @Context SecurityContext securityContext);
 
@@ -202,16 +470,32 @@ public interface DataCollectionConfRestApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Remove a source from a profile",
-            description = "Removes the given source name from the profile's source_names (no-op if absent).",
+            description = """
+        Remove the given source name from the profile's `sourceNames`. A name that is not present is a
+        no-op and still answers 200. The source row itself is not deleted. A successful response carries
+        no body.""",
             operationId = "removeSourceFromProfile"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Source removed (or already absent)"),
-            @ApiResponse(responseCode = "400", description = "Invalid profileId"),
-            @ApiResponse(responseCode = "404", description = "Profile not found")
+            @ApiResponse(responseCode = "200", description = "Source removed, or already absent. No response body."),
+            @ApiResponse(responseCode = "400", description = "`profileId` was not a positive integer",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "profileId must be a positive integer"))),
+            @ApiResponse(responseCode = "404", description = "Profile not found",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Profile not found for id: 999999"))),
+            @ApiResponse(responseCode = "500", description = "The update failed.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Unexpected error occurred\"}")))
     })
-    Response removeSourceFromProfile(@PathParam("profileId") Integer profileId,
-                                     @PathParam("sourceName") String sourceName,
+    Response removeSourceFromProfile(
+            @Parameter(description = "Profile id. Must be a positive integer.", example = "1", required = true)
+            @PathParam("profileId") Integer profileId,
+            @Parameter(description = "Source name to remove.", example = "Cisco", required = true)
+            @PathParam("sourceName") String sourceName,
                                      @Context SecurityContext securityContext);
 
     @GET
@@ -219,23 +503,55 @@ public interface DataCollectionConfRestApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Filter SnmpCollectionSource Records",
-            description = "Fetch SnmpCollectionSource records based on provided filters such as name, vendor, description.",
+            description = """
+        Page through the SNMP data collection sources.
+        - `filter`: case-insensitive substring match on name, vendor and description.
+        - `sortBy`: `name`, `vendor`, `description`; anything else falls back to `createdTime`.
+        - `order`: `asc` or `desc` (default `desc`).
+        - `limit` is **required** and has to be 1..1000; `offset` defaults to 0 when omitted.
+
+        `createdTime` and `lastModified` come back as epoch milliseconds.""",
             operationId = "filterSnmpCollectionSources"
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "SnmpCollectionSource records retrieved successfully",
-                    content = @Content),
-            @ApiResponse(responseCode = "400", description = "Bad Request – invalid or missing input parameters",
-                    content = @Content),
-            @ApiResponse(responseCode = "204", description = "No matching SnmpCollectionSource records found for the given criteria",
-                    content = @Content)
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = SnmpCollectionSourcePageResponse.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "totalRecords": 1,
+                      "snmpCollectionSourceList": [
+                        {
+                          "id": 24,
+                          "name": "Cisco",
+                          "vendor": "Cisco",
+                          "description": null,
+                          "enabled": true,
+                          "createdTime": 1786129480772,
+                          "lastModified": 1786129480772,
+                          "uploadedBy": "admin"
+                        }
+                      ]
+                    }"""))),
+            @ApiResponse(responseCode = "400", description = "`limit` was missing, below 1, or above 1000, or `offset` was negative",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Invalid offset/limit values (limit must be 1..1000)\"}"))),
+            @ApiResponse(responseCode = "204", description = "No matching SnmpCollectionSource records found for the given criteria")
     })
     Response filterSnmpCollectionSources(
+            @Parameter(description = "Case-insensitive substring matched against name, vendor and description.", example = "Cisco")
             @QueryParam("filter") String filter,
+            @Parameter(description = "Sort column. An unrecognised value falls back to `createdTime`.",
+                    example = "name", schema = @Schema(allowableValues = {"name", "vendor", "description", "createdTime"}))
             @QueryParam("sortBy") String sortBy,
+            @Parameter(description = "Sort direction.", example = "asc", schema = @Schema(allowableValues = {"asc", "desc"}))
             @QueryParam("order") String order,
+            @Parameter(description = "Total row count already known to the caller, used to skip the count query.", example = "120")
             @QueryParam("totalRecords") Integer totalRecords,
+            @Parameter(description = "Zero-based index of the first row to return. Defaults to 0.", example = "0")
             @QueryParam("offset") Integer offset,
+            @Parameter(description = "Rows to return. Required, 1..1000.", example = "20", required = true)
             @QueryParam("limit") Integer limit,
             @Context SecurityContext securityContext );
 
@@ -245,28 +561,62 @@ public interface DataCollectionConfRestApi {
     @Operation(
             summary = "Get DataCollectionMibGroup by Collection Source ID with filtering and sorting",
             description = """
-        Retrieves DataCollectionMibGroup records for the given Collection source ID with optional filtering, sorting, and pagination.
-        - `eventFilter`: case-insensitive match on Name, IfType.
-        - `eventSortBy`: sort field `name`, `ifType` defaults to `createdTime` if invalid.
-        - `eventOrder`: `asc` or `desc` (default: `desc`).
-        - `offset` and `limit`: for pagination.""",
+        Page through the MIB groups belonging to one source.
+        - `mibGroupFilter`: case-insensitive match on name and ifType.
+        - `sortBy`: `name` or `ifType`; anything else falls back to `createdTime`.
+        - `order`: `asc` or `desc` (default `desc`).
+        - `offset` and `limit` are **both required**: omitting `offset` fails with a 500 rather than
+          defaulting to 0. `limit` has to be 1..1000.
+
+        A `collectionSourceId` that does not exist answers 204 rather than 404.""",
             operationId = "filterDataCollectionMibGroupByCollectionSourceId"
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "DataCollectionMibGroup records retrieved successfully",
-                    content = @Content),
-            @ApiResponse(responseCode = "400", description = "Bad Request – invalid or missing input parameters",
-                    content = @Content),
-            @ApiResponse(responseCode = "204", description = "No matching DataCollectionMibGroup record found for the given criteria",
-                    content = @Content)
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionMibGroupPageResponse.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "totalRecords": 1,
+                      "dataCollectionMibGroupList": [
+                        {
+                          "id": 343,
+                          "name": "cisco-router",
+                          "ifType": "ignore",
+                          "mibGroupNames": null,
+                          "mibObjects": "[{\\"alias\\":\\"cpu5min\\",\\"oid\\":\\".1.3.6.1.4.1.9.2.1.58\\",\\"instance\\":\\"0\\",\\"type\\":\\"gauge\\"}]",
+                          "mibObjProperties": null,
+                          "enabled": true,
+                          "collectionSourceId": 24,
+                          "collectionSourceName": "Cisco"
+                        }
+                      ]
+                    }"""))),
+            @ApiResponse(responseCode = "400", description = "`collectionSourceId` not a positive integer, or `limit` missing or outside 1..1000",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Invalid collectionSourceId/offset/limit values (limit must be 1..1000)\"}"))),
+            @ApiResponse(responseCode = "204", description = "No matching DataCollectionMibGroup record found for the given criteria"),
+            @ApiResponse(responseCode = "500", description = "Raised when `offset` is omitted.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot invoke \"java.lang.Integer.intValue()\" because \"offset\" is null")))
     })
     Response filterDataCollectionMibGroupByCollectionSourceId(
+            @Parameter(description = "Source id owning the MIB groups. Must be a positive integer.", example = "24", required = true)
             @PathParam("collectionSourceId") Integer collectionSourceId,
+            @Parameter(description = "Case-insensitive substring matched against name and ifType.", example = "cisco")
             @QueryParam("mibGroupFilter") String mibGroupFilter,
+            @Parameter(description = "Sort column. An unrecognised value falls back to `createdTime`.",
+                    example = "name", schema = @Schema(allowableValues = {"name", "ifType", "createdTime"}))
             @QueryParam("sortBy") String sortBy,
+            @Parameter(description = "Sort direction.", example = "asc", schema = @Schema(allowableValues = {"asc", "desc"}))
             @QueryParam("order") String order,
+            @Parameter(description = "Total row count already known to the caller, used to skip the count query.", example = "40")
             @QueryParam("totalRecords") Integer totalRecords,
+            @Parameter(description = "Zero-based index of the first row to return. Required.", example = "0", required = true)
             @QueryParam("offset") Integer offset,
+            @Parameter(description = "Rows to return. Required, 1..1000.", example = "20", required = true)
             @QueryParam("limit") Integer limit,
             @Context SecurityContext securityContext );
 
@@ -276,38 +626,64 @@ public interface DataCollectionConfRestApi {
     @Operation(
             summary = "Get DataCollectionResourceType by Collection Source ID with filtering and sorting",
             description = """
-    Retrieves DataCollectionResourceType records for the given Collection source ID with optional filtering, sorting, and pagination.
-    - `resourceTypeFilter`: case-insensitive match on Name, Label.
-    - `sortBy`: sort field `name`, `label` (defaults to `createdTime` if invalid).
-    - `order`: `asc` or `desc` (default: `desc`).
-    - `offset` and `limit`: for pagination.
-    """,
+        Page through the resource types belonging to one source.
+        - `resourceTypeFilter`: case-insensitive match on name and label.
+        - `sortBy`: `name` or `label`; anything else falls back to `createdTime`.
+        - `order`: `asc` or `desc` (default `desc`).
+        - `offset` and `limit` are **both required**: omitting `offset` fails with a 500 rather than
+          defaulting to 0. `limit` has to be 1..1000.
+
+        A `collectionSourceId` that does not exist answers 204 rather than 404.""",
             operationId = "filterDataCollectionResourceTypeByCollectionSourceId"
     )
     @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "DataCollectionResourceType records retrieved successfully",
-                    content = @Content
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "Bad Request – invalid or missing input parameters",
-                    content = @Content
-            ),
-            @ApiResponse(
-                    responseCode = "204",
-                    description = "No matching DataCollectionResourceType record found for the given criteria",
-                    content = @Content
-            )
+            @ApiResponse(responseCode = "200", description = "DataCollectionResourceType records retrieved successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionResourceTypePageResponse.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "totalRecords": 1,
+                      "dataCollectionResourceTypeList": [
+                        {
+                          "id": 211,
+                          "name": "cpqDaPhyDrv",
+                          "label": "Compaq Physical Drive",
+                          "resourceLabel": "${index}",
+                          "persistenceSelectorStrategy": "org.opennms.netmgt.collection.support.PersistAllSelectorStrategy",
+                          "persistenceSelectorParams": null,
+                          "storageStrategy": "org.opennms.netmgt.dao.support.IndexStorageStrategy",
+                          "storageStrategyParams": null,
+                          "enabled": true,
+                          "collectionSourceId": 24,
+                          "collectionSourceName": "Cisco"
+                        }
+                      ]
+                    }"""))),
+            @ApiResponse(responseCode = "400", description = "`collectionSourceId` not a positive integer, or `limit` missing or outside 1..1000",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Invalid collectionSourceId/offset/limit values (limit must be 1..1000)\"}"))),
+            @ApiResponse(responseCode = "204", description = "No matching DataCollectionResourceType record found for the given criteria"),
+            @ApiResponse(responseCode = "500", description = "Raised when `offset` is omitted.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot invoke \"java.lang.Integer.intValue()\" because \"offset\" is null")))
     })
     Response filterDataCollectionResourceTypeByCollectionSourceId(
+            @Parameter(description = "Source id owning the resource types. Must be a positive integer.", example = "24", required = true)
             @PathParam("collectionSourceId") Integer collectionSourceId,
+            @Parameter(description = "Case-insensitive substring matched against name and label.", example = "cpq")
             @QueryParam("resourceTypeFilter") String resourceTypeFilter,
+            @Parameter(description = "Sort column. An unrecognised value falls back to `createdTime`.",
+                    example = "name", schema = @Schema(allowableValues = {"name", "label", "createdTime"}))
             @QueryParam("sortBy") String sortBy,
+            @Parameter(description = "Sort direction.", example = "asc", schema = @Schema(allowableValues = {"asc", "desc"}))
             @QueryParam("order") String order,
+            @Parameter(description = "Total row count already known to the caller, used to skip the count query.", example = "12")
             @QueryParam("totalRecords") Integer totalRecords,
+            @Parameter(description = "Zero-based index of the first row to return. Required.", example = "0", required = true)
             @QueryParam("offset") Integer offset,
+            @Parameter(description = "Rows to return. Required, 1..1000.", example = "20", required = true)
             @QueryParam("limit") Integer limit,
             @Context SecurityContext securityContext
     );
@@ -318,38 +694,63 @@ public interface DataCollectionConfRestApi {
     @Operation(
             summary = "Get DataCollectionSystemDef by Collection Source ID with filtering and sorting",
             description = """
-    Retrieves DataCollectionSystemDef records for the given Collection source ID with optional filtering, sorting, and pagination.
-    - `systemDefFilter`: case-insensitive match on Name
-    - `sortBy`: sort field `name` (defaults to `createdTime` if invalid).
-    - `order`: `asc` or `desc` (default: `desc`).
-    - `offset` and `limit`: for pagination.
-    """,
+        Page through the system definitions belonging to one source.
+        - `systemDefsFilter`: case-insensitive match on name.
+        - `sortBy`: `name`; anything else falls back to `createdTime`.
+        - `order`: `asc` or `desc` (default `desc`).
+        - `offset` and `limit` are **both required**: omitting `offset` fails with a 500 rather than
+          defaulting to 0. `limit` has to be 1..1000.
+
+        A `collectionSourceId` that does not exist answers 204 rather than 404.""",
             operationId = "filterDataCollectionSystemDefByCollectionSourceId"
     )
     @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "DataCollectionSystemDef records retrieved successfully",
-                    content = @Content
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "Bad Request – invalid or missing input parameters",
-                    content = @Content
-            ),
-            @ApiResponse(
-                    responseCode = "204",
-                    description = "No matching DataCollectionSystemDef record found for the given criteria",
-                    content = @Content
-            )
+            @ApiResponse(responseCode = "200", description = "DataCollectionSystemDef records retrieved successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionSystemDefPageResponse.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "totalRecords": 1,
+                      "dataCollectionSystemDefsList": [
+                        {
+                          "id": 219,
+                          "name": "Cisco Routers",
+                          "sysoid": null,
+                          "sysoidMask": ".1.3.6.1.4.1.9.1.",
+                          "ipAddresses": [],
+                          "ipAddressMasks": [],
+                          "mibGroupNames": "[\\"cisco-router\\"]",
+                          "enabled": true,
+                          "collectionSourceId": 24,
+                          "collectionSourceName": "Cisco"
+                        }
+                      ]
+                    }"""))),
+            @ApiResponse(responseCode = "400", description = "`collectionSourceId` not a positive integer, or `limit` missing or outside 1..1000",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Invalid collectionSourceId/offset/limit values (limit must be 1..1000)\"}"))),
+            @ApiResponse(responseCode = "204", description = "No matching DataCollectionSystemDef record found for the given criteria"),
+            @ApiResponse(responseCode = "500", description = "Raised when `offset` is omitted.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Cannot invoke \"java.lang.Integer.intValue()\" because \"offset\" is null")))
     })
     Response filterDataCollectionSystemDefByCollectionSourceId(
+            @Parameter(description = "Source id owning the system definitions. Must be a positive integer.", example = "24", required = true)
             @PathParam("collectionSourceId") Integer collectionSourceId,
+            @Parameter(description = "Case-insensitive substring matched against name.", example = "Cisco")
             @QueryParam("systemDefsFilter") String systemDefFilter,
+            @Parameter(description = "Sort column. An unrecognised value falls back to `createdTime`.",
+                    example = "name", schema = @Schema(allowableValues = {"name", "createdTime"}))
             @QueryParam("sortBy") String sortBy,
+            @Parameter(description = "Sort direction.", example = "asc", schema = @Schema(allowableValues = {"asc", "desc"}))
             @QueryParam("order") String order,
+            @Parameter(description = "Total row count already known to the caller, used to skip the count query.", example = "8")
             @QueryParam("totalRecords") Integer totalRecords,
+            @Parameter(description = "Zero-based index of the first row to return. Required.", example = "0", required = true)
             @QueryParam("offset") Integer offset,
+            @Parameter(description = "Rows to return. Required, 1..1000.", example = "20", required = true)
             @QueryParam("limit") Integer limit,
             @Context SecurityContext securityContext
     );
@@ -359,17 +760,41 @@ public interface DataCollectionConfRestApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Get SnmpCollectionSource by ID",
-            description = "Retrieve an SnmpCollectionSource by its unique identifier.",
+            description = """
+        Retrieve one SNMP data collection source by id. `createdTime` and `lastModified` come back as
+        epoch milliseconds. `vendor` defaults to the source name for a source created through the API.""",
             operationId = "getSnmpDataCollectionSourceById"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "SnmpCollectionSource retrieved successfully"),
-            @ApiResponse(responseCode = "404", description = "SnmpCollectionSource not found"),
-            @ApiResponse(responseCode = "400", description = "Bad request"),
-            @ApiResponse(responseCode = "500", description = "Internal server error")
-
+            @ApiResponse(responseCode = "200", description = "SnmpCollectionSource retrieved successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = SnmpCollectionSourceDto.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "id": 24,
+                      "name": "Cisco",
+                      "vendor": "Cisco",
+                      "description": null,
+                      "enabled": true,
+                      "createdTime": 1786129480772,
+                      "lastModified": 1786129480772,
+                      "uploadedBy": "admin"
+                    }"""))),
+            @ApiResponse(responseCode = "400", description = "`collectionSourceId` was not a positive integer",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Invalid collectionSourceId provided\"}"))),
+            @ApiResponse(responseCode = "404", description = "SnmpCollectionSource not found",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"snmpCollectionSource not found for id: 999999\"}"))),
+            @ApiResponse(responseCode = "500", description = "The source could not be read.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Unexpected error occurred\"}")))
     })
     Response getSnmpDataCollectionSourceById(
+            @Parameter(description = "Source id. Must be a positive integer.", example = "24", required = true)
             @PathParam("collectionSourceId") Integer collectionSourceId,
             @Context SecurityContext securityContext
     );
@@ -379,12 +804,22 @@ public interface DataCollectionConfRestApi {
     @Produces("application/json")
     @Operation(
             summary = "Get SnmpCollection Source Names",
-            description = "Retrieve the names and Ids of all SnmpCollection sources stored in the database.",
+            description = "Retrieve the id and name of every SNMP data collection source, in no defined order.",
             operationId = "getSnmpCollectionSourceNamesAndIds"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Successfully retrieved source names"),
-            @ApiResponse(responseCode = "500", description = "Internal server error")
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved source names",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            array = @ArraySchema(schema = @Schema(implementation = SnmpCollectionSourceNamesAndIdsResponse.class)),
+                            examples = @ExampleObject(value = """
+                    [
+                      { "id": 1, "name": "Makelsan" },
+                      { "id": 24, "name": "Cisco" }
+                    ]"""))),
+            @ApiResponse(responseCode = "500", description = "The source names could not be read.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Failed to fetch SnmpCollection source names: ...")))
     })
     Response getSnmpCollectionSourceNamesAndIds(@Context SecurityContext securityContext) throws Exception;
 
@@ -393,12 +828,18 @@ public interface DataCollectionConfRestApi {
     @Produces("application/json")
     @Operation(
             summary = "Get DataCollection Resource Type Names",
-            description = "Retrieve the names of all DataCollection Resource Types stored in the database.",
+            description = "Retrieve the names of every resource type across all sources, as a flat string array.",
             operationId = "getDataCollectionResourceTypeNames"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Successfully retrieved resource type names"),
-            @ApiResponse(responseCode = "500", description = "Internal server error")
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved resource type names",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            array = @ArraySchema(schema = @Schema(type = "string")),
+                            examples = @ExampleObject(value = "[\"ifIndex\", \"cpqDaPhyDrv\", \"mtxrWlStatIndex\"]"))),
+            @ApiResponse(responseCode = "500", description = "The names could not be read.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Failed to fetch Resource Type names: ...")))
     })
     Response getDataCollectionResourceTypeNames(@Context SecurityContext securityContext) throws Exception;
 
@@ -407,27 +848,56 @@ public interface DataCollectionConfRestApi {
     @Produces("application/json")
     @Operation(
             summary = "Get DataCollection MIB Group Names",
-            description = "Retrieve the names of all DataCollection MIB Groups stored in the database.",
+            description = "Retrieve the names of every MIB group across all sources, as a flat string array.",
             operationId = "getDataCollectionMibGroupNames"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Successfully retrieved MIB group names"),
-            @ApiResponse(responseCode = "500", description = "Internal server error")
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved MIB group names",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            array = @ArraySchema(schema = @Schema(type = "string")),
+                            examples = @ExampleObject(value = "[\"cisco-router\", \"mib2-interfaces\", \"domino-stats\"]"))),
+            @ApiResponse(responseCode = "500", description = "The names could not be read.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Failed to fetch MIB Group names: ...")))
     })
     Response getDataCollectionMibGroupNames(@Context SecurityContext securityContext) throws Exception;
+
     @POST
     @Path("/collectsources/{collectionSourceId}/mibgroups")
     @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Add a new Mib Group to an SnmpCollectionSources",
-            description = "Creates and adds a new Mib Group under the given SnmpCollectionSources by its ID.",
+            description = """
+        Create a MIB group under the given source, the equivalent of one `<group>` in a
+        `<datacollection-group>`. `mibObjects` and `mibObjProperties` are JSON documents carried as
+        strings, so their quotes are escaped inside the request body. The response body is the new MIB
+        group id as a bare integer.""",
             operationId = "addMibGroupToSnmpCollectionSources")
+    @RequestBody(
+            required = true,
+            description = "MIB group to create.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = SnmpCollectionMibGroupDto.class),
+                    examples = @ExampleObject(value = MIB_GROUP_JSON_EXAMPLE))
+    )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "MibGroup created successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid request (missing/invalid data)"),
-            @ApiResponse(responseCode = "404", description = "SnmpCollectionSources not found")})
-    Response addMibGroupToSnmpCollectionSources(@PathParam("collectionSourceId") final Integer collectionSourceId,
+            @ApiResponse(responseCode = "201", description = "MibGroup created successfully; body is the new id",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "integer", format = "int32"),
+                            examples = @ExampleObject(value = "343"))),
+            @ApiResponse(responseCode = "400", description = "`collectionSourceId` not a positive integer, missing body, or an unusable payload",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Request body (SnmpCollectionMibGroupDto) must not be null."))),
+            @ApiResponse(responseCode = "404", description = "SnmpCollectionSources not found",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "SnmpCollectionSource with ID 999999 not found")))})
+    Response addMibGroupToSnmpCollectionSources(
+            @Parameter(description = "Source id the MIB group is created under. Must be a positive integer.", example = "24", required = true)
+            @PathParam("collectionSourceId") final Integer collectionSourceId,
              final  SnmpCollectionMibGroupDto request, @Context SecurityContext securityContext) throws Exception;
 
 
@@ -437,13 +907,34 @@ public interface DataCollectionConfRestApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Add a new Resource Type to an SnmpCollectionSources",
-            description = "Creates and adds a new Resource Type under the given SnmpCollectionSources by its ID.",
+            description = """
+        Create a resource type under the given source, the equivalent of one `<resourceType>` in a
+        `<datacollection-group>`. `persistenceSelectorStrategy` and `storageStrategy` are fully
+        qualified class names; the `*Params` fields carry their parameters as a JSON string. The
+        response body is the new resource type id as a bare integer.""",
             operationId = "addResourceTypeToSnmpCollectionSources")
+    @RequestBody(
+            required = true,
+            description = "Resource type to create.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = SnmpCollectionResourceTypeDto.class),
+                    examples = @ExampleObject(value = RESOURCE_TYPE_JSON_EXAMPLE))
+    )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "ResourceType created successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid request (missing/invalid data)"),
-            @ApiResponse(responseCode = "404", description = "SnmpCollectionSources not found")})
+            @ApiResponse(responseCode = "201", description = "ResourceType created successfully; body is the new id",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "integer", format = "int32"),
+                            examples = @ExampleObject(value = "211"))),
+            @ApiResponse(responseCode = "400", description = "`collectionSourceId` not a positive integer, missing body, or an unusable payload",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Request body (SnmpCollectionResourceTypeDto) must not be null."))),
+            @ApiResponse(responseCode = "404", description = "SnmpCollectionSources not found",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "SnmpCollectionSource with ID 999999 not found")))})
     Response addResourceTypeToSnmpCollectionSources(
+            @Parameter(description = "Source id the resource type is created under. Must be a positive integer.", example = "24", required = true)
             @PathParam("collectionSourceId") final Integer collectionSourceId,
             final  SnmpCollectionResourceTypeDto request,
             @Context SecurityContext securityContext) throws Exception;
@@ -454,13 +945,34 @@ public interface DataCollectionConfRestApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Add a new System Definition to an SnmpCollectionSources",
-            description = "Creates and adds a new System Definition under the given SnmpCollectionSources by its ID.",
+            description = """
+        Create a system definition under the given source, the equivalent of one `<systemDef>` in a
+        `<datacollection-group>`. Supply either `sysoid` for an exact match or `sysoidMask` for a prefix
+        match. `mibGroupNames` is a JSON array carried as a string and names the MIB groups the
+        definition collects. The response body is the new system definition id as a bare integer.""",
             operationId = "addSystemDefToSnmpCollectionSources")
+    @RequestBody(
+            required = true,
+            description = "System definition to create.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = SnmpCollectionSystemDefDto.class),
+                    examples = @ExampleObject(value = SYSTEM_DEF_JSON_EXAMPLE))
+    )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "SystemDef created successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid request (missing/invalid data)"),
-            @ApiResponse(responseCode = "404", description = "SnmpCollectionSources not found")})
+            @ApiResponse(responseCode = "201", description = "SystemDef created successfully; body is the new id",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "integer", format = "int32"),
+                            examples = @ExampleObject(value = "219"))),
+            @ApiResponse(responseCode = "400", description = "`collectionSourceId` not a positive integer, missing body, or an unusable payload",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Request body (SnmpCollectionSystemDefDto) must not be null."))),
+            @ApiResponse(responseCode = "404", description = "SnmpCollectionSources not found",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "SnmpCollectionSource with ID 999999 not found")))})
     Response addSystemDefToSnmpCollectionSources(
+            @Parameter(description = "Source id the system definition is created under. Must be a positive integer.", example = "24", required = true)
             @PathParam("collectionSourceId") final Integer collectionSourceId,
             final SnmpCollectionSystemDefDto request,
             @Context SecurityContext securityContext) throws Exception;
@@ -471,15 +983,35 @@ public interface DataCollectionConfRestApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Update a Mib Group in an SnmpCollectionSources",
-            description = "Updates an existing Mib Group under the given SnmpCollectionSources by its ID.",
+            description = """
+        Replace the fields of an existing MIB group. The body is a whole MIB group, not a patch: a field
+        left out is written as null. The MIB group has to belong to the given source.""",
             operationId = "updateMibGroupInSnmpCollectionSources")
+    @RequestBody(
+            required = true,
+            description = "Replacement MIB group.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = SnmpCollectionMibGroupDto.class),
+                    examples = @ExampleObject(value = MIB_GROUP_JSON_EXAMPLE))
+    )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "MibGroup updated successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid request (missing/invalid data)"),
-            @ApiResponse(responseCode = "404", description = "SnmpCollectionSources or MibGroup not found")
+            @ApiResponse(responseCode = "200", description = "MibGroup updated successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "MibGroup updated successfully."))),
+            @ApiResponse(responseCode = "400", description = "Missing body",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Request body cannot be null"))),
+            @ApiResponse(responseCode = "404", description = "SnmpCollectionSources or MibGroup not found",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "MibGroup was not found: No MibGroup found for collectionSourceId=24, mibGroupId=999999")))
     })
     Response updateMibGroupInSnmpCollectionSources(
+            @Parameter(description = "Source id owning the MIB group.", example = "24", required = true)
             @PathParam("collectionSourceId") Integer collectionSourceId,
+            @Parameter(description = "MIB group id to update.", example = "343", required = true)
             @PathParam("mibGroupId") Integer mibGroupId,
             SnmpCollectionMibGroupDto request,
             @Context SecurityContext securityContext
@@ -491,15 +1023,35 @@ public interface DataCollectionConfRestApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Update a Resource Type in an SnmpCollectionSources",
-            description = "Updates an existing Resource Type under the given SnmpCollectionSources by its ID.",
+            description = """
+        Replace the fields of an existing resource type. The body is a whole resource type, not a patch:
+        a field left out is written as null. The resource type has to belong to the given source.""",
             operationId = "updateResourceTypeInSnmpCollectionSources")
+    @RequestBody(
+            required = true,
+            description = "Replacement resource type.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = SnmpCollectionResourceTypeDto.class),
+                    examples = @ExampleObject(value = RESOURCE_TYPE_JSON_EXAMPLE))
+    )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "ResourceType updated successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid request (missing/invalid data)"),
-            @ApiResponse(responseCode = "404", description = "SnmpCollectionSources or ResourceType not found")
+            @ApiResponse(responseCode = "200", description = "ResourceType updated successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "ResourceType updated successfully."))),
+            @ApiResponse(responseCode = "400", description = "Missing body",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Request body cannot be null"))),
+            @ApiResponse(responseCode = "404", description = "SnmpCollectionSources or ResourceType not found",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "ResourceType was not found: No ResourceType found for collectionSourceId=24, resourceTypeId=999999")))
     })
     Response updateResourceTypeInSnmpCollectionSources(
+            @Parameter(description = "Source id owning the resource type.", example = "24", required = true)
             @PathParam("collectionSourceId") Integer collectionSourceId,
+            @Parameter(description = "Resource type id to update.", example = "211", required = true)
             @PathParam("resourceTypeId") Integer resourceTypeId,
             SnmpCollectionResourceTypeDto request,
             @Context SecurityContext securityContext
@@ -511,20 +1063,41 @@ public interface DataCollectionConfRestApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Update a System Definition in an SnmpCollectionSources",
-            description = "Updates an existing System Definition under the given SnmpCollectionSources by its ID.",
+            description = """
+        Replace the fields of an existing system definition. The body is a whole system definition, not a
+        patch: a field left out is written as null, so switching from `sysoid` to `sysoidMask` means
+        sending only the one that should survive. The system definition has to belong to the given
+        source.""",
             operationId = "updateSystemDefInSnmpCollectionSources")
+    @RequestBody(
+            required = true,
+            description = "Replacement system definition.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = SnmpCollectionSystemDefDto.class),
+                    examples = @ExampleObject(value = SYSTEM_DEF_JSON_EXAMPLE))
+    )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "SystemDef updated successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid request (missing/invalid data)"),
-            @ApiResponse(responseCode = "404", description = "SnmpCollectionSources or SystemDef not found")
+            @ApiResponse(responseCode = "200", description = "SystemDef updated successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "SystemDef updated successfully."))),
+            @ApiResponse(responseCode = "400", description = "Missing body",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Request body cannot be null"))),
+            @ApiResponse(responseCode = "404", description = "SnmpCollectionSources or SystemDef not found",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "SystemDef was not found: No SystemDef found for collectionSourceId=24, systemDefId=999999")))
     })
     Response updateSystemDefInSnmpCollectionSources(
+            @Parameter(description = "Source id owning the system definition.", example = "24", required = true)
             @PathParam("collectionSourceId") Integer collectionSourceId,
+            @Parameter(description = "System definition id to update.", example = "219", required = true)
             @PathParam("systemDefId") Integer systemDefId,
             SnmpCollectionSystemDefDto request,
             @Context SecurityContext securityContext
     ) throws Exception;
-
 
     @POST
     @Path("/collectsources")
@@ -532,13 +1105,39 @@ public interface DataCollectionConfRestApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Create SNMP Data Collection Source",
-            description = "Create a SNMP data collection source.",
+            description = """
+        Create an empty SNMP data collection source and attach it to one or more existing profiles.
+        `name` and at least one entry in `profiles` are both required, every profile name has to already
+        exist, and the source name has to be unused. The source starts with no MIB groups, resource types
+        or system definitions: add those through the `/collectsources/{id}/mibgroups`,
+        `/resourcetypes` and `/systemdefs` endpoints, or upload a `<datacollection-group>` file.
+        `vendor` is set to the source name. The response body is the new source id as a bare integer.""",
             operationId = "createSnmpDataCollectionSource"
     )
+    @RequestBody(
+            required = true,
+            description = "Source name and the profiles to attach it to.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = SnmpCollectionCreateSourceDto.class),
+                    examples = @ExampleObject(value = """
+                    {
+                      "name": "Acme Packet",
+                      "profiles": [ "default" ]
+                    }"""))
+    )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "Source created successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid request"),
-            @ApiResponse(responseCode = "500", description = "Internal server error")
+            @ApiResponse(responseCode = "201", description = "Source created successfully; body is the new id",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "integer", format = "int32"),
+                            examples = @ExampleObject(value = "84"))),
+            @ApiResponse(responseCode = "400", description = "Missing body, blank name, empty `profiles`, a name already in use, or a profile that does not exist",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "The following profiles do not exist: [staging]"))),
+            @ApiResponse(responseCode = "500", description = "The source could not be created.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Unexpected error occurred\"}")))
     })
     Response createSnmpDataCollectionSource(
             SnmpCollectionCreateSourceDto request,
@@ -550,16 +1149,32 @@ public interface DataCollectionConfRestApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Delete SNMP Data Collection Sources",
-            description = "Delete one or more SNMP data collection sources by their IDs.",
+            description = """
+        Delete one or more sources and everything under them. Ids that do not exist are ignored, so a
+        request naming only unknown ids still answers 200. The source name is left behind in any
+        profile's `sourceNames`, so remove it from the profiles as well if the reference should go.""",
             operationId = "deleteSnmpDataCollectionSources"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Sources deleted successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid request (missing/invalid IDs)"),
-            @ApiResponse(responseCode = "404", description = "One or more sources not found"),
-            @ApiResponse(responseCode = "500", description = "Internal server error")
+            @ApiResponse(responseCode = "200", description = "Sources deleted successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Snmp Data Collection deleted successfully"))),
+            @ApiResponse(responseCode = "400", description = "No `id` parameter supplied",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Snmp Data Collection IDs to delete must not be empty"))),
+            @ApiResponse(responseCode = "404", description = "Reported when the delete itself raises an entity-not-found; an unknown id on its own answers 200.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "SnmpCollectionSource with ID 999999 not found"))),
+            @ApiResponse(responseCode = "500", description = "The deletion failed.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Unexpected error occurred\"}")))
     })
     Response deleteSnmpDataCollectionSources(
+            @Parameter(description = "Source id to delete. Repeat the parameter to delete several.", example = "84", required = true)
             @QueryParam("id") List<Integer> ids,
             @Context SecurityContext securityContext
     );
@@ -569,17 +1184,34 @@ public interface DataCollectionConfRestApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Delete MIB Groups for a Source",
-            description = "Delete one or more MIB groups belonging to the specified SNMP data collection source.",
+            description = """
+        Delete one or more MIB groups belonging to the given source. Ids that do not exist are ignored,
+        so a request naming only unknown ids still answers 200. A system definition that still names a
+        deleted MIB group in `mibGroupNames` is not updated.""",
             operationId = "deleteMibGroupsForSource"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "MIB groups deleted successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid request (missing/invalid MIB group IDs or invalid source id)"),
-            @ApiResponse(responseCode = "404", description = "Source and/or MIB groups not found"),
-            @ApiResponse(responseCode = "500", description = "Internal server error")
+            @ApiResponse(responseCode = "200", description = "MIB groups deleted successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Snmp Data Collection Mib Groups deleted successfully"))),
+            @ApiResponse(responseCode = "400", description = "No `id` parameter supplied, or an invalid source id",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "MIB Group IDs to delete must not be empty"))),
+            @ApiResponse(responseCode = "404", description = "Reported when the delete itself raises an entity-not-found; an unknown id on its own answers 200.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "SnmpCollectionSource with ID 999999 not found"))),
+            @ApiResponse(responseCode = "500", description = "The deletion failed.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Unexpected error occurred\"}")))
     })
     Response deleteMibGroupsForSource(
+            @Parameter(description = "Source id owning the MIB groups.", example = "24", required = true)
             @PathParam("snmpDataCollectionSourceId") Integer snmpDataCollectionSourceId,
+            @Parameter(description = "MIB group id to delete. Repeat the parameter to delete several.", example = "343", required = true)
             @QueryParam("id") List<Integer> ids,
             @Context SecurityContext securityContext
     );
@@ -589,17 +1221,33 @@ public interface DataCollectionConfRestApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Delete Resource Types for a Source",
-            description = "Delete one or more resource types belonging to the specified SNMP data collection source.",
+            description = """
+        Delete one or more resource types belonging to the given source. Ids that do not exist are
+        ignored, so a request naming only unknown ids still answers 200.""",
             operationId = "deleteResourceTypesForSource"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Resource types deleted successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid request (missing/invalid resource type IDs or invalid source id)"),
-            @ApiResponse(responseCode = "404", description = "Source and/or resource types not found"),
-            @ApiResponse(responseCode = "500", description = "Internal server error")
+            @ApiResponse(responseCode = "200", description = "Resource types deleted successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Snmp Data Collection Resource Types deleted successfully"))),
+            @ApiResponse(responseCode = "400", description = "No `id` parameter supplied, or an invalid source id",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Resource Type IDs to delete must not be empty"))),
+            @ApiResponse(responseCode = "404", description = "Reported when the delete itself raises an entity-not-found; an unknown id on its own answers 200.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "SnmpCollectionSource with ID 999999 not found"))),
+            @ApiResponse(responseCode = "500", description = "The deletion failed.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Unexpected error occurred\"}")))
     })
     Response deleteResourceTypesForSource(
+            @Parameter(description = "Source id owning the resource types.", example = "24", required = true)
             @PathParam("snmpDataCollectionSourceId") Integer snmpDataCollectionSourceId,
+            @Parameter(description = "Resource type id to delete. Repeat the parameter to delete several.", example = "211", required = true)
             @QueryParam("id") List<Integer> ids,
             @Context SecurityContext securityContext
     );
@@ -609,17 +1257,33 @@ public interface DataCollectionConfRestApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Delete System Definitions for a Source",
-            description = "Delete one or more system definitions belonging to the specified SNMP data collection source.",
+            description = """
+        Delete one or more system definitions belonging to the given source. Ids that do not exist are
+        ignored, so a request naming only unknown ids still answers 200.""",
             operationId = "deleteSystemDefsForSource"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "System definitions deleted successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid request (missing/invalid system definition IDs or invalid source id)"),
-            @ApiResponse(responseCode = "404", description = "Source and/or system definitions not found"),
-            @ApiResponse(responseCode = "500", description = "Internal server error")
+            @ApiResponse(responseCode = "200", description = "System definitions deleted successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Snmp Data Collection System Def deleted successfully"))),
+            @ApiResponse(responseCode = "400", description = "No `id` parameter supplied, or an invalid source id",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "System Def IDs to delete must not be empty"))),
+            @ApiResponse(responseCode = "404", description = "Reported when the delete itself raises an entity-not-found; an unknown id on its own answers 200.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "SnmpCollectionSource with ID 999999 not found"))),
+            @ApiResponse(responseCode = "500", description = "The deletion failed.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = DataCollectionConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\":\"Unexpected error occurred\"}")))
     })
     Response deleteSystemDefsForSource(
+            @Parameter(description = "Source id owning the system definitions.", example = "24", required = true)
             @PathParam("snmpDataCollectionSourceId") Integer snmpDataCollectionSourceId,
+            @Parameter(description = "System definition id to delete. Repeat the parameter to delete several.", example = "219", required = true)
             @QueryParam("id") List<Integer> ids,
             @Context SecurityContext securityContext
     );
@@ -630,15 +1294,27 @@ public interface DataCollectionConfRestApi {
     @Consumes("application/json")
     @Operation(
             summary = "Enable/Disable SNMP Data Collection Sources",
-            description = "Enable or disable one or more SNMP data collection sources",
+            description = """
+        Set the enabled flag on one or more sources. Ids are supplied as repeated `id` query parameters,
+        not as a request body. Ids that do not exist are ignored, so a request naming only unknown ids
+        still answers 200.""",
             operationId = "enableDisableSnmpDataCollectionSources"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Updated successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid request")
+            @ApiResponse(responseCode = "200", description = "Updated successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "SNMP data collection sources updated successfully."))),
+            @ApiResponse(responseCode = "400", description = "No `id` parameter supplied, or an id that is not a positive integer",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "All ids must be non-null positive integers.")))
     })
     Response enableDisableSnmpDataCollectionSources(
+            @Parameter(description = "Target state for every listed source.", example = "false", required = true,
+                    schema = @Schema(type = "boolean", allowableValues = {"true", "false"}))
             @PathParam("enabled") boolean enabled,
+            @Parameter(description = "Source id to update. Repeat the parameter to update several.", example = "24", required = true)
             @QueryParam("id") List<Integer> ids,
             @Context SecurityContext securityContext
     ) throws Exception;
@@ -649,16 +1325,33 @@ public interface DataCollectionConfRestApi {
     @Consumes("application/json")
     @Operation(
             summary = "Enable/Disable SNMP MIB Groups",
-            description = "Enable or disable one or more SNMP MIB groups",
+            description = """
+        Set the enabled flag on one or more MIB groups belonging to the given source. Ids are supplied as
+        repeated `id` query parameters, not as a request body. Ids that do not exist are ignored, so a
+        request naming only unknown ids still answers 200.""",
             operationId = "enableDisableSnmpMibGroups"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Updated successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid request")
+            @ApiResponse(responseCode = "200", description = "Updated successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "SNMP MIB groups updated successfully."))),
+            @ApiResponse(responseCode = "400", description = "Invalid source id, no `id` parameter supplied, or an id that is not a positive integer",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "snmpDataCollectionSourceId must be provided and must be a positive integer."))),
+            @ApiResponse(responseCode = "404", description = "Reported when the update itself raises an entity-not-found; an unknown id on its own answers 200.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Source or one/more ids were not found: ...")))
     })
     Response enableDisableSnmpMibGroups(
+            @Parameter(description = "Source id owning the MIB groups.", example = "24", required = true)
             @PathParam("snmpDataCollectionSourceId") Integer snmpDataCollectionSourceId,
+            @Parameter(description = "Target state for every listed MIB group.", example = "false", required = true,
+                    schema = @Schema(type = "boolean", allowableValues = {"true", "false"}))
             @PathParam("enabled") boolean enabled,
+            @Parameter(description = "MIB group id to update. Repeat the parameter to update several.", example = "343", required = true)
             @QueryParam("id") List<Integer> ids,
             @Context SecurityContext securityContext
     ) throws Exception;
@@ -669,16 +1362,33 @@ public interface DataCollectionConfRestApi {
     @Consumes("application/json")
     @Operation(
             summary = "Enable/Disable SNMP Resource Types",
-            description = "Enable or disable one or more SNMP resource types",
+            description = """
+        Set the enabled flag on one or more resource types belonging to the given source. Ids are
+        supplied as repeated `id` query parameters, not as a request body. Ids that do not exist are
+        ignored, so a request naming only unknown ids still answers 200.""",
             operationId = "enableDisableSnmpResourceTypes"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Updated successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid request")
+            @ApiResponse(responseCode = "200", description = "Updated successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "SNMP resource types updated successfully."))),
+            @ApiResponse(responseCode = "400", description = "Invalid source id, no `id` parameter supplied, or an id that is not a positive integer",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "snmpDataCollectionSourceId must be provided and must be a positive integer."))),
+            @ApiResponse(responseCode = "404", description = "Reported when the update itself raises an entity-not-found; an unknown id on its own answers 200.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Source or one/more ids were not found: ...")))
     })
     Response enableDisableSnmpResourceTypes(
+            @Parameter(description = "Source id owning the resource types.", example = "24", required = true)
             @PathParam("snmpDataCollectionSourceId") Integer snmpDataCollectionSourceId,
+            @Parameter(description = "Target state for every listed resource type.", example = "false", required = true,
+                    schema = @Schema(type = "boolean", allowableValues = {"true", "false"}))
             @PathParam("enabled") boolean enabled,
+            @Parameter(description = "Resource type id to update. Repeat the parameter to update several.", example = "211", required = true)
             @QueryParam("id") List<Integer> ids,
             @Context SecurityContext securityContext
     ) throws Exception;
@@ -690,16 +1400,33 @@ public interface DataCollectionConfRestApi {
     @Consumes("application/json")
     @Operation(
             summary = "Enable/Disable SNMP System Definitions",
-            description = "Enable or disable one or more SNMP system definitions",
+            description = """
+        Set the enabled flag on one or more system definitions belonging to the given source. Ids are
+        supplied as repeated `id` query parameters, not as a request body. Ids that do not exist are
+        ignored, so a request naming only unknown ids still answers 200.""",
             operationId = "enableDisableSnmpSystemDefs"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Updated successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid request")
+            @ApiResponse(responseCode = "200", description = "Updated successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "SNMP system defs updated successfully."))),
+            @ApiResponse(responseCode = "400", description = "Invalid source id, no `id` parameter supplied, or an id that is not a positive integer",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "snmpDataCollectionSourceId must be provided and must be a positive integer."))),
+            @ApiResponse(responseCode = "404", description = "Reported when the update itself raises an entity-not-found; an unknown id on its own answers 200.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Source or one/more ids were not found: ...")))
     })
     Response enableDisableSnmpSystemDefs(
+            @Parameter(description = "Source id owning the system definitions.", example = "24", required = true)
             @PathParam("snmpDataCollectionSourceId") Integer snmpDataCollectionSourceId,
+            @Parameter(description = "Target state for every listed system definition.", example = "false", required = true,
+                    schema = @Schema(type = "boolean", allowableValues = {"true", "false"}))
             @PathParam("enabled") boolean enabled,
+            @Parameter(description = "System definition id to update. Repeat the parameter to update several.", example = "219", required = true)
             @QueryParam("id") List<Integer> ids,
             @Context SecurityContext securityContext
     ) throws Exception;
@@ -711,18 +1438,79 @@ public interface DataCollectionConfRestApi {
     @Operation(
             summary = "Download Snmp Data Collection XML for a Source",
             description = """
-            Downloads all Resource types, Mib groups and System defs associated with the specified snmpDataCollection ID.
-        """,
+        Reassemble one source as a `<datacollection-group>` document carrying its resource types, MIB
+        groups and system definitions, served as an attachment named after the source. Defaults to XML;
+        `format=json` returns the same group as JSON, using the JAXB bean field names
+        (`groups`, `mibObjs`, `clazz`) rather than the XML element names.
+
+        The XML form is what `POST /datacollectionconf/upload` accepts back. Disabled child rows are
+        included, so the download is the stored definition rather than only what collectd would use.
+        Error responses on this endpoint are `<error>` XML regardless of `format`.""",
             operationId = "downloadSnmpDataCollectionById"
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Snmp Data Collection XML downloaded successfully",
-                    content = @Content(mediaType = "application/xml")),
-            @ApiResponse(responseCode = "400", description = "Invalid or missing source ID"),
-            @ApiResponse(responseCode = "404", description = "No snmpDataCollection found for the specified snmpDataCollection ID")
+                    content = {
+                        @Content(mediaType = MediaType.APPLICATION_XML,
+                                schema = @Schema(type = "string"),
+                                examples = @ExampleObject(value = """
+                    <datacollection-group xmlns="http://xmlns.opennms.org/xsd/config/datacollection" name="Cisco">
+                       <resourceType name="cpqDaPhyDrv" label="Compaq Physical Drive" resourceLabel="${index}">
+                          <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
+                          <storageStrategy class="org.opennms.netmgt.dao.support.IndexStorageStrategy"/>
+                       </resourceType>
+                       <group name="cisco-router" ifType="ignore">
+                          <mibObj oid=".1.3.6.1.4.1.9.2.1.58" instance="0" alias="cpu5min" type="gauge"/>
+                       </group>
+                       <systemDef name="Cisco Routers">
+                          <sysoidMask>.1.3.6.1.4.1.9.1.</sysoidMask>
+                          <collect>
+                             <includeGroup>cisco-router</includeGroup>
+                          </collect>
+                       </systemDef>
+                    </datacollection-group>""")),
+                        @Content(mediaType = MediaType.APPLICATION_JSON,
+                                schema = @Schema(type = "object"),
+                                examples = @ExampleObject(value = """
+                    {
+                      "groups" : [ {
+                        "includeGroups" : [ ],
+                        "ifType" : "ignore",
+                        "mibObjs" : [ {
+                          "maxval" : null,
+                          "minval" : null,
+                          "alias" : "cpu5min",
+                          "instance" : "0",
+                          "oid" : ".1.3.6.1.4.1.9.2.1.58",
+                          "type" : "gauge"
+                        } ],
+                        "name" : "cisco-router",
+                        "properties" : [ ]
+                      } ],
+                      "resourceTypes" : [ ],
+                      "systemDefs" : [ ],
+                      "name" : "Cisco"
+                    }"""))
+                    }),
+            @ApiResponse(responseCode = "400", description = "`collectionSourceId` was not a positive integer, or `format` was neither `xml` nor `json`",
+                    content = @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "<error>Invalid format: yaml. Supported values: xml, json</error>"))),
+            @ApiResponse(responseCode = "404", description = "No snmpDataCollection found for the specified snmpDataCollection ID",
+                    content = @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "<error>No Snmp Collection Source found for ID: 999999</error>"))),
+            @ApiResponse(responseCode = "500", description = "The group could not be serialized.",
+                    content = @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "<error>Failed to generate XML: ...</error>")))
     })
     Response downloadSnmpDataCollectionById(
-            @PathParam("collectionSourceId") Integer snmpDataCollectionId, @QueryParam("format") String format,
+            @Parameter(description = "Source id to export. Must be a positive integer.", example = "24", required = true)
+            @PathParam("collectionSourceId") Integer snmpDataCollectionId,
+            @Parameter(description = "Serialization format. Defaults to `xml` when omitted or blank.",
+                    example = "xml", schema = @Schema(allowableValues = {"xml", "json"}))
+            @QueryParam("format") String format,
             @Context SecurityContext securityContext
     ) throws Exception;
 
@@ -732,23 +1520,71 @@ public interface DataCollectionConfRestApi {
     @Operation(
             summary = "Download the top-level datacollection-config",
             description = """
-            Returns the top-level <datacollection-config> assembled from the
-            current profile rows: one <snmp-collection> per enabled profile,
-            with rrd metadata, storage flag, max-vars-per-pdu, and one
-            <include-collection dataCollectionGroup="..."> per source name in
-            the profile's source_names. Pair with /collectsources/{id}/download
-            to obtain the matching <datacollection-group> files. Re-uploadable
-            as a multipart batch via /upload.
-            """,
+        Return the top-level `<datacollection-config>` assembled from the current profile rows: one
+        `<snmp-collection>` per **enabled** profile, with rrd metadata, storage flag, max-vars-per-pdu,
+        and one `<include-collection dataCollectionGroup="..."/>` per source name in the profile's
+        `sourceNames`. Disabled profiles are omitted, matching what collectd loads. The `rrdRepository`
+        attribute is copied from the live in-memory config, and the upload path does not read it back.
+
+        Pair it with `/collectsources/{id}/download` to obtain the matching `<datacollection-group>`
+        files; the whole set is re-uploadable as one multipart batch via `/upload`. Defaults to XML;
+        `format=json` returns the same document using the JAXB bean field names. Error responses are
+        `<error>` XML regardless of `format`.""",
             operationId = "downloadDatacollectionConfig"
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "datacollection-config downloaded",
-                    content = @Content(mediaType = "application/xml")),
-            @ApiResponse(responseCode = "400", description = "Invalid format"),
-            @ApiResponse(responseCode = "500", description = "Marshal error")
+                    content = {
+                        @Content(mediaType = MediaType.APPLICATION_XML,
+                                schema = @Schema(type = "string"),
+                                examples = @ExampleObject(value = """
+                    <datacollection-config xmlns="http://xmlns.opennms.org/xsd/config/datacollection" rrdRepository="/opt/opennms/share/rrd/snmp">
+                       <snmp-collection name="default" snmpStorageFlag="select">
+                          <rrd step="300">
+                             <rra>RRA:AVERAGE:0.5:1:2016</rra>
+                             <rra>RRA:AVERAGE:0.5:12:1488</rra>
+                             <rra>RRA:AVERAGE:0.5:288:366</rra>
+                             <rra>RRA:MAX:0.5:288:366</rra>
+                             <rra>RRA:MIN:0.5:288:366</rra>
+                          </rrd>
+                          <include-collection dataCollectionGroup="MIB2"/>
+                          <include-collection dataCollectionGroup="Cisco"/>
+                       </snmp-collection>
+                    </datacollection-config>""")),
+                        @Content(mediaType = MediaType.APPLICATION_JSON,
+                                schema = @Schema(type = "object"),
+                                examples = @ExampleObject(value = """
+                    {
+                      "snmpCollections" : [ {
+                        "groups" : null,
+                        "rrd" : {
+                          "step" : 300,
+                          "rras" : [ "RRA:AVERAGE:0.5:1:2016", "RRA:AVERAGE:0.5:12:1488" ]
+                        },
+                        "resourceTypes" : [ ],
+                        "includeCollections" : [ {
+                          "excludeFilters" : [ ],
+                          "systemDef" : null,
+                          "dataCollectionGroup" : "MIB2"
+                        } ],
+                        "name" : "default",
+                        "snmpStorageFlag" : "select"
+                      } ],
+                      "rrdRepository" : "/opt/opennms/share/rrd/snmp"
+                    }"""))
+                    }),
+            @ApiResponse(responseCode = "400", description = "`format` was neither `xml` nor `json`",
+                    content = @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "<error>Invalid format: yaml. Supported values: xml, json</error>"))),
+            @ApiResponse(responseCode = "500", description = "The document could not be serialized.",
+                    content = @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "<error>Failed to generate XML: ...</error>")))
     })
     Response downloadDatacollectionConfig(
+            @Parameter(description = "Serialization format. Defaults to `xml` when omitted or blank.",
+                    example = "xml", schema = @Schema(allowableValues = {"xml", "json"}))
             @QueryParam("format") String format,
             @Context SecurityContext securityContext
     ) throws Exception;

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/EventConfRestApi.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/EventConfRestApi.java
@@ -117,7 +117,7 @@ public interface EventConfRestApi {
                         }
                       ]
                     }"""))),
-            @ApiResponse(responseCode = "400", description = "Invalid eventconf.xml or request")
+            @ApiResponse(responseCode = "400", description = "The multipart body has no `upload` part; rejected before the handler with an empty body. A file that fails to parse is not a 400: it is reported inside `errors` with 200.")
     })
     Response uploadEventConfFiles(@Multipart("upload") List<Attachment> attachments,
                                   @Context SecurityContext securityContext) throws Exception;
@@ -268,9 +268,9 @@ public interface EventConfRestApi {
             @Parameter(description = "Case-insensitive substring matched against UEI, event label, and description.",
                     example = "LINK-3")
             @QueryParam("eventFilter") String eventFilter,
-            @Parameter(description = "Sort field: `uei`, `eventLabel`, `description`, or `enabled`. Anything else sorts by `createdTime`.",
+            @Parameter(description = "Sort field: `uei`, `eventLabel`, `description`, `severity`, or `enabled`. Anything else sorts by `createdTime`.",
                     example = "uei",
-                    schema = @Schema(allowableValues = {"uei", "eventLabel", "description", "enabled"}))
+                    schema = @Schema(allowableValues = {"uei", "eventLabel", "description", "severity", "enabled"}))
             @QueryParam("eventSortBy") String eventSortBy,
             @Parameter(description = "Sort direction.", example = "asc",
                     schema = @Schema(allowableValues = {"asc", "desc"}, defaultValue = "desc"))
@@ -400,7 +400,7 @@ public interface EventConfRestApi {
                     content = @Content)
     })
     Response filterEventConfSource(
-            @Parameter(description = "Case-insensitive term matched against name, vendor, and description.", example = "cisco")
+            @Parameter(description = "Case-insensitive term matched against name, vendor, and description, and against the UEIs and event labels of the source's events.", example = "cisco")
             @QueryParam("filter") String filter,
             @Parameter(description = "Sort field: `name`, `vendor`, `description`, `fileOrder`, or `eventCount`. Anything else sorts by `createdTime`.",
                     example = "name", required = true,
@@ -488,7 +488,10 @@ public interface EventConfRestApi {
             @ApiResponse(responseCode = "404", description = "EventConfSource not found",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON,
                             schema = @Schema(type = "string"),
-                            examples = @ExampleObject(value = "Source with ID 17 not found")))})
+                            examples = @ExampleObject(value = "Source with ID 17 not found"))),
+            @ApiResponse(responseCode = "500", description = "The body could not be deserialized (for example the XML spellings sent as JSON), or persisting the event failed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string")))})
     Response addEventConfSourceEvent(
             @Parameter(description = "Identifier of the source the event is added to.", example = "17", required = true)
             @PathParam("sourceId") final Long sourceId,
@@ -588,8 +591,8 @@ public interface EventConfRestApi {
                     content = @Content(mediaType = MediaType.APPLICATION_JSON,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "EventConf events deleted successfully."))),
-            @ApiResponse(responseCode = "400", description = "Invalid request (missing/invalid event IDs)",
-                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+            @ApiResponse(responseCode = "500", description = "Missing or empty event ids. The IllegalArgumentException from the handler is mapped by the generic provider as 500 text/plain, not 400.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
                             schema = @Schema(type = "string"),
                             examples = @ExampleObject(value = "Event IDs to delete must not be null or empty"))),
             @ApiResponse(responseCode = "404", description = "Source or one or more events not found",

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/EventConfRestApi.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/EventConfRestApi.java
@@ -65,9 +65,8 @@ import java.util.List;
         matches is the one applied. Neither the source id nor its name enters into it.
 
         `fileOrder` carries no unique constraint, so two sources can hold the same value. Sources that
-        tie fall back to the order their events were inserted, lowest event id first. That is where the
-        ordering stops being defined by anything but the row ids, so treat a tie as unresolved rather
-        than as a rule to build on, and give a source that has to win a `fileOrder` of its own.""")
+        tie fall back to the order their events were inserted, lowest event id first, an ordering
+        nothing but the row ids defines.""")
 public interface EventConfRestApi {
 
     @POST
@@ -77,7 +76,7 @@ public interface EventConfRestApi {
     @Operation(
             summary = "Upload eventconf files",
             description = """
-        Upload one or more eventconf files including optional eventconf.xml to determine file order.
+        Upload one or more eventconf files, optionally including `eventconf.xml` to set file order.
         Every part must be named `upload`. A part named `eventconf.xml` is not stored as a source: its
         `<event-file>` entries set the search order of the remaining sources instead.
         Files that fail to parse are reported in `errors` while the rest are still stored, so a 200 does
@@ -227,7 +226,7 @@ public interface EventConfRestApi {
         - `eventOrder`: `asc` or `desc` (default: `desc`).
         - `offset` and `limit`: for pagination.
 
-        The response wraps the page in `eventConfSourceList` despite carrying events rather than sources.
+        The response wraps the page in `eventConfSourceList`; the entries are events, not sources.
         `createdTime` and `lastModified` come back as epoch milliseconds, not as the date-time strings the schema shows.""",
             operationId = "filterConfEventBySourceId"
     )
@@ -276,7 +275,7 @@ public interface EventConfRestApi {
             @Parameter(description = "Sort direction.", example = "asc",
                     schema = @Schema(allowableValues = {"asc", "desc"}, defaultValue = "desc"))
             @QueryParam("eventOrder") String eventOrder,
-            @Parameter(description = "Total matching records as already known to the caller. Supply it to skip the count query on subsequent pages.",
+            @Parameter(description = "Total matching records as already known to the caller. When present, the count query is not run.",
                     example = "132")
             @QueryParam("totalRecords") Integer totalRecords,
             @Parameter(description = "Zero-based index of the first record to return.", example = "0")
@@ -327,7 +326,6 @@ public interface EventConfRestApi {
     @Operation(
             summary = "Update EventConf Sources events",
             description = """
-        Update one or more eventConf sources  by their events IDs.
         Sets the enabled flag on the listed events of one source and reloads the event definitions.
         eventsIds that do not exist are ignored rather than reported.""",
             operationId = "enableDisableConfSourcesEvents"
@@ -368,8 +366,8 @@ public interface EventConfRestApi {
             description = """
         Fetch EventConfSource records based on provided filters such as name, vendor, description, fileOrder and eventCount.
         `filter` is a single case-insensitive term matched across those fields.
-        `sortBy` has to be supplied: without it the response carries the right `totalRecords`
-        and an empty `eventConfSourceList`. Any value works, valid or not.""",
+        `sortBy` has to be supplied: without it the response carries the correct `totalRecords` and an
+        empty `eventConfSourceList`. Any value is accepted; an unrecognised one sorts by `createdTime`.""",
             operationId = "filterEventConfSource"
     )
     @ApiResponses(value = {
@@ -404,14 +402,14 @@ public interface EventConfRestApi {
     Response filterEventConfSource(
             @Parameter(description = "Case-insensitive term matched against name, vendor, and description.", example = "cisco")
             @QueryParam("filter") String filter,
-            @Parameter(description = "Sort field: `name`, `vendor`, `description`, `fileOrder`, or `eventCount`. Anything else sorts by `createdTime`, but the parameter cannot be left out.",
+            @Parameter(description = "Sort field: `name`, `vendor`, `description`, `fileOrder`, or `eventCount`. Anything else sorts by `createdTime`.",
                     example = "name", required = true,
                     schema = @Schema(allowableValues = {"name", "vendor", "description", "fileOrder", "eventCount"}))
             @QueryParam("sortBy") String sortBy,
             @Parameter(description = "Sort direction.", example = "asc",
                     schema = @Schema(allowableValues = {"asc", "desc"}, defaultValue = "desc"))
             @QueryParam("order") String order,
-            @Parameter(description = "Total matching records as already known to the caller. Supply it to skip the count query on subsequent pages.",
+            @Parameter(description = "Total matching records as already known to the caller. When present, the count query is not run.",
                     example = "41")
             @QueryParam("totalRecords") Integer totalRecords,
             @Parameter(description = "Zero-based index of the first record to return.", example = "0")
@@ -535,10 +533,10 @@ public interface EventConfRestApi {
     @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     @Produces("application/json")
     @Operation(
-            summary = "Update EventConf  Event",
+            summary = "Update EventConf Event",
             description = """
-        Update  eventConf event by sourceId and eventId.
-        `event` is required: the whole definition is replaced from it, and `enabled` rides along.
+        Update an eventConf event by sourceId and eventId.
+        `event` is required: the whole definition is replaced from it, and `enabled` is applied with it.
         A body carrying only `enabled` fails with a 500, as does an unknown sourceId or eventId.""",
             operationId = "updateEventConfEvent"
     )
@@ -753,9 +751,9 @@ public interface EventConfRestApi {
     @Consumes({MediaType.APPLICATION_JSON})
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
-            summary = "Add a new  EventConfSource",
+            summary = "Add a new EventConfSource",
             description = """
-        Creates and adds a new  EventConfSource.
+        Creates and adds a new EventConfSource.
         The source starts empty and enabled, and is assigned the highest `fileOrder` so it is searched first.""",
             operationId = "addEventConfSource")
     @ApiResponses(value = {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/EventConfRestApi.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/EventConfRestApi.java
@@ -10,17 +10,30 @@
  */
 package org.opennms.web.rest.v2.api;
 
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+import org.opennms.netmgt.model.EventConfEventDto;
 import org.opennms.netmgt.model.events.EnableDisableConfSourceEventsPayload;
 import org.opennms.netmgt.model.events.EventConfSourceDeletePayload;
 import org.opennms.web.rest.v2.model.AddEventConfSourceRequest;
+import org.opennms.web.rest.v2.model.EventConfErrorResponse;
 import org.opennms.web.rest.v2.model.EventConfEventEditRequest;
+import org.opennms.web.rest.v2.model.EventConfEventPageResponse;
+import org.opennms.web.rest.v2.model.EventConfSourceCreatedResponse;
+import org.opennms.web.rest.v2.model.EventConfSourceDto;
+import org.opennms.web.rest.v2.model.EventConfSourcePageResponse;
+import org.opennms.web.rest.v2.model.EventConfUploadResponse;
+import org.opennms.web.rest.v2.model.SourceNameDto;
 import org.opennms.netmgt.xml.eventconf.Event;
 import org.opennms.netmgt.model.events.EventConfSrcEnableDisablePayload;
 import org.opennms.web.rest.v2.model.EventConfEventDeletePayload;
@@ -43,7 +56,18 @@ import javax.ws.rs.core.SecurityContext;
 import java.util.List;
 
 @Path("eventconf")
-@Tag(name = "EventConf", description = "EventConf API")
+@Tag(name = "EventConf", description = """
+        EventConf API.
+
+        Event definitions live in the database, grouped into sources that each stand for one event
+        configuration file. When two sources define the same event, the source with the higher
+        `fileOrder` wins: sources are loaded highest-`fileOrder`-first and the first definition that
+        matches is the one applied. Neither the source id nor its name enters into it.
+
+        `fileOrder` carries no unique constraint, so two sources can hold the same value. Sources that
+        tie fall back to the order their events were inserted, lowest event id first. That is where the
+        ordering stops being defined by anything but the row ids, so treat a tie as unresolved rather
+        than as a rule to build on, and give a source that has to win a `fileOrder` of its own.""")
 public interface EventConfRestApi {
 
     @POST
@@ -52,11 +76,48 @@ public interface EventConfRestApi {
     @Produces("application/json")
     @Operation(
             summary = "Upload eventconf files",
-            description = "Upload one or more eventconf files including optional eventconf.xml to determine file order.",
+            description = """
+        Upload one or more eventconf files including optional eventconf.xml to determine file order.
+        Every part must be named `upload`. A part named `eventconf.xml` is not stored as a source: its
+        `<event-file>` entries set the search order of the remaining sources instead.
+        Files that fail to parse are reported in `errors` while the rest are still stored, so a 200 does
+        not by itself mean every file was accepted.""",
             operationId = "uploadEventConfFiles"
     )
+    @RequestBody(
+            required = true,
+            description = "Multipart form with one `upload` part per eventconf file.",
+            content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA,
+                    schema = @Schema(type = "string", format = "binary"))
+    )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Upload successful"),
+            @ApiResponse(responseCode = "200", description = "Upload processed. Per-file outcomes are split between `success` and `errors`.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = EventConfUploadResponse.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "success": [
+                        {
+                          "file": "Cisco.syslog.events",
+                          "eventCount": 2,
+                          "vendor": "Cisco",
+                          "events": [
+                            {
+                              "uei": "uei.opennms.org/vendor/cisco/syslog/LINK-3-UPDOWN",
+                              "label": "Cisco Syslog: LINK-3-UPDOWN",
+                              "description": "Cisco Syslog: LINK-3-UPDOWN",
+                              "enabled": true
+                            }
+                          ]
+                        }
+                      ],
+                      "errors": [
+                        {
+                          "file": "Broken.events",
+                          "error": "UnmarshalException: unexpected element (uri:\\"\\", local:\\"evnts\\")"
+                        }
+                      ]
+                    }"""))),
             @ApiResponse(responseCode = "400", description = "Invalid eventconf.xml or request")
     })
     Response uploadEventConfFiles(@Multipart("upload") List<Attachment> attachments,
@@ -67,22 +128,49 @@ public interface EventConfRestApi {
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     @Operation(
             summary = "Filter EventConf Records",
-            description = "Fetch EventConf records based on provided filters such as UEI, vendor, source and name.",
+            description = """
+        Fetch EventConf records based on provided filters such as UEI, vendor, source and name.
+        Each filter is optional; omitted filters are not applied. `limit` must be at least 1.
+        `createdTime` and `lastModified` come back as epoch milliseconds, not as the date-time strings the schema shows.""",
             operationId = "filterEventConf"
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "EventConf records retrieved successfully",
-                    content = @Content),
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            array = @ArraySchema(schema = @Schema(implementation = EventConfEventDto.class)),
+                            examples = @ExampleObject(value = """
+                    [
+                      {
+                        "id": 4211,
+                        "uei": "uei.opennms.org/vendor/cisco/syslog/LINK-3-UPDOWN",
+                        "eventLabel": "Cisco Syslog: LINK-3-UPDOWN",
+                        "description": "Interface state change reported by a Cisco device.",
+                        "enabled": true,
+                        "xmlContent": "<event xmlns=\\"http://xmlns.opennms.org/xsd/eventconf\\">...</event>",
+                        "createdTime": 1787670300817,
+                        "lastModified": 1787670300817,
+                        "modifiedBy": "admin",
+                        "sourceName": "Cisco.syslog.events",
+                        "vendor": "Cisco",
+                        "fileOrder": 24,
+                        "severity": "Warning"
+                      }
+                    ]"""))),
             @ApiResponse(responseCode = "400", description = "Bad Request – invalid or missing input parameters",
                     content = @Content),
             @ApiResponse(responseCode = "204", description = "No matching EventConf records found for the given criteria",
                     content = @Content)
     })
     Response filterEventConf(
+            @Parameter(description = "Exact UEI to match.", example = "uei.opennms.org/vendor/cisco/syslog/LINK-3-UPDOWN")
             @QueryParam("uei") String uei,
+            @Parameter(description = "Vendor to match.", example = "Cisco")
             @QueryParam("vendor") String vendor,
+            @Parameter(description = "Source name to match.", example = "Cisco.syslog.events")
             @QueryParam("sourceName") String sourceName,
+            @Parameter(description = "Zero-based index of the first record to return.", example = "0")
             @QueryParam("offset") int offset,
+            @Parameter(description = "Maximum number of records to return.", example = "20")
             @QueryParam("limit") int limit,
             @Context SecurityContext securityContext );
 
@@ -92,14 +180,40 @@ public interface EventConfRestApi {
     @Consumes("application/json")
     @Operation(
             summary = "Enable/Disable EventConf Sources",
-            description = "Enable or disable one or more sources (and optionally cascade to their events)",
+            description = """
+        Enable or disable one or more sources, cascading to their events when asked.
+        `cascadeToEvents` has to be present: omitting it fails with a 500.
+        sourceIds that do not exist are ignored rather than reported.
+        The event definitions are reloaded into memory once the update commits.""",
             operationId = "enableDisableEventConfSources"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Updated successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid request")
+            @ApiResponse(responseCode = "200", description = "Updated successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "EventConf sources updated successfully."))),
+            @ApiResponse(responseCode = "400", description = "Invalid request: missing body, missing `enabled`, or empty `sourceIds`",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "At least one sourceId must be provided."))),
+            @ApiResponse(responseCode = "500", description = "Update failed, including when `cascadeToEvents` is absent",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Unexpected error occurred: Cannot invoke \"java.lang.Boolean.booleanValue()\"")))
     })
-    Response enableDisableEventConfSources(EventConfSrcEnableDisablePayload eventConfSrcEnableDisablePayload, @Context SecurityContext securityContext) throws Exception;
+    Response enableDisableEventConfSources(
+            @RequestBody(required = true,
+                    description = "Sources to update and the state to set. All three members are required.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = EventConfSrcEnableDisablePayload.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "enabled": false,
+                      "cascadeToEvents": true,
+                      "sourceIds": [17, 18]
+                    }""")))
+            EventConfSrcEnableDisablePayload eventConfSrcEnableDisablePayload,
+            @Context SecurityContext securityContext) throws Exception;
 
     @GET
     @Path("filter/{sourceId}/events")
@@ -111,24 +225,63 @@ public interface EventConfRestApi {
         - `eventFilter`: case-insensitive match on UEI, Event Label, or Description.
         - `eventSortBy`: sort field `uei`, `eventLabel`, `description`, `enabled` defaults to `createdTime` if invalid.
         - `eventOrder`: `asc` or `desc` (default: `desc`).
-        - `offset` and `limit`: for pagination.""",
+        - `offset` and `limit`: for pagination.
+
+        The response wraps the page in `eventConfSourceList` despite carrying events rather than sources.
+        `createdTime` and `lastModified` come back as epoch milliseconds, not as the date-time strings the schema shows.""",
             operationId = "filterConfEventBySourceId"
     )
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "EventConf records retrieved successfully",
-                content = @Content),
+                content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                        schema = @Schema(implementation = EventConfEventPageResponse.class),
+                        examples = @ExampleObject(value = """
+                {
+                  "totalRecords": 132,
+                  "eventConfSourceList": [
+                    {
+                      "id": 4211,
+                      "uei": "uei.opennms.org/vendor/cisco/syslog/LINK-3-UPDOWN",
+                      "eventLabel": "Cisco Syslog: LINK-3-UPDOWN",
+                      "description": "Interface state change reported by a Cisco device.",
+                      "enabled": true,
+                      "xmlContent": "<event xmlns=\\"http://xmlns.opennms.org/xsd/eventconf\\">...</event>",
+                      "createdTime": 1787670300817,
+                      "lastModified": 1787670300817,
+                      "modifiedBy": "admin",
+                      "sourceName": "Cisco.syslog.events",
+                      "vendor": "Cisco",
+                      "fileOrder": 24,
+                      "severity": "Warning"
+                    }
+                  ]
+                }"""))),
         @ApiResponse(responseCode = "400", description = "Bad Request – invalid or missing input parameters",
-                content = @Content),
+                content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                        schema = @Schema(implementation = EventConfErrorResponse.class),
+                        examples = @ExampleObject(value = "{\"error\": \"Invalid sourceId/offset/limit values\"}"))),
         @ApiResponse(responseCode = "204", description = "No matching EventConfEvent record found for the given criteria",
                 content = @Content)
     })
     Response filterConfEventsBySourceId(
+            @Parameter(description = "Identifier of the source whose events are listed.", example = "17", required = true)
             @PathParam("sourceId") Long sourceId,
+            @Parameter(description = "Case-insensitive substring matched against UEI, event label, and description.",
+                    example = "LINK-3")
             @QueryParam("eventFilter") String eventFilter,
+            @Parameter(description = "Sort field: `uei`, `eventLabel`, `description`, or `enabled`. Anything else sorts by `createdTime`.",
+                    example = "uei",
+                    schema = @Schema(allowableValues = {"uei", "eventLabel", "description", "enabled"}))
             @QueryParam("eventSortBy") String eventSortBy,
+            @Parameter(description = "Sort direction.", example = "asc",
+                    schema = @Schema(allowableValues = {"asc", "desc"}, defaultValue = "desc"))
             @QueryParam("eventOrder") String eventOrder,
+            @Parameter(description = "Total matching records as already known to the caller. Supply it to skip the count query on subsequent pages.",
+                    example = "132")
             @QueryParam("totalRecords") Integer totalRecords,
+            @Parameter(description = "Zero-based index of the first record to return.", example = "0")
             @QueryParam("offset") Integer offset,
+            @Parameter(description = "Maximum number of records to return.", example = "20")
             @QueryParam("limit") Integer limit,
             @Context SecurityContext securityContext );
 
@@ -139,16 +292,33 @@ public interface EventConfRestApi {
     @Produces("application/json")
     @Operation(
             summary = "Delete EventConf Sources",
-            description = "Delete one or more eventConf sources by their IDs.",
+            description = """
+        Delete one or more eventConf sources by their IDs.
+        Deleting a source also removes the events it holds.
+        sourceIds that do not exist are ignored rather than reported.""",
             operationId = "deleteEventConfSources"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Sources deleted successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid request (missing/invalid IDs)"),
-            @ApiResponse(responseCode = "404", description = "One or more sources not found")
+            @ApiResponse(responseCode = "200", description = "Sources deleted successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "EventConf sources deleted successfully."))),
+            @ApiResponse(responseCode = "400", description = "Invalid request (missing/invalid IDs)",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "At least one sourceId must be provided."))),
+            @ApiResponse(responseCode = "500", description = "Delete failed",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string")))
     })
-    Response deleteEventConfSources(EventConfSourceDeletePayload eventConfSourceDeletePayload,
-                                    @Context SecurityContext securityContext) throws Exception;
+    Response deleteEventConfSources(
+            @RequestBody(required = true,
+                    description = "Sources to delete.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = EventConfSourceDeletePayload.class),
+                            examples = @ExampleObject(value = "{\"sourceIds\": [17, 18]}")))
+            EventConfSourceDeletePayload eventConfSourceDeletePayload,
+            @Context SecurityContext securityContext) throws Exception;
 
     @PATCH
     @Path("/sources/{sourceId}/events/status")
@@ -156,38 +326,97 @@ public interface EventConfRestApi {
     @Produces("application/json")
     @Operation(
             summary = "Update EventConf Sources events",
-            description = "Update one or more eventConf sources  by their events IDs.",
+            description = """
+        Update one or more eventConf sources  by their events IDs.
+        Sets the enabled flag on the listed events of one source and reloads the event definitions.
+        eventsIds that do not exist are ignored rather than reported.""",
             operationId = "enableDisableConfSourcesEvents"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Updated successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid request (missing/invalid IDs)"),
-            @ApiResponse(responseCode = "404", description = "One or more sources not found")
+            @ApiResponse(responseCode = "200", description = "Updated successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "EventConfEvents updated successfully."))),
+            @ApiResponse(responseCode = "400", description = "Invalid request (missing/invalid IDs)",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "At least one eventConfEventsIds must be provided."))),
+            @ApiResponse(responseCode = "500", description = "Update failed",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string")))
     })
-    Response enableDisableEventConfSourcesEvents(@PathParam("sourceId") final Long sourceId,EnableDisableConfSourceEventsPayload enableDisableConfSourceEventsPayload,
-                                    @Context SecurityContext securityContext) throws Exception;
+    Response enableDisableEventConfSourcesEvents(
+            @Parameter(description = "Identifier of the source owning the events.", example = "17", required = true)
+            @PathParam("sourceId") final Long sourceId,
+            @RequestBody(required = true,
+                    description = "Events to update and the state to set. Note the field is `enable`, not `enabled`.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = EnableDisableConfSourceEventsPayload.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "enable": true,
+                      "eventsIds": [4211, 4212]
+                    }""")))
+            EnableDisableConfSourceEventsPayload enableDisableConfSourceEventsPayload,
+            @Context SecurityContext securityContext) throws Exception;
+
     @GET
     @Path("filter/sources")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Filter EventConfSource Records",
-            description = "Fetch EventConfSource records based on provided filters such as name, vendor, description, fileOrder and eventCount.",
+            description = """
+        Fetch EventConfSource records based on provided filters such as name, vendor, description, fileOrder and eventCount.
+        `filter` is a single case-insensitive term matched across those fields.
+        `sortBy` has to be supplied: without it the response carries the right `totalRecords`
+        and an empty `eventConfSourceList`. Any value works, valid or not.""",
             operationId = "filterEventConfSource"
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "EventConfSource records retrieved successfully",
-                    content = @Content),
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = EventConfSourcePageResponse.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "totalRecords": 41,
+                      "eventConfSourceList": [
+                        {
+                          "id": 17,
+                          "name": "Cisco.syslog.events",
+                          "description": "Syslog events forwarded by Cisco IOS devices",
+                          "vendor": "Cisco",
+                          "fileOrder": 24,
+                          "enabled": true,
+                          "eventCount": 132,
+                          "createdTime": 1787670300817,
+                          "lastModified": 1787670354466,
+                          "uploadedBy": "admin"
+                        }
+                      ]
+                    }"""))),
             @ApiResponse(responseCode = "400", description = "Bad Request – invalid or missing input parameters",
-                    content = @Content),
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = EventConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\": \"Invalid offset/limit values\"}"))),
             @ApiResponse(responseCode = "204", description = "No matching EventConfSource records found for the given criteria",
                     content = @Content)
     })
     Response filterEventConfSource(
+            @Parameter(description = "Case-insensitive term matched against name, vendor, and description.", example = "cisco")
             @QueryParam("filter") String filter,
+            @Parameter(description = "Sort field: `name`, `vendor`, `description`, `fileOrder`, or `eventCount`. Anything else sorts by `createdTime`, but the parameter cannot be left out.",
+                    example = "name", required = true,
+                    schema = @Schema(allowableValues = {"name", "vendor", "description", "fileOrder", "eventCount"}))
             @QueryParam("sortBy") String sortBy,
+            @Parameter(description = "Sort direction.", example = "asc",
+                    schema = @Schema(allowableValues = {"asc", "desc"}, defaultValue = "desc"))
             @QueryParam("order") String order,
+            @Parameter(description = "Total matching records as already known to the caller. Supply it to skip the count query on subsequent pages.",
+                    example = "41")
             @QueryParam("totalRecords") Integer totalRecords,
+            @Parameter(description = "Zero-based index of the first record to return.", example = "0")
             @QueryParam("offset") Integer offset,
+            @Parameter(description = "Maximum number of records to return.", example = "20")
             @QueryParam("limit") Integer limit,
             @Context SecurityContext securityContext );
 
@@ -202,8 +431,15 @@ public interface EventConfRestApi {
             operationId = "getEventConfSourcesNames"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Successfully retrieved source names"),
-            @ApiResponse(responseCode = "500", description = "Internal server error")
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved source names",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            array = @ArraySchema(schema = @Schema(type = "string")),
+                            examples = @ExampleObject(value = """
+                    ["Cisco.syslog.events", "Juniper.traps.events", "opennms.catch-all.events"]"""))),
+            @ApiResponse(responseCode = "500", description = "Internal server error",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Failed to fetch EventConf source names: ...")))
     })
     Response getEventConfSourcesNames(@Context SecurityContext securityContext) throws Exception;
 
@@ -216,8 +452,18 @@ public interface EventConfRestApi {
             operationId = "getEventConfSourceNamesAndIds"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Successfully retrieved source names and IDs"),
-            @ApiResponse(responseCode = "500", description = "Internal server error")
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved source names and IDs",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            array = @ArraySchema(schema = @Schema(implementation = SourceNameDto.class)),
+                            examples = @ExampleObject(value = """
+                    [
+                      {"id": 17, "name": "Cisco.syslog.events"},
+                      {"id": 18, "name": "Juniper.traps.events"}
+                    ]"""))),
+            @ApiResponse(responseCode = "500", description = "Internal server error",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Failed to fetch EventConf source names and IDs: ...")))
     })
     Response getEventConfSourceNamesAndIds(@Context SecurityContext securityContext) throws Exception;
 
@@ -227,13 +473,60 @@ public interface EventConfRestApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Add a new event to an EventConfSource",
-            description = "Creates and adds a new event under the given EventConfSource by its ID.",
+            description = """
+        Creates and adds a new event under the given EventConfSource by its ID.
+        `uei`, `event-label`, and `severity` are required; the remaining members follow the eventconf schema.
+        The response body is the new event's identifier.""",
             operationId = "addEventConfSourceEvent")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "Event created successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid request (missing/invalid data)"),
-            @ApiResponse(responseCode = "404", description = "EventConfSource not found")})
-    Response addEventConfSourceEvent(@PathParam("sourceId") final Long sourceId, Event event, @Context SecurityContext securityContext) throws Exception;
+            @ApiResponse(responseCode = "201", description = "Event created successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "integer", format = "int64"),
+                            examples = @ExampleObject(value = "4213"))),
+            @ApiResponse(responseCode = "400", description = "Invalid request (missing/invalid data)",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Invalid event payload: Event 'severity' is required"))),
+            @ApiResponse(responseCode = "404", description = "EventConfSource not found",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Source with ID 17 not found")))})
+    Response addEventConfSourceEvent(
+            @Parameter(description = "Identifier of the source the event is added to.", example = "17", required = true)
+            @PathParam("sourceId") final Long sourceId,
+            @RequestBody(required = true,
+                    description = """
+                            Event definition, using the same structure as an <event> element in an eventconf file.
+                            The JSON form goes through Jackson rather than JAXB, so `logmsg.dest` takes the enum
+                            constant name (`LOGNDISPLAY`) and the message text is `logmsg.value`; the XML form takes
+                            the eventconf spellings. Sending the XML spellings as JSON fails with a 500.""",
+                    content = {
+                            @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = Event.class),
+                                    examples = @ExampleObject(value = """
+                            {
+                              "uei": "uei.opennms.org/vendor/cisco/syslog/LINK-3-UPDOWN",
+                              "event-label": "Cisco Syslog: LINK-3-UPDOWN",
+                              "severity": "Warning",
+                              "descr": "Interface state change reported by a Cisco device.",
+                              "logmsg": {
+                                "dest": "LOGNDISPLAY",
+                                "value": "Interface state change on %interface%."
+                              }
+                            }""")),
+                            @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = Event.class),
+                                    examples = @ExampleObject(value = """
+                            <event xmlns="http://xmlns.opennms.org/xsd/eventconf">
+                              <uei>uei.opennms.org/vendor/cisco/syslog/LINK-3-UPDOWN</uei>
+                              <event-label>Cisco Syslog: LINK-3-UPDOWN</event-label>
+                              <descr>Interface state change reported by a Cisco device.</descr>
+                              <logmsg dest="logndisplay">Interface state change on %interface%.</logmsg>
+                              <severity>Warning</severity>
+                            </event>"""))
+                    })
+            Event event,
+            @Context SecurityContext securityContext) throws Exception;
 
 
 
@@ -243,16 +536,46 @@ public interface EventConfRestApi {
     @Produces("application/json")
     @Operation(
             summary = "Update EventConf  Event",
-            description = "Update  eventConf event by sourceId and eventId.",
+            description = """
+        Update  eventConf event by sourceId and eventId.
+        `event` is required: the whole definition is replaced from it, and `enabled` rides along.
+        A body carrying only `enabled` fails with a 500, as does an unknown sourceId or eventId.""",
             operationId = "updateEventConfEvent"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Updated successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid request"),
-            @ApiResponse(responseCode = "404", description = "One or more sources not found")
+            @ApiResponse(responseCode = "200", description = "Updated successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "EventConfEvent updated successfully."))),
+            @ApiResponse(responseCode = "400", description = "Invalid request",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Request body cannot be null"))),
+            @ApiResponse(responseCode = "500", description = "Update failed, including when the event does not exist or the body omits `event`",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Unexpected error occurred: Failed to update EventConfEvent XML for eventId=4211")))
     })
-    Response updateEventConfEvent(@PathParam("sourceId") final Long sourceId,@PathParam("eventId") final Long eventId, EventConfEventEditRequest payload,
-                                  @Context SecurityContext securityContext) throws Exception;
+    Response updateEventConfEvent(
+            @Parameter(description = "Identifier of the source owning the event.", example = "17", required = true)
+            @PathParam("sourceId") final Long sourceId,
+            @Parameter(description = "Identifier of the event to update.", example = "4211", required = true)
+            @PathParam("eventId") final Long eventId,
+            @RequestBody(required = true,
+                    description = "Replacement event definition. `event` must be present.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = EventConfEventEditRequest.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "enabled": true,
+                              "event": {
+                                "uei": "uei.opennms.org/vendor/cisco/syslog/LINK-3-UPDOWN",
+                                "event-label": "Cisco Syslog: LINK-3-UPDOWN",
+                                "severity": "Minor"
+                              }
+                            }""")))
+            EventConfEventEditRequest payload,
+            @Context SecurityContext securityContext) throws Exception;
     @DELETE
     @Path("/sources/{sourceId}/events")
     @Consumes(MediaType.APPLICATION_JSON)
@@ -263,12 +586,27 @@ public interface EventConfRestApi {
             operationId = "deleteEventsForSource"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Events deleted successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid request (missing/invalid event IDs)"),
-            @ApiResponse(responseCode = "404", description = "Source or one or more events not found")
+            @ApiResponse(responseCode = "200", description = "Events deleted successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "EventConf events deleted successfully."))),
+            @ApiResponse(responseCode = "400", description = "Invalid request (missing/invalid event IDs)",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Event IDs to delete must not be null or empty"))),
+            @ApiResponse(responseCode = "404", description = "Source or one or more events not found",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "One or more eventIds were not found: 9999")))
     })
     Response deleteEventsForSource(
+            @Parameter(description = "Identifier of the source owning the events.", example = "17", required = true)
             @PathParam("sourceId") Long sourceId,
+            @RequestBody(required = true,
+                    description = "Events to delete.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = EventConfEventDeletePayload.class),
+                            examples = @ExampleObject(value = "{\"eventIds\": [4211, 4212]}")))
             EventConfEventDeletePayload eventConfEventDeletePayload,
             @Context SecurityContext securityContext
     ) throws Exception;
@@ -282,13 +620,38 @@ public interface EventConfRestApi {
             operationId = "getEventConfSourceById"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "EventConfSource retrieved successfully"),
-            @ApiResponse(responseCode = "404", description = "EventConfSource not found"),
-            @ApiResponse(responseCode = "400", description = "Bad request"),
-            @ApiResponse(responseCode = "500", description = "Internal server error")
+            @ApiResponse(responseCode = "200", description = "EventConfSource retrieved successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = EventConfSourceDto.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "id": 17,
+                      "name": "Cisco.syslog.events",
+                      "description": "Syslog events forwarded by Cisco IOS devices",
+                      "vendor": "Cisco",
+                      "fileOrder": 24,
+                      "enabled": true,
+                      "eventCount": 132,
+                      "createdTime": 1787670300817,
+                      "lastModified": 1787670354466,
+                      "uploadedBy": "admin"
+                    }"""))),
+            @ApiResponse(responseCode = "404", description = "EventConfSource not found",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = EventConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\": \"EventConfSource not found for id: 17\"}"))),
+            @ApiResponse(responseCode = "400", description = "Bad request",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = EventConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\": \"Invalid sourceId provided\"}"))),
+            @ApiResponse(responseCode = "500", description = "Internal server error",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = EventConfErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"error\": \"Unexpected error occurred: ...\"}")))
 
     })
     Response getEventConfSourceById(
+            @Parameter(description = "Identifier of the source to retrieve.", example = "17", required = true)
             @PathParam("sourceId") Long sourceId,
             @Context SecurityContext securityContext
     );
@@ -301,16 +664,35 @@ public interface EventConfRestApi {
             summary = "Download EventConf XML for a Source",
             description = """
             Downloads all EventConf events associated with the specified source ID.
+            The body is an eventconf `<events>` document, returned as an attachment named after the source.
         """,
             operationId = "downloadEventConfXmlBySourceId"
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "EventConf XML downloaded successfully",
-                    content = @Content(mediaType = "application/xml")),
-            @ApiResponse(responseCode = "400", description = "Invalid or missing source ID"),
-            @ApiResponse(responseCode = "404", description = "No events found for the specified source ID")
+                    content = @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(type = "string", format = "binary"),
+                            examples = @ExampleObject(value = """
+                    <events xmlns="http://xmlns.opennms.org/xsd/eventconf">
+                      <event>
+                        <uei>uei.opennms.org/vendor/cisco/syslog/LINK-3-UPDOWN</uei>
+                        <event-label>Cisco Syslog: LINK-3-UPDOWN</event-label>
+                        <descr>Interface state change reported by a Cisco device.</descr>
+                        <logmsg dest="logndisplay">Interface state change on %interface%.</logmsg>
+                        <severity>Warning</severity>
+                      </event>
+                    </events>"""))),
+            @ApiResponse(responseCode = "400", description = "Invalid or missing source ID",
+                    content = @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "<error>Invalid source ID</error>"))),
+            @ApiResponse(responseCode = "404", description = "No events found for the specified source ID",
+                    content = @Content(mediaType = MediaType.APPLICATION_XML,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "<error>No events found for source ID: 17</error>")))
     })
     Response downloadEventConfXmlBySourceId(
+            @Parameter(description = "Identifier of the source to export.", example = "17", required = true)
             @PathParam("sourceId") Long sourceId,
             @Context SecurityContext securityContext
     ) throws Exception;
@@ -320,17 +702,48 @@ public interface EventConfRestApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Get EventConf Events by Vendor",
-            description = "Returns all EventConf events associated with the specified vendor name.",
+            description = """
+        Returns all EventConf events associated with the specified vendor name.
+        `createdTime` and `lastModified` come back as epoch milliseconds, not as the date-time strings the schema shows.""",
             operationId = "getEventsByVendor"
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "EventConf Events retrieved successfully",
-                    content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "400", description = "Invalid or missing vendor name"),
-            @ApiResponse(responseCode = "404", description = "No events found for the specified vendor"),
-            @ApiResponse(responseCode = "500", description = "Internal server error")
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            array = @ArraySchema(schema = @Schema(implementation = EventConfEventDto.class)),
+                            examples = @ExampleObject(value = """
+                    [
+                      {
+                        "id": 4211,
+                        "uei": "uei.opennms.org/vendor/cisco/syslog/LINK-3-UPDOWN",
+                        "eventLabel": "Cisco Syslog: LINK-3-UPDOWN",
+                        "description": "Interface state change reported by a Cisco device.",
+                        "enabled": true,
+                        "xmlContent": "<event xmlns=\\"http://xmlns.opennms.org/xsd/eventconf\\">...</event>",
+                        "createdTime": 1787670300817,
+                        "lastModified": 1787670300817,
+                        "modifiedBy": "admin",
+                        "sourceName": "Cisco.syslog.events",
+                        "vendor": "Cisco",
+                        "fileOrder": 24,
+                        "severity": "Warning"
+                      }
+                    ]"""))),
+            @ApiResponse(responseCode = "400", description = "Invalid or missing vendor name",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Vendor name must not be null or blank"))),
+            @ApiResponse(responseCode = "404", description = "No events found for the specified vendor",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "No events found for vendor: Cisco"))),
+            @ApiResponse(responseCode = "500", description = "Internal server error",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error while retrieving events for vendor: Cisco. Cause: ...")))
     })
     Response getEventsByVendor(
+            @Parameter(description = "Vendor name to match.", example = "Cisco", required = true)
             @PathParam("vendorName") String vendorName,
             @Context SecurityContext securityContext
     ) throws Exception;
@@ -341,12 +754,44 @@ public interface EventConfRestApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Add a new  EventConfSource",
-            description = "Creates and adds a new  EventConfSource.",
-            operationId = "addEventConfSourceEvent")
+            description = """
+        Creates and adds a new  EventConfSource.
+        The source starts empty and enabled, and is assigned the highest `fileOrder` so it is searched first.""",
+            operationId = "addEventConfSource")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "EventConfSource created successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid request (missing/invalid data)"),
-            @ApiResponse(responseCode = "500", description = "Internal server error")})
-    Response addEventConfSource(final AddEventConfSourceRequest request, @Context SecurityContext securityContext) throws Exception;
+            @ApiResponse(responseCode = "201", description = "EventConfSource created successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = EventConfSourceCreatedResponse.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "id": 42,
+                      "name": "Cisco.syslog.events",
+                      "fileOrder": 25
+                    }"""))),
+            @ApiResponse(responseCode = "400", description = "Invalid request (missing/invalid data)",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Invalid request: Source name must not be null or blank."))),
+            @ApiResponse(responseCode = "409", description = "A source with the same name already exists",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "An EventConfSource with the same name already exists"))),
+            @ApiResponse(responseCode = "500", description = "Internal server error",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Unexpected error occurred while creating EventConfSource")))})
+    Response addEventConfSource(
+            @RequestBody(required = true,
+                    description = "Source to create.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = AddEventConfSourceRequest.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "name": "Cisco.syslog.events",
+                      "description": "Syslog events forwarded by Cisco IOS devices",
+                      "vendor": "Cisco"
+                    }""")))
+            final AddEventConfSourceRequest request,
+            @Context SecurityContext securityContext) throws Exception;
 
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/EventRestApi.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/EventRestApi.java
@@ -40,83 +40,133 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 @Path("events")
-@Tag(name = "Events", description = "Events API V2")
+@Tag(name = "Events", description = """
+        Events API V2.
+
+        Events are the immutable record of everything OpenNMS and its agents report. This resource
+        reads them and publishes new ones. It does not modify or delete them: the inherited write
+        operations on `/events` and `/events/{id}` are reachable but fail, see below.
+
+        Timestamps are rendered differently per representation: JSON carries epoch milliseconds
+        (`1787685470949`), XML carries an ISO-8601 string with offset
+        (`2026-08-25T15:17:50.949-04:00`). The generated schema shows the XML form for both.
+
+        `POST /events` and `POST /events/{tiebreaker}` are the same operation. The tiebreaker template
+        matches the empty string, and CXF resolves `POST /events` to it, so a POST to the collection
+        publishes an event and the `EventDTO` request body the document shows for `POST /events` is not
+        what the handler reads. Publish an `Event` document instead, as shown under
+        `POST /events/{tiebreaker}`.
+
+        `PUT /events`, `DELETE /events`, `POST /events/{id}`, `PUT /events/{id}` and
+        `DELETE /events/{id}` are inherited from the generic DAO resource and answer 500 with
+        `object is not an instance of declaring class`. This implementation is proxied on its interface,
+        so the inherited methods cannot be invoked on the proxy. Do not build against them.
+
+        `GET /events/{id}` is missing from this document but works: it returns one event by database id,
+        200 with the same schema as an element of the `GET /events` list, or 404. The generator drops it
+        because both this interface and the abstract superclass declare that signature, and neither
+        declaration can be removed without breaking the endpoint.
+
+        Collection reads accept a CXF FIQL expression in `_s` together with `limit`, `offset`,
+        `orderBy` and `order`. The default page size is 10 and the default sort is `eventTime`
+        descending. Property names usable in `_s` and `orderBy` are listed by
+        `GET /events/properties`; naming a property the entity does not have fails with 500 rather
+        than 400.""")
 public interface EventRestApi {
+
+    // These five declarations have to stay. <tx:annotation-driven/> proxies this implementation on its
+    // interfaces, so a method absent here is absent from the proxy and answers 500 at runtime, which is
+    // what already happens to the inherited write operations. Their OpenAPI detail lives on the
+    // EventRestService overrides, because swagger resolves annotations from the superclass first.
 
     @GET
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
-    @Operation(summary = "Get all events", description = "Get all events", operationId = "EventRestAPIGetAllEvents", tags = {"Events"})
-    @ApiResponses(value = {
-
-            @ApiResponse(responseCode = "200", description = "Successful operation",
-                    content = @Content),
-            @ApiResponse(responseCode = "204", description = "No events found",
-                    content = @Content)
-    })
     Response get(@Context final UriInfo uriInfo, @Context final SearchContext searchContext) ;
 
     @GET
     @Path("{id}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
-    @Operation(summary = "Get the events specified by the given ID", description = "Get the events specified by the given ID", operationId = "EventRestAPIGetEventById", tags = {"Events"})
-    @ApiResponses(value = {
-
-            @ApiResponse(responseCode = "200", description = "Successful operation",
-                    content = @Content),
-            @ApiResponse(responseCode = "204", description = "No events found",
-                    content = @Content)
-    })
     Response get(@Context final UriInfo uriInfo, @PathParam("id") final Long id) ;
 
     @GET
     @Path("count")
     @Produces({MediaType.TEXT_PLAIN})
-    @Operation(summary = "Get total count of events", description = "Get total count of events", operationId = "EventRestAPIGetEventsCount", tags = {"Events"})
-    @ApiResponses(value = {
-
-            @ApiResponse(responseCode = "200", description = "Successful operation",
-                    content = @Content)
-    })
     Response getCount(@Context final UriInfo uriInfo, @Context final SearchContext searchContext) ;
 
     @GET
     @Path("properties")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-    @Operation(summary = "Get event properties", description = "Get event properties with a given query", operationId = "EventRestAPIGetEventProperties", tags = {"Events"})
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Successful operation",
-                    content = @Content),
-            @ApiResponse(responseCode = "204", description = "No events properties found",
-                    content = @Content)
-    })
     Response getProperties(@QueryParam("q") final String query) ;
 
     @GET
     @Path("properties/{propertyId}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-    @Operation(summary = "Get event properties specified by query and propertyId", description = "Get event properties with a given query and propertyId", operationId = "EventRestAPIGetPropertyByPropertyId", tags = {"Events"})
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Successful operation",
-                    content = @Content),
-            @ApiResponse(responseCode = "404", description = "No events properties found",
-                    content = @Content)
-    })
     Response getPropertyValues(@PathParam("propertyId") final String propertyId, @QueryParam("q") final String query, @QueryParam("limit") final Integer limit) ;
 
 
     @POST
     @Path("{tiebreaker: $}")
     @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-    @Operation(summary = "Publish a new event", description = "Publish a new event", operationId = "EventRestAPIPostTiebreaker")
+    @Operation(summary = "Publish a new event",
+            description = """
+        Hand an event to eventd. `POST /events` resolves to this same handler, so both forms of the path
+        behave alike.
+
+        `uei` is the only field worth treating as required: `time` defaults to now and `source` defaults
+        to `ReST` when they are absent. Nothing else is validated here. An event whose UEI matches no
+        event configuration is still stored, under `uei.opennms.org/default/event`, so a body as small as
+        `{}` yields 204 and leaves a row behind.
+
+        The 204 says only that eventd accepted the event for processing. Whether it is persisted, and
+        whether it raises an alarm, is decided by the matching event configuration afterwards.
+
+        The two representations are not interchangeable. In XML the parameter value is element text with
+        `type` and `encoding` as attributes; in JSON the same value is an object whose text sits in a
+        `value` field. Sending the XML shape as JSON fails.""",
+            operationId = "EventRestAPIPostTiebreaker")
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true,
+            description = "The event to publish.",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = Event.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "uei": "uei.opennms.org/internal/droolsEngineException",
+                      "source": "my-integration",
+                      "parms": [
+                        {
+                          "parmName": "enginename",
+                          "value": { "value": "north-uplink", "type": "string", "encoding": "text" }
+                        }
+                      ]
+                    }""")),
+                    @Content(mediaType = MediaType.APPLICATION_XML, schema = @Schema(implementation = Event.class),
+                            examples = @ExampleObject(value = """
+                    <event>
+                      <uei>uei.opennms.org/internal/droolsEngineException</uei>
+                      <source>my-integration</source>
+                      <parms>
+                        <parm>
+                          <parmName>enginename</parmName>
+                          <value type="string" encoding="text">north-uplink</value>
+                        </parm>
+                      </parms>
+                    </event>"""))
+            })
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", description = "Successful operation",
-                    content = @Content),
-            @ApiResponse(responseCode = "500", description = "Publish event error",
-                    content = @Content),
+            @ApiResponse(responseCode = "204", description = "The event was handed to eventd. No body is returned."),
+            @ApiResponse(responseCode = "415", description = "The request declared a content type other than JSON or XML. No body is returned."),
+            @ApiResponse(responseCode = "500", description = "The body could not be deserialised.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = {
+                                    @ExampleObject(name = "malformed XML", value = "Failed to marshal/unmarshal XML file while unmarshalling an object (Event)"),
+                                    @ExampleObject(name = "wrong JSON field type", value = "Can not construct instance of java.lang.Long from String value notanumber: not a valid Long value")
+                            }))
     })
     Response create(@RequestBody Event event) ;
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/EventRestApi.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/EventRestApi.java
@@ -47,43 +47,37 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 @Path("events")
 @Tag(name = "Events", description = """
-        Events API V2.
+        Events API V2. Reads events and publishes new ones.
 
-        Events are the immutable record of everything OpenNMS and its agents report. This resource
-        reads them and publishes new ones. It does not modify or delete them: the inherited write
-        operations on `/events` and `/events/{id}` are reachable but fail, see below.
+        JSON carries timestamps as epoch milliseconds (`1787685470949`); XML carries an ISO-8601 string
+        with offset (`2026-08-25T15:17:50.949-04:00`). The generated schema shows the XML form for both.
 
-        Timestamps are rendered differently per representation: JSON carries epoch milliseconds
-        (`1787685470949`), XML carries an ISO-8601 string with offset
-        (`2026-08-25T15:17:50.949-04:00`). The generated schema shows the XML form for both.
-
-        `POST /events` and `POST /events/{tiebreaker}` are the same operation. The tiebreaker template
-        matches the empty string, and CXF resolves `POST /events` to it, so a POST to the collection
-        publishes an event and the `EventDTO` request body the document shows for `POST /events` is not
-        what the handler reads. Publish an `Event` document instead, as shown under
-        `POST /events/{tiebreaker}`.
+        `POST /events` and `POST /events/{tiebreaker}` are the same operation: the tiebreaker template
+        matches the empty string and CXF resolves `POST /events` to it. The handler reads an `Event`
+        document, not the `EventDTO` body this document shows for `POST /events`.
 
         `PUT /events`, `DELETE /events`, `POST /events/{id}`, `PUT /events/{id}` and
         `DELETE /events/{id}` are inherited from the generic DAO resource and answer 500 with
-        `object is not an instance of declaring class`. This implementation is proxied on its interface,
-        so the inherited methods cannot be invoked on the proxy. Do not build against them.
+        `object is not an instance of declaring class`: this implementation is proxied on its interface,
+        and the inherited methods are not on the proxy.
 
-        `GET /events/{id}` is missing from this document but works: it returns one event by database id,
-        200 with the same schema as an element of the `GET /events` list, or 404. The generator drops it
-        because both this interface and the abstract superclass declare that signature, and neither
-        declaration can be removed without breaking the endpoint.
+        `GET /events/{id}` is absent from this document but works: it returns one event by database id,
+        200 with the same schema as an element of the `GET /events` list, or 404.
 
         Collection reads accept a CXF FIQL expression in `_s` together with `limit`, `offset`,
         `orderBy` and `order`. The default page size is 10 and the default sort is `eventTime`
-        descending. Property names usable in `_s` and `orderBy` are listed by
-        `GET /events/properties`; naming a property the entity does not have fails with 500 rather
-        than 400.""")
+        descending. `GET /events/properties` lists the property names usable in `_s` and `orderBy`;
+        naming a property the entity does not have fails with 500 rather than 400.""")
 public interface EventRestApi {
 
     // These five declarations have to stay. <tx:annotation-driven/> proxies this implementation on its
     // interfaces, so a method absent here is absent from the proxy and answers 500 at runtime, which is
     // what already happens to the inherited write operations. Their OpenAPI detail lives on the
     // EventRestService overrides, because swagger resolves annotations from the superclass first.
+    //
+    // GET /events/{id} is dropped from the generated document because this interface and the abstract
+    // superclass both declare that signature; neither declaration can be removed without breaking the
+    // endpoint.
 
     @GET
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.APPLICATION_ATOM_XML})
@@ -115,13 +109,11 @@ public interface EventRestApi {
     @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     @Operation(summary = "Publish a new event",
             description = """
-        Hand an event to eventd. `POST /events` resolves to this same handler, so both forms of the path
-        behave alike.
+        Hand an event to eventd. `POST /events` resolves to this same handler.
 
-        `uei` is the only field worth treating as required: `time` defaults to now and `source` defaults
-        to `ReST` when they are absent. Nothing else is validated here. An event whose UEI matches no
-        event configuration is still stored, under `uei.opennms.org/default/event`, so a body as small as
-        `{}` yields 204 and leaves a row behind.
+        `time` defaults to now and `source` defaults to `ReST` when absent. Nothing else is validated
+        here. An event whose UEI matches no event configuration is still stored, under
+        `uei.opennms.org/default/event`, so a body as small as `{}` yields 204 and leaves a row behind.
 
         The 204 says only that eventd accepted the event for processing. Whether it is persisted, and
         whether it raises an alarm, is decided by the matching event configuration afterwards.

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/NodeLinkRestApi.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/NodeLinkRestApi.java
@@ -62,21 +62,17 @@ import io.swagger.v3.oas.annotations.tags.Tag;
         Enlinkd API.
 
         Every operation is addressed by a node criteria and returns the link-discovery rows enlinkd has
-        persisted for that node. The response fields are display strings assembled for the web UI, not
-        raw table columns: a port reads `GigabitEthernet0/1(ifindex:1)(interfaceName:Gi0/1)`, and the
-        `*Url` fields are relative JSP paths (`element/snmpinterface.jsp?node=2&ifindex=1`) meant to be
-        resolved against the OpenNMS web root.
+        persisted for that node. The response fields are display strings, not raw table columns: a port
+        reads `GigabitEthernet0/1(ifindex:1)(interfaceName:Gi0/1)`, and the `*Url` fields are JSP paths
+        (`element/snmpinterface.jsp?node=2&ifindex=1`) relative to the OpenNMS web root.
 
-        The create and last-poll timestamps are already formatted for display, so they arrive as
-        locale-dependent strings such as `8/17/26, 5:20:39 PM` rather than as epoch milliseconds or
-        ISO-8601. On this instance the separator before AM/PM is U+202F (narrow no-break space), not a
-        plain space, which matters to anything matching on the text. Treat these fields as opaque
-        labels rather than parsing them.
+        The create and last-poll timestamps arrive pre-formatted as locale-dependent strings such as
+        `8/17/26, 5:20:39 PM` rather than as epoch milliseconds or ISO-8601. On this instance the
+        separator before AM/PM is U+202F (narrow no-break space), not a plain space.
 
-        A protocol that discovery has not populated is not an error: the `_links` operations answer 200
-        with an empty array, and the LLDP, CDP, OSPF and IS-IS `_elems` operations answer 204.
-        `bridge_elems` returns a collection rather than a single element, so it answers 200 with an
-        empty array like the link operations.""")
+        Where discovery has populated nothing, the `_links` operations answer 200 with an empty array
+        and the LLDP, CDP, OSPF and IS-IS `_elems` operations answer 204. `bridge_elems` returns a
+        collection rather than a single element, so it answers 200 with an empty array.""")
 public interface NodeLinkRestApi {
 
     /** Shared so the twelve node-criteria parameters cannot drift apart. */
@@ -98,7 +94,7 @@ public interface NodeLinkRestApi {
         collections are always present, empty where that protocol has nothing for the node. The
         single-element fields (`lldpElementNode`, `cdpElementNode`, `ospfElementNode`,
         `isisElementNode`) are omitted from the JSON entirely when the node has no such element, rather
-        than being emitted as null, so a client has to treat a missing key as "not discovered".""",
+        than being emitted as null.""",
             operationId = "NodeLinkRestApiGetAllTypesOfLinks", tags = {"Enlinkd"})
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "All link types held for the node.",
@@ -165,8 +161,8 @@ public interface NodeLinkRestApi {
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     @Operation(summary = "Get a node's LLDP Link",
             description = """
-        LLDP neighbour rows for one node. `ldpRemPort` is spelled without the leading `l`; that is the
-        name on the wire in both JSON and XML, not a typo in this document.""",
+        LLDP neighbour rows for one node. `ldpRemPort` is spelled without a leading `l` in both JSON
+        and XML.""",
             operationId = "NodeLinkRestApiGetNodeLLDPLinkByNodeId", tags = {"Enlinkd"})
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "LLDP links held for the node, empty when LLDP found none.",
@@ -291,7 +287,7 @@ public interface NodeLinkRestApi {
     @Path("lldp_elems/{node_criteria}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     @Operation(summary = "Get a node's LLDP element",
-            description = "The node's own LLDP identity (chassis id and system name) as discovery recorded it.",
+            description = "The node's own LLDP identity: chassis id and system name.",
             operationId = "NodeLinkRestApiGetElementLLDPLinkByNodeId", tags = {"Enlinkd"})
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "The node's LLDP element.",
@@ -319,9 +315,9 @@ public interface NodeLinkRestApi {
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     @Operation(summary = "Get a node's bridge element",
             description = """
-        The node's bridge identities, one per discovered bridge base address. Unlike the other
-        `_elems` operations this one returns a collection, so a node with no bridge element answers
-        200 with an empty array rather than 204.""",
+        The node's bridge identities, one per discovered VLAN. A device with no VLAN table yields a single
+        entry whose `vlan` is null. This operation returns a collection, so a node with no bridge element
+        answers 200 with an empty array rather than 204.""",
             operationId = "NodeLinkRestApiGetElementBridgeLinkByNodeId", tags = {"Enlinkd"})
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "The node's bridge elements, empty when it has none.",
@@ -341,7 +337,7 @@ public interface NodeLinkRestApi {
     @Path("cdp_elems/{node_criteria}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     @Operation(summary = "Get a node's CDP element",
-            description = "The node's own CDP identity (global device id and run state) as discovery recorded it.",
+            description = "The node's own CDP identity: global device id and run state.",
             operationId = "NodeLinkRestApiGetElementCDPLinkByNodeId" , tags = {"Enlinkd"})
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "The node's CDP element.",

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/NodeLinkRestApi.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/NodeLinkRestApi.java
@@ -42,148 +42,382 @@ import org.opennms.web.rest.model.v2.OspfElementNodeDTO;
 import org.opennms.web.rest.model.v2.OspfLinkNodeDTO;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
+/**
+ * Read-only projections of the link-discovery (enlinkd) tables for a single
+ * node, shaped for the node link pages rather than for machine consumption:
+ * the fields are pre-rendered display strings, some of which embed relative
+ * JSP URLs.
+ */
 @Path("enlinkd")
+@Tag(name = "Enlinkd", description = """
+        Enlinkd API.
+
+        Every operation is addressed by a node criteria and returns the link-discovery rows enlinkd has
+        persisted for that node. The response fields are display strings assembled for the web UI, not
+        raw table columns: a port reads `GigabitEthernet0/1(ifindex:1)(interfaceName:Gi0/1)`, and the
+        `*Url` fields are relative JSP paths (`element/snmpinterface.jsp?node=2&ifindex=1`) meant to be
+        resolved against the OpenNMS web root.
+
+        The create and last-poll timestamps are already formatted for display, so they arrive as
+        locale-dependent strings such as `8/17/26, 5:20:39 PM` rather than as epoch milliseconds or
+        ISO-8601. On this instance the separator before AM/PM is U+202F (narrow no-break space), not a
+        plain space, which matters to anything matching on the text. Treat these fields as opaque
+        labels rather than parsing them.
+
+        A protocol that discovery has not populated is not an error: the `_links` operations answer 200
+        with an empty array, and the LLDP, CDP, OSPF and IS-IS `_elems` operations answer 204.
+        `bridge_elems` returns a collection rather than a single element, so it answers 200 with an
+        empty array like the link operations.""")
 public interface NodeLinkRestApi {
+
+    /** Shared so the twelve node-criteria parameters cannot drift apart. */
+    String NODE_CRITERIA_DESC = """
+            Either a numeric node id (`2`) or a `foreignSource:foreignId` pair (`loopback-lab:lb-001`).
+            The pair form is recognised by the presence of a colon; anything else is parsed as an
+            integer.""";
+
+    String NODE_CRITERIA_500 = """
+            The criteria contains no colon and is not an integer, so parsing it as a node id fails.
+            A well-formed criteria that matches nothing answers 404 instead.""";
 
     @GET
     @Path("{node_criteria}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-    @Operation(summary = "Get a node's all types of links", description = "Get all types of links for a specific node", operationId = "NodeLinkRestApiGetAllTypesOfLinks", tags = {"Enlinkd"})
+    @Operation(summary = "Get a node's all types of links",
+            description = """
+        Every link type and element enlinkd holds for one node, in a single response. The link
+        collections are always present, empty where that protocol has nothing for the node. The
+        single-element fields (`lldpElementNode`, `cdpElementNode`, `ospfElementNode`,
+        `isisElementNode`) are omitted from the JSON entirely when the node has no such element, rather
+        than being emitted as null, so a client has to treat a missing key as "not discovered".""",
+            operationId = "NodeLinkRestApiGetAllTypesOfLinks", tags = {"Enlinkd"})
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "successful operation",
-                    content = @Content(schema = @Schema(implementation = EnlinkdDTO.class))),
-            @ApiResponse(responseCode = "404", description = "Node not found",
-                    content = @Content)
+            @ApiResponse(responseCode = "200", description = "All link types held for the node.",
+                    content = @Content(schema = @Schema(implementation = EnlinkdDTO.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "lldpLinkNodes": [
+                        {
+                          "lldpLocalPort": "GigabitEthernet0/1(ifindex:1)(interfaceName:Gi0/1)",
+                          "lldpLocalPortUrl": "element/snmpinterface.jsp?node=2&ifindex=1",
+                          "lldpRemChassisId": "loopback-004(macAddress:ch-001)",
+                          "lldpRemChassisIdUrl": "element/linkednode.jsp?node=1",
+                          "lldpRemInfo": "loopback-004",
+                          "ldpRemPort": "GigabitEthernet0/2(interfaceName:Gi0/2)",
+                          "lldpCreateTime": "8/17/26, 5:20:39 PM",
+                          "lldpLastPollTime": "8/17/26, 5:20:39 PM"
+                        }
+                      ],
+                      "bridgeLinkNodes": [],
+                      "cdpLinkNodes": [],
+                      "ospfLinkNodes": [
+                        {
+                          "ospfLocalPort": "lo()(ifindex:1)(10.10.1.2)",
+                          "ospfLocalPortUrl": "element/snmpinterface.jsp?node=2&ifindex=1",
+                          "ospfRemRouterId": "loopback-004(router id:10.255.0.1)",
+                          "ospfRemRouterUrl": "element/linkednode.jsp?node=1",
+                          "ospfRemPort": "(10.10.1.1)",
+                          "ospfRemPortUrl": "element/interface.jsp?node=1&intf=10.10.1.1",
+                          "ospfLinkInfo": "(mask:255.255.255.252)",
+                          "ospfLinkCreateTime": "8/17/26, 5:20:39 PM",
+                          "ospfLinkLastPollTime": "8/17/26, 5:20:39 PM"
+                        }
+                      ],
+                      "isisLinkNodes": [],
+                      "lldpElementNode": {
+                        "lldpChassisId": "(macAddress:ch-002)",
+                        "lldpSysName": "loopback-001",
+                        "lldpCreateTime": "8/17/26, 5:20:39 PM",
+                        "lldpLastPollTime": "8/17/26, 5:20:39 PM"
+                      },
+                      "bridgeElementNodes": [],
+                      "ospfElementNode": {
+                        "ospfRouterId": "10.255.0.2",
+                        "ospfVersionNumber": 2,
+                        "ospfAdminStat": "enabled",
+                        "ospfCreateTime": "8/17/26, 5:20:39 PM",
+                        "ospfLastPollTime": "8/17/26, 5:20:39 PM"
+                      }
+                    }"""))),
+            @ApiResponse(responseCode = "404", description = "No node matches the criteria.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Not able to find node with criteria : 99999999"))),
+            @ApiResponse(responseCode = "500", description = NODE_CRITERIA_500,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "For input string: \"router-1\"")))
     })
-    EnlinkdDTO getEnlinkd(@PathParam("node_criteria") String nodeCriteria);
+    EnlinkdDTO getEnlinkd(@Parameter(description = NODE_CRITERIA_DESC, required = true, example = "2")
+                          @PathParam("node_criteria") String nodeCriteria);
 
     @GET
     @Path("lldp_links/{node_criteria}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-    @Operation(summary = "Get a node's LLDP Link", description = "Get LLDP link for a specific node", operationId = "NodeLinkRestApiGetNodeLLDPLinkByNodeId", tags = {"Enlinkd"})
+    @Operation(summary = "Get a node's LLDP Link",
+            description = """
+        LLDP neighbour rows for one node. `ldpRemPort` is spelled without the leading `l`; that is the
+        name on the wire in both JSON and XML, not a typo in this document.""",
+            operationId = "NodeLinkRestApiGetNodeLLDPLinkByNodeId", tags = {"Enlinkd"})
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "successful operation",
-                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = LldpLinkNodeDTO.class)))),
-            @ApiResponse(responseCode = "404", description = "Node not found",
-                    content = @Content)
+            @ApiResponse(responseCode = "200", description = "LLDP links held for the node, empty when LLDP found none.",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = LldpLinkNodeDTO.class)),
+                            examples = @ExampleObject(value = """
+                    [
+                      {
+                        "lldpLocalPort": "GigabitEthernet0/1001(ifindex:2)(interfaceName:Gi0/1001)",
+                        "lldpLocalPortUrl": "element/snmpinterface.jsp?node=1011&ifindex=2",
+                        "lldpRemChassisId": "scale-core-001(macAddress:sc-001001)",
+                        "lldpRemChassisIdUrl": "element/linkednode.jsp?node=1001",
+                        "lldpRemInfo": "scale-core-001",
+                        "ldpRemPort": "GigabitEthernet0/1011(interfaceName:Gi0/1011)",
+                        "lldpCreateTime": "8/18/26, 1:16:57 PM",
+                        "lldpLastPollTime": "8/18/26, 1:16:57 PM"
+                      }
+                    ]"""))),
+            @ApiResponse(responseCode = "404", description = "No node matches the criteria.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Not able to find node with criteria : 99999999"))),
+            @ApiResponse(responseCode = "500", description = NODE_CRITERIA_500,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
     })
-    List<LldpLinkNodeDTO> getLldpLinks(@PathParam("node_criteria") String nodeCriteria);
+    List<LldpLinkNodeDTO> getLldpLinks(@Parameter(description = NODE_CRITERIA_DESC, required = true, example = "1011")
+                                       @PathParam("node_criteria") String nodeCriteria);
 
     @GET
     @Path("bridge_links/{node_criteria}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-    @Operation(summary = "Get a node's bridge Link", description = "Get bridge link for a specific node", operationId = "NodeLinkRestApiGetNodeBridgeLinkByNodeId", tags = {"Enlinkd"})
+    @Operation(summary = "Get a node's bridge Link",
+            description = """
+        Bridge-forwarding links for one node. Each entry covers one local port and carries the remote
+        ends reachable through it as a nested collection.""",
+            operationId = "NodeLinkRestApiGetNodeBridgeLinkByNodeId", tags = {"Enlinkd"})
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "successful operation",
-                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = BridgeLinkNodeDTO.class)))),
-            @ApiResponse(responseCode = "404", description = "Node not found",
-                    content = @Content)
+            @ApiResponse(responseCode = "200", description = "Bridge links held for the node, empty when bridge discovery found none.",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = BridgeLinkNodeDTO.class)),
+                            examples = @ExampleObject(value = "[]"))),
+            @ApiResponse(responseCode = "404", description = "No node matches the criteria.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Not able to find node with criteria : 99999999"))),
+            @ApiResponse(responseCode = "500", description = NODE_CRITERIA_500,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
     })
-    List<BridgeLinkNodeDTO> getBridgeLinks(@PathParam("node_criteria") String nodeCriteria);
+    List<BridgeLinkNodeDTO> getBridgeLinks(@Parameter(description = NODE_CRITERIA_DESC, required = true, example = "2")
+                                           @PathParam("node_criteria") String nodeCriteria);
 
     @GET
     @Path("cdp_links/{node_criteria}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-    @Operation(summary = "Get a node's CDP Link", description = "Get CDP link for a specific node", operationId = "NodeLinkRestApiGetNodeCDPLinkByNodeId", tags = {"Enlinkd"})
+    @Operation(summary = "Get a node's CDP Link", description = "CDP neighbour rows for one node.",
+            operationId = "NodeLinkRestApiGetNodeCDPLinkByNodeId", tags = {"Enlinkd"})
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "successful operation",
-                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = CdpLinkNodeDTO.class)))),
-            @ApiResponse(responseCode = "404", description = "Node not found",
-                    content = @Content)
+            @ApiResponse(responseCode = "200", description = "CDP links held for the node, empty when CDP found none.",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = CdpLinkNodeDTO.class)),
+                            examples = @ExampleObject(value = "[]"))),
+            @ApiResponse(responseCode = "404", description = "No node matches the criteria.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Not able to find node with criteria : 99999999"))),
+            @ApiResponse(responseCode = "500", description = NODE_CRITERIA_500,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
     })
-    List<CdpLinkNodeDTO> getCdpLinks(@PathParam("node_criteria") String nodeCriteria);
+    List<CdpLinkNodeDTO> getCdpLinks(@Parameter(description = NODE_CRITERIA_DESC, required = true, example = "2")
+                                     @PathParam("node_criteria") String nodeCriteria);
 
     @GET
     @Path("ospf_links/{node_criteria}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-    @Operation(summary = "Get a node's OSPF Link", description = "Get OSPF link for a specific node", operationId = "NodeLinkRestApiGetNodeOSPFLinkByNodeId", tags = {"Enlinkd"})
+    @Operation(summary = "Get a node's OSPF Link",
+            description = "OSPF adjacency rows for one node, one entry per local interface with a discovered neighbour.",
+            operationId = "NodeLinkRestApiGetNodeOSPFLinkByNodeId", tags = {"Enlinkd"})
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "successful operation",
-                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = OspfLinkNodeDTO.class)))),
-            @ApiResponse(responseCode = "404", description = "Node not found",
-                    content = @Content)
+            @ApiResponse(responseCode = "200", description = "OSPF links held for the node, empty when OSPF found none.",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = OspfLinkNodeDTO.class)),
+                            examples = @ExampleObject(value = """
+                    [
+                      {
+                        "ospfLocalPort": "lo()(ifindex:1)(10.10.1.2)",
+                        "ospfLocalPortUrl": "element/snmpinterface.jsp?node=2&ifindex=1",
+                        "ospfRemRouterId": "loopback-004(router id:10.255.0.1)",
+                        "ospfRemRouterUrl": "element/linkednode.jsp?node=1",
+                        "ospfRemPort": "(10.10.1.1)",
+                        "ospfRemPortUrl": "element/interface.jsp?node=1&intf=10.10.1.1",
+                        "ospfLinkInfo": "(mask:255.255.255.252)",
+                        "ospfLinkCreateTime": "8/17/26, 5:20:39 PM",
+                        "ospfLinkLastPollTime": "8/17/26, 5:20:39 PM"
+                      }
+                    ]"""))),
+            @ApiResponse(responseCode = "404", description = "No node matches the criteria.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Not able to find node with criteria : 99999999"))),
+            @ApiResponse(responseCode = "500", description = NODE_CRITERIA_500,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
     })
-    List<OspfLinkNodeDTO> getOspfLinks(@PathParam("node_criteria") String nodeCriteria);
+    List<OspfLinkNodeDTO> getOspfLinks(@Parameter(description = NODE_CRITERIA_DESC, required = true, example = "2")
+                                       @PathParam("node_criteria") String nodeCriteria);
 
     @GET
     @Path("isis_links/{node_criteria}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-    @Operation(summary = "Get a node's IS-IS Link", description = "Get IS-IS link for a specific node", operationId = "NodeLinkRestApiGetNodeISISLinkByNodeId", tags = {"Enlinkd"})
+    @Operation(summary = "Get a node's IS-IS Link", description = "IS-IS adjacency rows for one node.",
+            operationId = "NodeLinkRestApiGetNodeISISLinkByNodeId", tags = {"Enlinkd"})
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "successful operation",
-                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = IsisLinkNodeDTO.class)))),
-            @ApiResponse(responseCode = "404", description = "Node not found",
-                    content = @Content)
+            @ApiResponse(responseCode = "200", description = "IS-IS links held for the node, empty when IS-IS found none.",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = IsisLinkNodeDTO.class)),
+                            examples = @ExampleObject(value = "[]"))),
+            @ApiResponse(responseCode = "404", description = "No node matches the criteria.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Not able to find node with criteria : 99999999"))),
+            @ApiResponse(responseCode = "500", description = NODE_CRITERIA_500,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
     })
-    List<IsisLinkNodeDTO> getIsisLinks(@PathParam("node_criteria") String nodeCriteria);
+    List<IsisLinkNodeDTO> getIsisLinks(@Parameter(description = NODE_CRITERIA_DESC, required = true, example = "2")
+                                       @PathParam("node_criteria") String nodeCriteria);
 
     @GET
     @Path("lldp_elems/{node_criteria}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-    @Operation(summary = "Get a node's LLDP element", description = "Get LLDP element for a specific node", operationId = "NodeLinkRestApiGetElementLLDPLinkByNodeId", tags = {"Enlinkd"})
+    @Operation(summary = "Get a node's LLDP element",
+            description = "The node's own LLDP identity (chassis id and system name) as discovery recorded it.",
+            operationId = "NodeLinkRestApiGetElementLLDPLinkByNodeId", tags = {"Enlinkd"})
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "successful operation",
-                    content = @Content(schema = @Schema(implementation = LldpElementNodeDTO.class))),
-            @ApiResponse(responseCode = "204", description = "No corresponding element found"),
-            @ApiResponse(responseCode = "404", description = "Node not found",
-                    content = @Content)
+            @ApiResponse(responseCode = "200", description = "The node's LLDP element.",
+                    content = @Content(schema = @Schema(implementation = LldpElementNodeDTO.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "lldpChassisId": "(macAddress:ch-002)",
+                      "lldpSysName": "loopback-001",
+                      "lldpCreateTime": "8/17/26, 5:20:39 PM",
+                      "lldpLastPollTime": "8/17/26, 5:20:39 PM"
+                    }"""))),
+            @ApiResponse(responseCode = "204", description = "The node exists but has no LLDP element."),
+            @ApiResponse(responseCode = "404", description = "No node matches the criteria.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Not able to find node with criteria : 99999999"))),
+            @ApiResponse(responseCode = "500", description = NODE_CRITERIA_500,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
     })
-    LldpElementNodeDTO getLldpElem(@PathParam("node_criteria") String nodeCriteria);
+    LldpElementNodeDTO getLldpElem(@Parameter(description = NODE_CRITERIA_DESC, required = true, example = "loopback-lab:lb-001")
+                                   @PathParam("node_criteria") String nodeCriteria);
 
     @GET
     @Path("bridge_elems/{node_criteria}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-    @Operation(summary = "Get a node's bridge element", description = "Get bridge element for a specific node", operationId = "NodeLinkRestApiGetElementBridgeLinkByNodeId", tags = {"Enlinkd"})
+    @Operation(summary = "Get a node's bridge element",
+            description = """
+        The node's bridge identities, one per discovered bridge base address. Unlike the other
+        `_elems` operations this one returns a collection, so a node with no bridge element answers
+        200 with an empty array rather than 204.""",
+            operationId = "NodeLinkRestApiGetElementBridgeLinkByNodeId", tags = {"Enlinkd"})
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "successful operation",
-                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = BridgeElementNodeDTO.class)))),
-            @ApiResponse(responseCode = "404", description = "Node not found",
-                    content = @Content)
+            @ApiResponse(responseCode = "200", description = "The node's bridge elements, empty when it has none.",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = BridgeElementNodeDTO.class)),
+                            examples = @ExampleObject(value = "[]"))),
+            @ApiResponse(responseCode = "404", description = "No node matches the criteria.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Not able to find node with criteria : 99999999"))),
+            @ApiResponse(responseCode = "500", description = NODE_CRITERIA_500,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
     })
-    List<BridgeElementNodeDTO> getBridgeElem(@PathParam("node_criteria") String nodeCriteria);
+    List<BridgeElementNodeDTO> getBridgeElem(@Parameter(description = NODE_CRITERIA_DESC, required = true, example = "2")
+                                             @PathParam("node_criteria") String nodeCriteria);
 
     @GET
     @Path("cdp_elems/{node_criteria}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-    @Operation(summary = "Get a node's CDP element", description = "Get CDP element for a specific node", operationId = "NodeLinkRestApiGetElementCDPLinkByNodeId" , tags = {"Enlinkd"})
+    @Operation(summary = "Get a node's CDP element",
+            description = "The node's own CDP identity (global device id and run state) as discovery recorded it.",
+            operationId = "NodeLinkRestApiGetElementCDPLinkByNodeId" , tags = {"Enlinkd"})
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "successful operation",
-                    content = @Content(schema = @Schema(implementation = CdpElementNodeDTO.class))),
-            @ApiResponse(responseCode = "204", description = "No corresponding element found"),
-            @ApiResponse(responseCode = "404", description = "Node not found",
-                    content = @Content)
+            @ApiResponse(responseCode = "200", description = "The node's CDP element.",
+                    content = @Content(schema = @Schema(implementation = CdpElementNodeDTO.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "cdpGlobalRun": "true",
+                      "cdpGlobalDeviceId": "core-sw-01",
+                      "cdpGlobalDeviceIdFormat": "other",
+                      "cdpCreateTime": "8/17/26, 5:20:39 PM",
+                      "cdpLastPollTime": "8/17/26, 5:20:39 PM"
+                    }"""))),
+            @ApiResponse(responseCode = "204", description = "The node exists but has no CDP element."),
+            @ApiResponse(responseCode = "404", description = "No node matches the criteria.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Not able to find node with criteria : 99999999"))),
+            @ApiResponse(responseCode = "500", description = NODE_CRITERIA_500,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
     })
-    CdpElementNodeDTO getCdpElem(@PathParam("node_criteria") String nodeCriteria);
+    CdpElementNodeDTO getCdpElem(@Parameter(description = NODE_CRITERIA_DESC, required = true, example = "2")
+                                 @PathParam("node_criteria") String nodeCriteria);
 
     @GET
     @Path("ospf_elems/{node_criteria}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-    @Operation(summary = "Get a node's OSPF element", description = "Get OSPF element for a specific node", operationId = "NodeLinkRestApiGetElementOSPFLinkByNodeId", tags = {"Enlinkd"})
+    @Operation(summary = "Get a node's OSPF element",
+            description = "The node's own OSPF identity: router id, protocol version and admin state.",
+            operationId = "NodeLinkRestApiGetElementOSPFLinkByNodeId", tags = {"Enlinkd"})
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "successful operation",
-                    content = @Content(schema = @Schema(implementation = OspfElementNodeDTO.class))),
-            @ApiResponse(responseCode = "204", description = "No corresponding element found"),
-            @ApiResponse(responseCode = "404", description = "Node not found",
-                    content = @Content)
+            @ApiResponse(responseCode = "200", description = "The node's OSPF element.",
+                    content = @Content(schema = @Schema(implementation = OspfElementNodeDTO.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "ospfRouterId": "10.255.0.2",
+                      "ospfVersionNumber": 2,
+                      "ospfAdminStat": "enabled",
+                      "ospfCreateTime": "8/17/26, 5:20:39 PM",
+                      "ospfLastPollTime": "8/17/26, 5:20:39 PM"
+                    }"""))),
+            @ApiResponse(responseCode = "204", description = "The node exists but has no OSPF element."),
+            @ApiResponse(responseCode = "404", description = "No node matches the criteria.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Not able to find node with criteria : 99999999"))),
+            @ApiResponse(responseCode = "500", description = NODE_CRITERIA_500,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
     })
-    OspfElementNodeDTO getOspfElem(@PathParam("node_criteria") String nodeCriteria);
+    OspfElementNodeDTO getOspfElem(@Parameter(description = NODE_CRITERIA_DESC, required = true, example = "2")
+                                   @PathParam("node_criteria") String nodeCriteria);
 
     @GET
     @Path("isis_elems/{node_criteria}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-    @Operation(summary = "Get a node's IS-IS element", description = "Get IS-IS element for a specific node", operationId = "NodeLinkRestApiGetElementISISLinkByNodeId", tags = {"Enlinkd"})
+    @Operation(summary = "Get a node's IS-IS element",
+            description = "The node's own IS-IS identity: system id and administrative state.",
+            operationId = "NodeLinkRestApiGetElementISISLinkByNodeId", tags = {"Enlinkd"})
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "successful operation",
-                    content = @Content(schema = @Schema(implementation = IsisElementNodeDTO.class))),
-            @ApiResponse(responseCode = "204", description = "No corresponding element found"),
-            @ApiResponse(responseCode = "404", description = "Node not found",
-                    content = @Content)
+            @ApiResponse(responseCode = "200", description = "The node's IS-IS element.",
+                    content = @Content(schema = @Schema(implementation = IsisElementNodeDTO.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "isisSysID": "0102.0304.0506",
+                      "isisSysAdminState": "on",
+                      "isisCreateTime": "8/17/26, 5:20:39 PM",
+                      "isisLastPollTime": "8/17/26, 5:20:39 PM"
+                    }"""))),
+            @ApiResponse(responseCode = "204", description = "The node exists but has no IS-IS element."),
+            @ApiResponse(responseCode = "404", description = "No node matches the criteria.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Not able to find node with criteria : 99999999"))),
+            @ApiResponse(responseCode = "500", description = NODE_CRITERIA_500,
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string")))
     })
-    IsisElementNodeDTO getIsisElem(@PathParam("node_criteria") String nodeCriteria);
+    IsisElementNodeDTO getIsisElem(@Parameter(description = NODE_CRITERIA_DESC, required = true, example = "2")
+                                   @PathParam("node_criteria") String nodeCriteria);
+
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/NodeLinkRestApi.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/NodeLinkRestApi.java
@@ -346,7 +346,6 @@ public interface NodeLinkRestApi {
                     {
                       "cdpGlobalRun": "true",
                       "cdpGlobalDeviceId": "core-sw-01",
-                      "cdpGlobalDeviceIdFormat": "other",
                       "cdpCreateTime": "8/17/26, 5:20:39 PM",
                       "cdpLastPollTime": "8/17/26, 5:20:39 PM"
                     }"""))),

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/SnmpConfigRestApi.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/SnmpConfigRestApi.java
@@ -131,7 +131,7 @@ public interface SnmpConfigRestApi {
         Resolve the effective agent configuration for one address, which is what the poller and collector
         would use: the top-level defaults with the first matching `<definition>` applied on top.
         A definition that carries an explicit `timeout` or `retry` of 0 supplies that 0 rather than
-        falling back to the top-level value, so a 0 here usually means a definition set it.""",
+        falling back to the top-level value.""",
             operationId = "getConfigForIp"
     )
     @ApiResponses(value = {
@@ -358,13 +358,12 @@ public interface SnmpConfigRestApi {
             summary = "Download SNMP configuration",
             description = """
         Download the SNMP configuration as an attachment (`snmp-config.json` or `snmp-config.xml`),
-        for re-upload through `/snmp-config/upload` or `/snmp-config/upload/xml`.
+        which `/snmp-config/upload` and `/snmp-config/upload/xml` accept back.
         `format=xml` selects XML; every other value, including an unrecognised one, yields JSON.
 
         Only the XML form round-trips faithfully. The JSON form materialises inherited numeric fields as
         literal `0`, so re-uploading it through `/snmp-config/upload` pins each definition's `timeout`
-        and `retry` to 0 instead of leaving them to inherit the top-level defaults. Prefer XML when the
-        download is meant to be restored.""",
+        and `retry` to 0 instead of leaving them to inherit the top-level defaults.""",
             operationId = "downloadConfig"
     )
     @ApiResponses(value = {
@@ -404,7 +403,7 @@ public interface SnmpConfigRestApi {
 
         A document produced by `GET /snmp-config/download` is not a faithful restore: its inherited
         numeric fields are serialized as literal `0`, and uploading them pins each definition's
-        `timeout` and `retry` to 0. Use `/snmp-config/upload/xml` with the XML download to restore a
+        `timeout` and `retry` to 0. `/snmp-config/upload/xml` with the XML download restores a
         configuration unchanged.""",
             operationId = "uploadConfig"
     )

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/SnmpConfigRestApi.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/SnmpConfigRestApi.java
@@ -11,7 +11,11 @@
 package org.opennms.web.rest.v2.api;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -19,7 +23,9 @@ import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 import org.opennms.netmgt.config.snmp.Configuration;
 import org.opennms.netmgt.config.snmp.Definition;
+import org.opennms.netmgt.config.snmp.SnmpConfig;
 import org.opennms.netmgt.config.snmp.SnmpProfile;
+import org.opennms.netmgt.snmp.SnmpAgentConfig;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -33,19 +39,86 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 @Path("snmp-config")
-@Tag(name = "SnmpConfig", description = "SNMP Configuration API")
+@Tag(name = "SnmpConfig", description = """
+        SNMP Configuration API.
+
+        Reads and edits `snmp-config.xml`: the top-level defaults, the `<definition>` blocks that override
+        them per address, range or IP-match expression, and the labelled `<profile>` entries provisioning
+        can try against an unknown agent.
+
+        Bodies here are the JAXB config beans, and they serialize through the codehaus Jackson provider,
+        so JSON uses the `@JsonProperty` names (`readCommunity`, `maxVarsPerPdu`) rather than the
+        hyphenated XML attribute names. On `SnmpProfile` the XML `<filter>` element is `filter` in JSON,
+        not `filterExpression`; an unrecognised field fails with a 500 from the parser rather than a 400.
+
+        Validation failures return a `text/plain` message.""")
 public interface SnmpConfigRestApi {
+
+    String DEFINITION_JSON_EXAMPLE = """
+            {
+              "specific": [ "192.0.2.10" ],
+              "range": [ { "begin": "192.0.2.32", "end": "192.0.2.63" } ],
+              "ipMatch": [],
+              "location": "Default",
+              "version": "v2c",
+              "readCommunity": "public",
+              "port": 161,
+              "timeout": 1800,
+              "retry": 1,
+              "maxVarsPerPdu": 10,
+              "maxRepetitions": 2,
+              "maxRequestSize": 65535
+            }""";
+
     @GET
     @Path("")
     @Produces({MediaType.APPLICATION_JSON})
     @Operation(
             summary = "Get SNMP configuration",
-            description = "Get SNMP configuration",
+            description = """
+        Return the whole SNMP configuration: the top-level defaults, every `<definition>`, and the
+        profiles. Fields the config does not set are present and null rather than absent.""",
             operationId = "getSnmpConfig"
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "SNMP configuration retrieved successfully",
-                    content = @Content)
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = SnmpConfig.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "maxVarsPerPdu": 10,
+                      "maxRepetitions": 2,
+                      "maxRequestSize": 65535,
+                      "version": "v2c",
+                      "readCommunity": "public",
+                      "writeCommunity": null,
+                      "timeout": 1800,
+                      "retry": 1,
+                      "port": 161,
+                      "ttl": null,
+                      "encrypted": false,
+                      "definition": [
+                        {
+                          "maxVarsPerPdu": 10,
+                          "maxRepetitions": 2,
+                          "maxRequestSize": 65535,
+                          "timeout": 0,
+                          "retry": 0,
+                          "port": 1161,
+                          "encrypted": false,
+                          "range": [],
+                          "specific": [ "127.0.0.1" ],
+                          "ipMatch": [],
+                          "location": null,
+                          "profileLabel": null
+                        }
+                      ],
+                      "profiles": { "profile": [] }
+                    }"""))),
+            @ApiResponse(responseCode = "500", description = "The stored configuration could not be read.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error retrieving SNMP config.")))
     })
     Response getSnmpConfig();
 
@@ -54,17 +127,57 @@ public interface SnmpConfigRestApi {
     @Produces({MediaType.APPLICATION_JSON})
     @Operation(
             summary = "Lookup SNMP configuration",
-            description = "Lookup SNMP configuration given an ipAddress and location",
+            description = """
+        Resolve the effective agent configuration for one address, which is what the poller and collector
+        would use: the top-level defaults with the first matching `<definition>` applied on top.
+        A definition that carries an explicit `timeout` or `retry` of 0 supplies that 0 rather than
+        falling back to the top-level value, so a 0 here usually means a definition set it.""",
             operationId = "getConfigForIp"
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "SNMP configuration for the given item retrieved successfully",
-                    content = @Content),
-            @ApiResponse(responseCode = "400", description = "Bad Request – invalid or missing input parameters",
-                    content = @Content)
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = SnmpAgentConfig.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "address": "127.0.0.1",
+                      "proxyFor": null,
+                      "version3": false,
+                      "port": 1161,
+                      "version": 2,
+                      "contextName": null,
+                      "timeout": 1800,
+                      "retries": 1,
+                      "authPassPhrase": null,
+                      "privPassPhrase": null,
+                      "securityLevel": 1,
+                      "authProtocol": null,
+                      "privProtocol": null,
+                      "engineId": null,
+                      "contextEngineId": null,
+                      "enterpriseId": null,
+                      "maxRequestSize": 65535,
+                      "maxVarsPerPdu": 10,
+                      "maxRepetitions": 2,
+                      "ttl": null,
+                      "securityName": "opennmsUser",
+                      "readCommunity": "public",
+                      "writeCommunity": "private",
+                      "versionAsString": "v2c"
+                    }"""))),
+            @ApiResponse(responseCode = "400", description = "`ipAddress` was missing or unparseable, or `location` named a monitoring location that does not exist.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Missing or invalid 'ipAddress'."))),
+            @ApiResponse(responseCode = "500", description = "The lookup failed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error looking up SNMP config.")))
     })
     Response getConfigForIp(
+            @Parameter(description = "IPv4 or IPv6 address to resolve. Required.", required = true, example = "127.0.0.1")
             @QueryParam("ipAddress") String ipAddress,
+            @Parameter(description = "Monitoring location name. Omitted, empty or `Default` all mean the default location.", example = "Default")
             @QueryParam("location") String location);
 
     @POST
@@ -72,16 +185,39 @@ public interface SnmpConfigRestApi {
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Save SNMP default override configuration",
-            description = "Save SNMP default override configuration",
+            description = """
+        Replace the top-level defaults in `snmp-config.xml`. The body is a whole `Configuration`, not a
+        patch, and the saved document is normalised: attributes that were previously absent may be
+        written out explicitly with their default values. Existing definitions and profiles are left
+        alone. The body is validated against `snmp-config.xsd` before it is saved.""",
             operationId = "saveDefaultOverrides"
     )
+    @RequestBody(
+            required = true,
+            description = "Replacement top-level defaults.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = Configuration.class),
+                    examples = @ExampleObject(value = """
+                    {
+                      "version": "v2c",
+                      "readCommunity": "public",
+                      "timeout": 1800,
+                      "retry": 1,
+                      "maxVarsPerPdu": 10,
+                      "maxRepetitions": 2,
+                      "maxRequestSize": 65535
+                    }"""))
+    )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", description = "SNMP configuration default overrides saved successfully",
-                    content = @Content),
-            @ApiResponse(responseCode = "400", description = "Bad Request – invalid or missing input parameters",
-                    content = @Content),
-            @ApiResponse(responseCode = "500", description = "Server Error or Bad Request – invalid or missing input parameters",
-                    content = @Content)
+            @ApiResponse(responseCode = "204", description = "SNMP configuration default overrides saved successfully. No response body."),
+            @ApiResponse(responseCode = "400", description = "Missing request body.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Missing or invalid request body."))),
+            @ApiResponse(responseCode = "500", description = "Schema validation or the save itself failed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error saving SNMP default overrides, failed schema validation.")))
     })
     Response saveDefaultOverrides(Configuration config);
 
@@ -90,16 +226,35 @@ public interface SnmpConfigRestApi {
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Add an SNMP configuration definition",
-            description = "Add an SNMP configuration definition.",
+            description = """
+        Add a `<definition>` to `snmp-config.xml`. At least one of `specific`, `range` or `ipMatch` has
+        to be present, and `ipMatch` cannot be combined with either of the other two. Every address and
+        range is parsed before the save, and `location` has to name an existing monitoring location
+        (omitted, empty or `Default` all mean the default location).
+
+        The factory merges the new entry into an existing definition when the two carry identical
+        attributes, and drops attributes that repeat the top-level defaults, so the saved XML may not
+        look field-for-field like the body that was sent. The `Location` header on the 201 points at
+        `/snmp-config` rather than at the new definition, which has no address of its own.""",
             operationId = "addDefinition"
     )
+    @RequestBody(
+            required = true,
+            description = "Definition to add.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = Definition.class),
+                    examples = @ExampleObject(value = DEFINITION_JSON_EXAMPLE))
+    )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "SNMP configuration definition added successfully",
-                    content = @Content),
-            @ApiResponse(responseCode = "400", description = "Bad Request – invalid or missing input parameters",
-                    content = @Content),
-            @ApiResponse(responseCode = "500", description = "Server Error or Bad Request – invalid or missing input parameters",
-                    content = @Content)
+            @ApiResponse(responseCode = "201", description = "SNMP configuration definition added successfully. No response body; `Location` is `/snmp-config`."),
+            @ApiResponse(responseCode = "400", description = "Missing body, no specific/range/ipMatch, `ipMatch` mixed with ranges or specifics, an unparseable address, or an unknown location.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Definition must have at least one specific IP, IP range or IP match specified."))),
+            @ApiResponse(responseCode = "500", description = "Schema validation or the save itself failed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error saving SNMP definition, failed schema validation.")))
     })
     Response addDefinition(Definition definition);
 
@@ -107,19 +262,31 @@ public interface SnmpConfigRestApi {
     @Path("/definition")
     @Operation(
             summary = "Delete an SNMP configuration definition",
-            description = "Delete an SNMP configuration definition for a location. User can provide comma-separated lists of specific IPs or IP ranges or IP match expressions to delete.",
+            description = """
+        Remove specific addresses, ranges or IP-match expressions from the definitions at one location.
+        Each parameter takes a comma-separated list; ranges use `begin-end`. A request that matches
+        nothing is reported as a 400 rather than as a no-op success.""",
             operationId = "removeDefinition"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", description = "SNMP configuration definition for the given item removed successfully",
-                    content = @Content),
-            @ApiResponse(responseCode = "400", description = "Bad Request – invalid or missing input parameters, or no matching definition found",
-                    content = @Content)
+            @ApiResponse(responseCode = "204", description = "SNMP configuration definition for the given item removed successfully. No response body."),
+            @ApiResponse(responseCode = "400", description = "No items supplied, an unparseable address or range, an unknown location, or nothing matched.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "No configuration items removed, mostly likely no matching definitions found."))),
+            @ApiResponse(responseCode = "500", description = "The removal failed.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error removing SNMP definition.")))
     })
     Response removeDefinition(
+            @Parameter(description = "Comma-separated specific IP addresses to remove.", example = "192.0.2.10,192.0.2.11")
             @QueryParam("specifics") String specifics,
+            @Parameter(description = "Comma-separated ranges to remove, each written `begin-end`.", example = "192.0.2.32-192.0.2.63")
             @QueryParam("ranges") String ranges,
+            @Parameter(description = "Comma-separated IP-match expressions to remove.", example = "192.0.2.*")
             @QueryParam("ipmatches") String ipMatches,
+            @Parameter(description = "Monitoring location the definitions belong to. Omitted, empty or `Default` all mean the default location.", example = "Default")
             @QueryParam("location") String location);
 
     @POST
@@ -127,14 +294,39 @@ public interface SnmpConfigRestApi {
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Add or update an SNMP configuration profile",
-            description = "Add or update an SNMP configuration profile.",
+            description = """
+        Add a profile, or replace the existing profile that carries the same `label`. `label` is
+        required. The XML `<filter>` element is `filter` in JSON: sending `filterExpression` fails with a
+        500 from the parser, as does any other field the bean does not declare. A body of `null` also
+        fails with a 500.""",
             operationId = "saveProfile"
     )
+    @RequestBody(
+            required = true,
+            description = "Profile to add or replace.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = SnmpProfile.class),
+                    examples = @ExampleObject(value = """
+                    {
+                      "label": "edge-switches",
+                      "filter": "iphostname LIKE '%edge%'",
+                      "version": "v2c",
+                      "readCommunity": "public",
+                      "port": 161,
+                      "timeout": 1800,
+                      "retry": 1
+                    }"""))
+    )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", description = "SNMP configuration profile added or updated successfully",
-                    content = @Content),
-            @ApiResponse(responseCode = "400", description = "Bad Request – invalid or missing input parameters",
-                    content = @Content)
+            @ApiResponse(responseCode = "204", description = "SNMP configuration profile added or updated successfully. No response body."),
+            @ApiResponse(responseCode = "400", description = "`label` was missing or empty.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Missing or invalid 'label'."))),
+            @ApiResponse(responseCode = "500", description = "A missing body, or a body carrying a field the bean does not declare.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Unrecognized field \"filterExpression\" (Class org.opennms.netmgt.config.snmp.SnmpProfile), not marked as ignorable")))
     })
     Response saveProfile(SnmpProfile profile);
 
@@ -142,48 +334,96 @@ public interface SnmpConfigRestApi {
     @Path("/profile")
     @Operation(
             summary = "Delete an SNMP configuration profile",
-            description = "Delete an SNMP configuration profile with the given label.",
+            description = "Delete the SNMP configuration profile carrying the given label.",
             operationId = "removeProfile"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", description = "SNMP configuration profile with the given label removed successfully",
-                    content = @Content),
-            @ApiResponse(responseCode = "400", description = "Bad Request – invalid or missing input parameters",
-                    content = @Content),
-            @ApiResponse(responseCode = "404", description = "Not Found – profile with given label not found",
-                    content = @Content)
+            @ApiResponse(responseCode = "204", description = "SNMP configuration profile with the given label removed successfully. No response body."),
+            @ApiResponse(responseCode = "400", description = "`label` was missing or empty.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Missing or invalid 'label'."))),
+            @ApiResponse(responseCode = "404", description = "No profile carries that label.",
+                    content = @Content(schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Profile with label edge-switches not found.")))
     })
-    Response removeProfile(@QueryParam("label") final String label);
+    Response removeProfile(
+            @Parameter(description = "Label of the profile to delete. Required.", required = true, example = "edge-switches")
+            @QueryParam("label") final String label);
 
     @GET
     @Path("/download")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     @Operation(
             summary = "Download SNMP configuration",
-            description = "Download SNMP configuration in Json or XML format, suitable for upload.",
+            description = """
+        Download the SNMP configuration as an attachment (`snmp-config.json` or `snmp-config.xml`),
+        for re-upload through `/snmp-config/upload` or `/snmp-config/upload/xml`.
+        `format=xml` selects XML; every other value, including an unrecognised one, yields JSON.
+
+        Only the XML form round-trips faithfully. The JSON form materialises inherited numeric fields as
+        literal `0`, so re-uploading it through `/snmp-config/upload` pins each definition's `timeout`
+        and `retry` to 0 instead of leaving them to inherit the top-level defaults. Prefer XML when the
+        download is meant to be restored.""",
             operationId = "downloadConfig"
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "SNMP configuration in download format retrieved successfully",
-                    content = { @Content(mediaType = "application/json"), @Content(mediaType = "application/xml") }),
-            @ApiResponse(responseCode = "400", description = "Bad Request – invalid or missing input parameters",
-                    content = @Content)
+                    content = {
+                        @Content(mediaType = MediaType.APPLICATION_JSON,
+                                schema = @Schema(implementation = SnmpConfig.class)),
+                        @Content(mediaType = MediaType.APPLICATION_XML,
+                                schema = @Schema(type = "string"),
+                                examples = @ExampleObject(value = """
+                    <snmp-config xmlns="http://xmlns.opennms.org/xsd/config/snmp" max-vars-per-pdu="10" max-repetitions="2" max-request-size="65535" version="v2c" read-community="public" timeout="1800" retry="1">
+                       <definition max-vars-per-pdu="10" max-repetitions="2" max-request-size="65535" port="1161">
+                          <specific>127.0.0.1</specific>
+                       </definition>
+                    </snmp-config>"""))
+                    }),
+            @ApiResponse(responseCode = "500", description = "The stored configuration could not be serialized.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error retrieving SNMP config.")))
     })
-    Response downloadConfig(@QueryParam("format") String format);
+    Response downloadConfig(
+            @Parameter(description = "`xml` for XML. Any other value, including an unrecognised one, yields JSON.",
+                    example = "xml",
+                    schema = @Schema(allowableValues = {"json", "xml"}))
+            @QueryParam("format") String format);
 
     @POST
     @Path("/upload")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Operation(
             summary = "Upload SNMP configuration in Json format.",
-            description = "Upload SNMP configuration in Json format and apply the changes.",
+            description = """
+        Replace the whole SNMP configuration from a JSON document and apply the changes. The single part
+        must be named `upload`. The document is converted to XML and validated against
+        `snmp-config.xsd` before it is applied.
+
+        A document produced by `GET /snmp-config/download` is not a faithful restore: its inherited
+        numeric fields are serialized as literal `0`, and uploading them pins each definition's
+        `timeout` and `retry` to 0. Use `/snmp-config/upload/xml` with the XML download to restore a
+        configuration unchanged.""",
             operationId = "uploadConfig"
     )
+    @RequestBody(
+            required = true,
+            description = "Multipart form with one `upload` part holding the JSON SNMP configuration.",
+            content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA,
+                    schema = @Schema(type = "string", format = "binary"))
+    )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "SNMP configuration uploaded and applied successfully",
-                    content = @Content),
-            @ApiResponse(responseCode = "400", description = "Bad Request – invalid or missing configuration.",
-                    content = @Content)
+            @ApiResponse(responseCode = "200", description = "SNMP configuration uploaded and applied successfully. No response body."),
+            @ApiResponse(responseCode = "400", description = "Unreadable, unparseable or schema-invalid document. A request with no `upload` part is rejected before the handler runs and has no body.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Invalid configuration file."))),
+            @ApiResponse(responseCode = "500", description = "The document parsed but could not be applied.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Could not save updated config")))
     })
     Response uploadConfig(@Multipart("upload") Attachment attachment);
 
@@ -192,14 +432,29 @@ public interface SnmpConfigRestApi {
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Operation(
             summary = "Upload SNMP configuration in XML format",
-            description = "Upload SNMP configuration in XML format and apply the changes.",
+            description = """
+        Replace the whole SNMP configuration from a `<snmp-config>` document and apply the changes. The
+        single part must be named `upload`. The document is validated against `snmp-config.xsd` before
+        it is applied. This is the path that restores a `GET /snmp-config/download?format=xml` body
+        byte-for-byte.""",
             operationId = "uploadConfigXml"
     )
+    @RequestBody(
+            required = true,
+            description = "Multipart form with one `upload` part holding the XML SNMP configuration.",
+            content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA,
+                    schema = @Schema(type = "string", format = "binary"))
+    )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "SNMP configuration uploaded and applied successfully",
-                    content = @Content),
-            @ApiResponse(responseCode = "400", description = "Bad Request – invalid or missing configuration.",
-                    content = @Content)
+            @ApiResponse(responseCode = "200", description = "SNMP configuration uploaded and applied successfully. No response body."),
+            @ApiResponse(responseCode = "400", description = "Unreadable, unparseable or schema-invalid document. A request with no `upload` part is rejected before the handler runs and has no body.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Invalid configuration file."))),
+            @ApiResponse(responseCode = "500", description = "The document parsed but could not be applied.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Could not save updated config")))
     })
     Response uploadConfigXml(@Multipart("upload") Attachment attachment);
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/TrapdRestApi.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/TrapdRestApi.java
@@ -33,7 +33,11 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 
@@ -44,26 +48,79 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.opennms.web.rest.v2.model.TrapdConfigDto;
 
 @Path("trapd")
-@Tag(name = "Trapd", description = "Trapd API V2")
+@Tag(name = "Trapd", description = """
+        Trapd API V2.
+
+        Reads and replaces the whole trapd configuration. There is no partial update: `PUT /trapd/config`
+        and both upload endpoints replace the stored configuration with the body they are given, so send a
+        complete document rather than the fields you want to change. `snmpTrapPort` and `newSuspectOnTrap`
+        must be present; the remaining numeric fields fall back to the defaults in
+        `trapd-configuration.xsd` when omitted.
+
+        SNMPv3 passphrases are masked as `******` by `GET /trapd/config`. Sending a masked value back on a
+        user that already has an `id` keeps the stored passphrase, which makes read-modify-write safe
+        without handling cleartext. Sending a masked value for a user id that does not already exist is
+        rejected with a 400. The two download endpoints return passphrases in cleartext, not masked.""")
 public interface TrapdRestApi {
+
+    String TRAPD_CONFIG_JSON_EXAMPLE = """
+            {
+              "snmpTrapAddress": "*",
+              "snmpTrapPort": 10162,
+              "newSuspectOnTrap": false,
+              "includeRawMessage": false,
+              "threads": 0,
+              "queueSize": 10000,
+              "batchSize": 1000,
+              "batchInterval": 500,
+              "useAddressFromVarbind": false,
+              "snmpv3User": [
+                {
+                  "id": "b0019905-75f8-4856-8c0b-84381e9485a3",
+                  "engineId": "0x0102030405",
+                  "securityName": "trapUser",
+                  "securityLevel": 3,
+                  "authProtocol": "SHA-256",
+                  "authPassphrase": "******",
+                  "privacyProtocol": "AES256",
+                  "privacyPassphrase": "******"
+                }
+              ]
+            }""";
+
     @POST
     @Path("upload")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Upload Trap configuration in JSON format.",
-            description = "Upload Trap configuration in JSON format and apply the changes. Requires ROLE_ADMIN.",
+            description = """
+        Upload Trap configuration in JSON format and apply the changes. Requires ROLE_ADMIN.
+        The single part must be named `upload` and hold a JSON document with the same shape as
+        `GET /trapd/config`. The uploaded document replaces the stored configuration in full, and a
+        successful response carries no body.""",
             operationId = "uploadTrapdConfiguration"
     )
+    @RequestBody(
+            required = true,
+            description = "Multipart form with one `upload` part holding the JSON trapd configuration.",
+            content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA,
+                    schema = @Schema(type = "string", format = "binary"))
+    )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Trap configuration uploaded and applied successfully",
-                content = @Content),
-            @ApiResponse(responseCode = "400", description = "Bad Request – invalid or missing configuration.",
-                content = @Content),
-            @ApiResponse(responseCode = "403", description = "Forbidden – admin role required.",
-                content = @Content),
+            @ApiResponse(responseCode = "200", description = "Trap configuration uploaded and applied successfully. No response body."),
+            @ApiResponse(responseCode = "400", description = "Unparseable JSON, a failed validation rule, or a masked passphrase on a user id that does not exist. A request with no `upload` part is rejected before the handler runs and has no body.",
+                content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                        schema = @Schema(type = "string"),
+                        examples = @ExampleObject(value = "snmpTrapPort is required and must be between 1 and 65535."))),
+            @ApiResponse(responseCode = "403", description = "Admin role required.",
+                content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                        schema = @Schema(type = "string"),
+                        examples = @ExampleObject(value = "Admin role required to upload Trapd configuration."))),
             @ApiResponse(responseCode = "500", description = "Failed to persist Trap configuration.",
-                content = @Content)
+                content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                        schema = @Schema(type = "string"),
+                        examples = @ExampleObject(value = "Failed to persist Trapd configuration.")))
     })
     Response uploadTrapdConfiguration(@Multipart("upload") Attachment attachment, @Context SecurityContext securityContext);
 
@@ -73,18 +130,33 @@ public interface TrapdRestApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Upload Trap configuration in XML format.",
-            description = "Upload Trap configuration in XML format and apply the changes. Requires ROLE_ADMIN.",
+            description = """
+        Upload Trap configuration in XML format and apply the changes. Requires ROLE_ADMIN.
+        The single part must be named `upload` and hold a `<trapd-configuration>` document, the same form
+        that `GET /trapd/download?format=xml` produces. The uploaded document replaces the stored
+        configuration in full, and a successful response carries no body.""",
             operationId = "uploadTrapdConfigurationXml"
     )
+    @RequestBody(
+            required = true,
+            description = "Multipart form with one `upload` part holding the XML trapd configuration.",
+            content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA,
+                    schema = @Schema(type = "string", format = "binary"))
+    )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Trap configuration uploaded and applied successfully",
-                content = @Content),
-            @ApiResponse(responseCode = "400", description = "Bad Request – invalid or missing configuration.",
-                content = @Content),
-            @ApiResponse(responseCode = "403", description = "Forbidden – admin role required.",
-                content = @Content),
+            @ApiResponse(responseCode = "200", description = "Trap configuration uploaded and applied successfully. No response body."),
+            @ApiResponse(responseCode = "400", description = "Unparseable or schema-invalid XML, or a failed validation rule. A request with no `upload` part is rejected before the handler runs and has no body.",
+                content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                        schema = @Schema(type = "string"),
+                        examples = @ExampleObject(value = "Invalid Trapd XML configuration."))),
+            @ApiResponse(responseCode = "403", description = "Admin role required.",
+                content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                        schema = @Schema(type = "string"),
+                        examples = @ExampleObject(value = "Admin role required to upload Trapd configuration."))),
             @ApiResponse(responseCode = "500", description = "Failed to persist Trap configuration.",
-                content = @Content)
+                content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                        schema = @Schema(type = "string"),
+                        examples = @ExampleObject(value = "Failed to persist Trapd configuration.")))
     })
     Response uploadTrapdConfigurationXml(@Multipart("upload") Attachment attachment, @Context SecurityContext securityContext);
 
@@ -93,31 +165,82 @@ public interface TrapdRestApi {
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     @Operation(
             summary = "Download trapd configuration",
-            description = "Download trapd configuration in JSON or XML format. Requires ROLE_ADMIN.",
-            operationId = "downloadConfig"
+            description = """
+        Download trapd configuration in JSON or XML format. Requires ROLE_ADMIN.
+        The response is served as an attachment (`trapd-config.json` or `trapd-config.xml`) and is
+        accepted back by the matching upload endpoint. SNMPv3 passphrases appear in cleartext here.""",
+            operationId = "downloadTrapdConfig"
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Trapd configuration in download format retrieved successfully",
-                    content = { @Content(mediaType = "application/json"), @Content(mediaType = "application/xml") }),
-            @ApiResponse(responseCode = "400", description = "Bad Request – invalid or missing input parameters",
-                    content = @Content),
-            @ApiResponse(responseCode = "403", description = "Forbidden – admin role required.",
-                    content = @Content)
+                    content = {
+                        @Content(mediaType = MediaType.APPLICATION_JSON,
+                                schema = @Schema(implementation = TrapdConfigDto.class),
+                                examples = @ExampleObject(value = """
+                    {
+                      "snmpTrapAddress" : "*",
+                      "snmpTrapPort" : 10162,
+                      "newSuspectOnTrap" : false,
+                      "includeRawMessage" : false,
+                      "threads" : 0,
+                      "queueSize" : 10000,
+                      "batchSize" : 1000,
+                      "batchInterval" : 500,
+                      "useAddressFromVarbind" : false,
+                      "snmpv3User" : [ ]
+                    }""")),
+                        @Content(mediaType = MediaType.APPLICATION_XML,
+                                schema = @Schema(type = "string"),
+                                examples = @ExampleObject(value = """
+                    <trapd-configuration xmlns="http://xmlns.opennms.org/xsd/config/trapd" snmp-trap-address="*" snmp-trap-port="10162" new-suspect-on-trap="false" include-raw-message="false" threads="0" queue-size="10000" batch-size="1000" batch-interval="500" use-address-from-varbind="false"/>"""))
+                    }),
+            @ApiResponse(responseCode = "400", description = "`format` was neither `json` nor `xml`.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Invalid format parameter. Supported values are 'json' and 'xml'."))),
+            @ApiResponse(responseCode = "403", description = "Admin role required.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Admin role required to download Trapd configuration."))),
+            @ApiResponse(responseCode = "404", description = "No trapd configuration is stored.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Trapd configuration not found."))),
+            @ApiResponse(responseCode = "500", description = "The stored configuration could not be serialized.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Error retrieving Trapd config.")))
     })
-    Response downloadTrapdConfig(@QueryParam("format") String format, @Context SecurityContext securityContext);
+    Response downloadTrapdConfig(
+            @Parameter(description = "Serialization format. Anything other than `json` or `xml` is rejected. Defaults to `json` when omitted.",
+                    example = "xml",
+                    schema = @Schema(allowableValues = {"json", "xml"}))
+            @QueryParam("format") String format,
+            @Context SecurityContext securityContext);
 
     @GET
     @Path("config")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Get trapd configuration",
-            description = "Retrieve the current trapd configuration.",
+            description = """
+        Retrieve the current trapd configuration. SNMPv3 passphrases are returned masked as `******`;
+        send those masked values straight back to `PUT /trapd/config` to keep the stored credentials.""",
             operationId = "getTrapdConfiguration"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Configuration retrieved successfully"),
-            @ApiResponse(responseCode = "404", description = "Configuration not found"),
-            @ApiResponse(responseCode = "500", description = "Failed to retrieve trapd configuration")
+            @ApiResponse(responseCode = "200", description = "Configuration retrieved successfully",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = TrapdConfigDto.class),
+                            examples = @ExampleObject(value = TRAPD_CONFIG_JSON_EXAMPLE))),
+            @ApiResponse(responseCode = "404", description = "No trapd configuration is stored.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Trapd configuration not found."))),
+            @ApiResponse(responseCode = "500", description = "Failed to retrieve trapd configuration",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Failed to retrieve Trapd configuration.")))
     })
     Response getTrapdConfiguration(@Context SecurityContext securityContext);
     
@@ -127,13 +250,31 @@ public interface TrapdRestApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Update trapd configuration",
-            description = "Update trapd configuration with provided JSON payload.",
+            description = """
+        Replace the trapd configuration with the supplied JSON document. The body is a whole
+        configuration, not a patch: omitted fields fall back to the XSD defaults rather than keeping
+        their current values. `snmpTrapPort` and `newSuspectOnTrap` are required.
+        A field the DTO does not declare fails with a 500 from the JSON parser rather than a 400.
+        A successful response carries no body.""",
             operationId = "updateTrapdConfiguration"
     )
+    @RequestBody(
+            required = true,
+            description = "Complete trapd configuration.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = TrapdConfigDto.class),
+                    examples = @ExampleObject(value = TRAPD_CONFIG_JSON_EXAMPLE))
+    )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Configuration updated successfully"),
-            @ApiResponse(responseCode = "400", description = "Invalid configuration payload"),
-            @ApiResponse(responseCode = "500", description = "Failed to update trapd configuration")
+            @ApiResponse(responseCode = "200", description = "Configuration updated successfully. No response body."),
+            @ApiResponse(responseCode = "400", description = "Missing body, a failed validation rule, a duplicate SNMPv3 user id, or a masked passphrase on a user id that does not exist.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Invalid SNMPv3 user at index 0: authProtocol and authPassphrase must be provided together."))),
+            @ApiResponse(responseCode = "500", description = "Failed to update trapd configuration, including a body carrying a field the DTO does not declare.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "Failed to persist Trapd configuration.")))
     })
     Response updateTrapdConfiguration(TrapdConfigDto payload, @Context SecurityContext securityContext);
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/TrapdRestApi.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/TrapdRestApi.java
@@ -52,15 +52,13 @@ import org.opennms.web.rest.v2.model.TrapdConfigDto;
         Trapd API V2.
 
         Reads and replaces the whole trapd configuration. There is no partial update: `PUT /trapd/config`
-        and both upload endpoints replace the stored configuration with the body they are given, so send a
-        complete document rather than the fields you want to change. `snmpTrapPort` and `newSuspectOnTrap`
-        must be present; the remaining numeric fields fall back to the defaults in
-        `trapd-configuration.xsd` when omitted.
+        and both upload endpoints replace the stored configuration with the body they are given.
+        `snmpTrapPort` and `newSuspectOnTrap` must be present; the remaining numeric fields fall back to
+        the defaults in `trapd-configuration.xsd` when omitted.
 
         SNMPv3 passphrases are masked as `******` by `GET /trapd/config`. Sending a masked value back on a
-        user that already has an `id` keeps the stored passphrase, which makes read-modify-write safe
-        without handling cleartext. Sending a masked value for a user id that does not already exist is
-        rejected with a 400. The two download endpoints return passphrases in cleartext, not masked.""")
+        user that already has an `id` keeps the stored passphrase. Sending a masked value for a user id
+        that does not already exist is rejected with a 400. The two download endpoints return passphrases in cleartext, not masked.""")
 public interface TrapdRestApi {
 
     String TRAPD_CONFIG_JSON_EXAMPLE = """
@@ -224,8 +222,8 @@ public interface TrapdRestApi {
     @Operation(
             summary = "Get trapd configuration",
             description = """
-        Retrieve the current trapd configuration. SNMPv3 passphrases are returned masked as `******`;
-        send those masked values straight back to `PUT /trapd/config` to keep the stored credentials.""",
+        Retrieve the current trapd configuration. SNMPv3 passphrases are returned masked as `******`; a
+        masked value sent back to `PUT /trapd/config` keeps the stored credentials.""",
             operationId = "getTrapdConfiguration"
     )
     @ApiResponses(value = {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/infopanel/InfoPanelItem.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/infopanel/InfoPanelItem.java
@@ -48,8 +48,8 @@ public class InfoPanelItem {
     private int order;
 
     @Schema(description = """
-            The template's rendered output. Operator-authored markup, so the consuming client is
-            responsible for sanitizing it before injecting it into the DOM.""",
+            The template's rendered output. Operator-authored markup, served without
+            sanitization.""",
             example = "<table><tr><td>sysName</td><td>loopback-001</td></tr></table>")
     @JsonProperty("html")
     private String html;

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/infopanel/InfoPanelItem.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/infopanel/InfoPanelItem.java
@@ -23,6 +23,8 @@ package org.opennms.web.rest.v2.infopanel;
 
 import org.codehaus.jackson.annotate.JsonProperty;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * One rendered info-panel item: a titled HTML fragment produced from an
  * {@code etc/infopanel/} Jinjava template. {@code order} controls display
@@ -31,12 +33,24 @@ import org.codehaus.jackson.annotate.JsonProperty;
  */
 public class InfoPanelItem {
 
+    @Schema(description = """
+            Panel heading, taken from the `title` variable the template set. Templates that set no title
+            get the literal `No title defined`.""",
+            example = "SNMP Attributes")
     @JsonProperty("title")
     private String title;
 
+    @Schema(description = """
+            Display position, ascending. Taken from the template's `order` variable; a missing or
+            non-numeric value becomes 0.""",
+            example = "10")
     @JsonProperty("order")
     private int order;
 
+    @Schema(description = """
+            The template's rendered output. Operator-authored markup, so the consuming client is
+            responsible for sanitizing it before injecting it into the DOM.""",
+            example = "<table><tr><td>sysName</td><td>loopback-001</td></tr></table>")
     @JsonProperty("html")
     private String html;
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/infopanel/TopologyInfopanelRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/infopanel/TopologyInfopanelRestService.java
@@ -89,9 +89,8 @@ public class TopologyInfopanelRestService {
             ]""";
 
     private static final String EMPTY_RESULT_NOTE = """
-            An empty array is the normal answer when `$OPENNMS_HOME/etc/infopanel/` holds no `*.html`
-            templates, or when every template set `visible` to false for this subject. It does not
-            indicate an error.""";
+            An empty array is returned when `$OPENNMS_HOME/etc/infopanel/` holds no `*.html`
+            templates, or when every template set `visible` to false for this subject.""";
 
     @GET
     @Transactional(readOnly = true)
@@ -145,8 +144,7 @@ public class TopologyInfopanelRestService {
         resolved to, and the discovery protocol.
 
         Port labels are matched against each node's SNMP interfaces by `ifName` first, then `ifDescr`.
-        A port that matches nothing leaves the endpoint's `snmpInterface` and `ifIndex` null, which
-        templates are expected to handle.
+        A port that matches nothing leaves the endpoint's `snmpInterface` and `ifIndex` null.
 
         """ + EMPTY_RESULT_NOTE,
             operationId = "getTopologyInfopanelForEdge")

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/infopanel/TopologyInfopanelRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/infopanel/TopologyInfopanelRestService.java
@@ -40,6 +40,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 /**
@@ -71,9 +79,47 @@ public class TopologyInfopanelRestService {
 
     private volatile InfoPanelRenderer m_renderer;
 
+    private static final String ITEMS_EXAMPLE = """
+            [
+              {
+                "title": "SNMP Attributes",
+                "order": 10,
+                "html": "<table><tr><td>sysName</td><td>loopback-001</td></tr></table>"
+              }
+            ]""";
+
+    private static final String EMPTY_RESULT_NOTE = """
+            An empty array is the normal answer when `$OPENNMS_HOME/etc/infopanel/` holds no `*.html`
+            templates, or when every template set `visible` to false for this subject. It does not
+            indicate an error.""";
+
     @GET
     @Transactional(readOnly = true)
-    public List<InfoPanelItem> getForNode(@QueryParam("nodeId") final Integer nodeId) {
+    @Operation(summary = "Get info-panel items for a node",
+            description = """
+        Renders every `*.html` Jinjava template in `$OPENNMS_HOME/etc/infopanel/` against the node and
+        returns the ones that set `visible` to true, sorted ascending by `order`. A template that fails
+        to render is skipped and logged; it does not fail the request.
+
+        """ + EMPTY_RESULT_NOTE,
+            operationId = "getTopologyInfopanelForNode")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Rendered items, empty when no template produced one.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            array = @ArraySchema(schema = @Schema(implementation = InfoPanelItem.class)),
+                            examples = @ExampleObject(value = ITEMS_EXAMPLE))),
+            @ApiResponse(responseCode = "400", description = "`nodeId` was not supplied.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "A nodeId query parameter is required"))),
+            @ApiResponse(responseCode = "404", description = """
+                    No node with that id. A non-numeric `nodeId` also lands here, as an empty-bodied 404
+                    from the parameter conversion rather than this message.""",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "No node with id 99999999")))
+    })
+    public List<InfoPanelItem> getForNode(@Parameter(description = "Numeric id of the node to render for.",
+                                                  required = true, example = "2")
+                                          @QueryParam("nodeId") final Integer nodeId) {
         if (nodeId == null) {
             throw webException(Response.Status.BAD_REQUEST, "A nodeId query parameter is required");
         }
@@ -92,10 +138,46 @@ public class TopologyInfopanelRestService {
     @GET
     @javax.ws.rs.Path("edge")
     @Transactional(readOnly = true)
-    public List<InfoPanelItem> getForEdge(@QueryParam("sourceNodeId") final Integer sourceNodeId,
+    @Operation(summary = "Get info-panel items for a link between two nodes",
+            description = """
+        Same template set and same visible/title/order contract as the node operation, rendered with an
+        `edge` context instead: the two endpoint nodes, their port labels, the SNMP interface each port
+        resolved to, and the discovery protocol.
+
+        Port labels are matched against each node's SNMP interfaces by `ifName` first, then `ifDescr`.
+        A port that matches nothing leaves the endpoint's `snmpInterface` and `ifIndex` null, which
+        templates are expected to handle.
+
+        """ + EMPTY_RESULT_NOTE,
+            operationId = "getTopologyInfopanelForEdge")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Rendered items, empty when no template produced one.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                            array = @ArraySchema(schema = @Schema(implementation = InfoPanelItem.class)),
+                            examples = @ExampleObject(value = ITEMS_EXAMPLE))),
+            @ApiResponse(responseCode = "400", description = "`sourceNodeId` or `targetNodeId` was not supplied.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "sourceNodeId and targetNodeId query parameters are required"))),
+            @ApiResponse(responseCode = "404", description = "Either endpoint id does not resolve to a node.",
+                    content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string"),
+                            examples = @ExampleObject(value = "No node with id 99999999")))
+    })
+    public List<InfoPanelItem> getForEdge(@Parameter(description = "Numeric id of the link's source node.",
+                                                  required = true, example = "2")
+                                          @QueryParam("sourceNodeId") final Integer sourceNodeId,
+                                          @Parameter(description = "Numeric id of the link's target node.",
+                                                  required = true, example = "1")
                                           @QueryParam("targetNodeId") final Integer targetNodeId,
+                                          @Parameter(description = """
+                                                  Port label on the source node, matched against its SNMP
+                                                  interfaces by ifName then ifDescr.""",
+                                                  example = "Gi0/1")
                                           @QueryParam("sourcePort") final String sourcePort,
+                                          @Parameter(description = "Port label on the target node, matched the same way.",
+                                                  example = "Gi0/2")
                                           @QueryParam("targetPort") final String targetPort,
+                                          @Parameter(description = "Discovery protocol the link came from, passed through to the templates.",
+                                                  example = "LLDP")
                                           @QueryParam("protocol") final String protocol) {
         if (sourceNodeId == null || targetNodeId == null) {
             throw webException(Response.Status.BAD_REQUEST, "sourceNodeId and targetNodeId query parameters are required");

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/AddEventConfSourceRequest.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/AddEventConfSourceRequest.java
@@ -21,10 +21,21 @@
  */
 package org.opennms.web.rest.v2.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "AddEventConfSourceRequest", description = "Request body used to create an empty EventConf source.")
 public class AddEventConfSourceRequest {
 
+    @Schema(description = "Source name. Conventionally the event file basename, without the '.xml' extension.",
+            example = "Cisco.syslog.events", required = true)
     private String name;
+
+    @Schema(description = "Free-form description of the source.",
+            example = "Syslog events forwarded by Cisco IOS devices")
     private String description;
+
+    @Schema(description = "Vendor the source belongs to. Defaults to the part of the name before the first dot, and must not exceed 128 characters.",
+            example = "Cisco")
     private String vendor;
 
     public AddEventConfSourceRequest() {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/AddEventConfSourceRequest.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/AddEventConfSourceRequest.java
@@ -26,7 +26,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(name = "AddEventConfSourceRequest", description = "Request body used to create an empty EventConf source.")
 public class AddEventConfSourceRequest {
 
-    @Schema(description = "Source name. Conventionally the event file basename, without the '.xml' extension.",
+    @Schema(description = "Source name.",
             example = "Cisco.syslog.events", required = true)
     private String name;
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/AlarmMemoRequest.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/AlarmMemoRequest.java
@@ -31,7 +31,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(name = "AlarmMemoRequest",
         description = """
                 Form parameters accepted by the sticky memo and journal (reduction key memo) updates.
-                Each call replaces the whole note; there is no append.""")
+                Each call replaces the whole note.""")
 public class AlarmMemoRequest {
 
     @Schema(description = "Memo text. Required: a request without it is rejected with 400.",

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/AlarmMemoRequest.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/AlarmMemoRequest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+
+package org.opennms.web.rest.v2.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Describes the form parameters the memo and journal handlers read out of a
+ * {@code MultivaluedMap}; it is not deserialised as a type.
+ */
+@Schema(name = "AlarmMemoRequest",
+        description = """
+                Form parameters accepted by the sticky memo and journal (reduction key memo) updates.
+                Each call replaces the whole note; there is no append.""")
+public class AlarmMemoRequest {
+
+    @Schema(description = "Memo text. Required: a request without it is rejected with 400.",
+            required = true,
+            example = "Waiting on the carrier.")
+    public String body;
+
+    @Schema(description = "Author recorded on the memo. Defaults to the authenticated user.",
+            example = "admin")
+    public String user;
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/AlarmPropertyUpdateRequest.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/AlarmPropertyUpdateRequest.java
@@ -47,7 +47,7 @@ public class AlarmPropertyUpdateRequest {
 
     @Schema(description = """
             User credited with the acknowledgement. Defaults to the authenticated user. A caller
-            without ROLE_ADMIN may only name itself.""",
+            without ROLE_ADMIN or ROLE_DELEGATE may only name itself.""",
             example = "admin")
     public String ackUser;
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/AlarmPropertyUpdateRequest.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/AlarmPropertyUpdateRequest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+
+package org.opennms.web.rest.v2.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Describes the form parameters the alarm and situation property-update handlers read out of a
+ * {@code MultivaluedMap}; it is not deserialised as a type.
+ */
+@Schema(name = "AlarmPropertyUpdateRequest",
+        description = """
+                Form parameters accepted by the alarm and situation property updates. Every field is
+                optional and only the fields present are acted on.
+
+                `ticketId` and `ticketState` are written straight onto the alarm row. `ack`,
+                `escalate` and `clear` are handled as acknowledgements instead and are mutually
+                exclusive: `ack` is examined first, then `escalate`, then `clear`, and the first one
+                present wins. `escalate=false` and `clear=false` are accepted and do nothing.
+
+                A `ticketState` that is not one of the enumerated names is ignored rather than
+                rejected, so a misspelt value still yields 204.""")
+public class AlarmPropertyUpdateRequest {
+
+    @Schema(description = "`true` acknowledges the alarm, `false` un-acknowledges it.", example = "true")
+    public Boolean ack;
+
+    @Schema(description = """
+            User credited with the acknowledgement. Defaults to the authenticated user. A caller
+            without ROLE_ADMIN may only name itself.""",
+            example = "admin")
+    public String ackUser;
+
+    @Schema(description = "`true` raises the severity by one step. Ignored unless `ack` is absent.",
+            example = "true")
+    public Boolean escalate;
+
+    @Schema(description = "`true` sets the severity to Cleared. Ignored unless `ack` and `escalate` are absent.",
+            example = "true")
+    public Boolean clear;
+
+    @Schema(description = "Trouble ticket identifier to store on the alarm.", example = "INC0012345")
+    public String ticketId;
+
+    @Schema(description = "Trouble ticket state. Unrecognised values are ignored.",
+            allowableValues = {"OPEN", "CREATE_PENDING", "CREATE_FAILED", "UPDATE_PENDING", "UPDATE_FAILED",
+                    "CLOSED", "CLOSE_PENDING", "CLOSE_FAILED", "RESOLVED", "RESOLVE_PENDING", "RESOLVE_FAILED",
+                    "CANCELLED", "CANCEL_PENDING", "CANCEL_FAILED"},
+            example = "OPEN")
+    public String ticketState;
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/DataCollectionConfErrorResponse.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/DataCollectionConfErrorResponse.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Documentation-only: describes the single-key error object several
+ * /datacollectionconf handlers build from an ad-hoc Map. Nothing returns this type.
+ */
+@Schema(description = "Single-key error object returned by the /datacollectionconf endpoints that wrap "
+        + "their message in an object rather than returning a bare string.")
+public class DataCollectionConfErrorResponse {
+
+    @Schema(description = "Human-readable reason the request was rejected.",
+            example = "Invalid offset/limit values (limit must be 1..1000)")
+    private String error;
+
+    public String getError() {
+        return error;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/DataCollectionConfUploadResponse.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/DataCollectionConfUploadResponse.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2.model;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+/**
+ * Documentation-only: describes the two-list body POST /datacollectionconf/upload
+ * builds from an ad-hoc Map. Nothing returns this type.
+ */
+@Schema(description = "Per-file outcome of a data collection config upload. A 200 only means the request "
+        + "was processed: files that failed to parse or failed to persist appear under `errors` while "
+        + "the rest are still stored.")
+public class DataCollectionConfUploadResponse {
+
+    @ArraySchema(schema = @Schema(implementation = SuccessEntry.class),
+            arraySchema = @Schema(description = "One entry per source stored and, on the bulk path, per "
+                    + "profile created or updated."))
+    private List<SuccessEntry> success;
+
+    @ArraySchema(schema = @Schema(implementation = ErrorEntry.class),
+            arraySchema = @Schema(description = "One entry per file that could not be processed."))
+    private List<ErrorEntry> errors;
+
+    public List<SuccessEntry> getSuccess() {
+        return success;
+    }
+
+    public void setSuccess(List<SuccessEntry> success) {
+        this.success = success;
+    }
+
+    public List<ErrorEntry> getErrors() {
+        return errors;
+    }
+
+    public void setErrors(List<ErrorEntry> errors) {
+        this.errors = errors;
+    }
+
+    @Schema(description = "A file that was accepted. On the sources-only path only `file` is present, "
+            + "and it carries the parsed <datacollection-group> name rather than the uploaded filename. "
+            + "On the bulk path (a <datacollection-config> in the batch) `file` is the uploaded "
+            + "basename and either `source` or `profile` names what was written.")
+    public static class SuccessEntry {
+
+        @Schema(description = "Source name on the sources-only path, uploaded basename on the bulk path.",
+                example = "Cisco")
+        private String file;
+
+        @Schema(description = "Name of the source that was created or updated. Bulk path only.",
+                example = "Cisco")
+        private String source;
+
+        @Schema(description = "Name of the profile that was created or updated from a <snmp-collection> "
+                + "entry. Bulk path only.",
+                example = "default")
+        private String profile;
+
+        public String getFile() {
+            return file;
+        }
+
+        public void setFile(String file) {
+            this.file = file;
+        }
+
+        public String getSource() {
+            return source;
+        }
+
+        public void setSource(String source) {
+            this.source = source;
+        }
+
+        public String getProfile() {
+            return profile;
+        }
+
+        public void setProfile(String profile) {
+            this.profile = profile;
+        }
+    }
+
+    @Schema(description = "A file that could not be processed.")
+    public static class ErrorEntry {
+
+        @Schema(description = "Source name or uploaded basename the failure is attributed to.",
+                example = "Broken")
+        private String file;
+
+        @Schema(description = "Exception simple name and message.",
+                example = "UnmarshalException: null")
+        private String error;
+
+        public String getFile() {
+            return file;
+        }
+
+        public void setFile(String file) {
+            this.file = file;
+        }
+
+        public String getError() {
+            return error;
+        }
+
+        public void setError(String error) {
+            this.error = error;
+        }
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/DataCollectionMibGroupPageResponse.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/DataCollectionMibGroupPageResponse.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2.model;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.opennms.netmgt.model.SnmpCollectionMibGroupDto;
+
+import java.util.List;
+
+/**
+ * Documentation-only: describes the paged body the matching /datacollectionconf filter
+ * handler builds from an ad-hoc Map. Nothing returns this type.
+ */
+@Schema(description = "One page of MIB groups belonging to a source.")
+public class DataCollectionMibGroupPageResponse {
+
+    @Schema(description = "Total number of matching rows, ignoring offset and limit.", example = "1")
+    private Integer totalRecords;
+
+    @ArraySchema(schema = @Schema(implementation = SnmpCollectionMibGroupDto.class),
+            arraySchema = @Schema(description = "The MIB groups on this page."))
+    private List<SnmpCollectionMibGroupDto> dataCollectionMibGroupList;
+
+    public Integer getTotalRecords() {
+        return totalRecords;
+    }
+
+    public void setTotalRecords(Integer totalRecords) {
+        this.totalRecords = totalRecords;
+    }
+
+    public List<SnmpCollectionMibGroupDto> getDataCollectionMibGroupList() {
+        return dataCollectionMibGroupList;
+    }
+
+    public void setDataCollectionMibGroupList(List<SnmpCollectionMibGroupDto> dataCollectionMibGroupList) {
+        this.dataCollectionMibGroupList = dataCollectionMibGroupList;
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/DataCollectionResourceTypePageResponse.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/DataCollectionResourceTypePageResponse.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2.model;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.opennms.netmgt.model.SnmpCollectionResourceTypeDto;
+
+import java.util.List;
+
+/**
+ * Documentation-only: describes the paged body the matching /datacollectionconf filter
+ * handler builds from an ad-hoc Map. Nothing returns this type.
+ */
+@Schema(description = "One page of resource types belonging to a source.")
+public class DataCollectionResourceTypePageResponse {
+
+    @Schema(description = "Total number of matching rows, ignoring offset and limit.", example = "1")
+    private Integer totalRecords;
+
+    @ArraySchema(schema = @Schema(implementation = SnmpCollectionResourceTypeDto.class),
+            arraySchema = @Schema(description = "The resource types on this page."))
+    private List<SnmpCollectionResourceTypeDto> dataCollectionResourceTypeList;
+
+    public Integer getTotalRecords() {
+        return totalRecords;
+    }
+
+    public void setTotalRecords(Integer totalRecords) {
+        this.totalRecords = totalRecords;
+    }
+
+    public List<SnmpCollectionResourceTypeDto> getDataCollectionResourceTypeList() {
+        return dataCollectionResourceTypeList;
+    }
+
+    public void setDataCollectionResourceTypeList(List<SnmpCollectionResourceTypeDto> dataCollectionResourceTypeList) {
+        this.dataCollectionResourceTypeList = dataCollectionResourceTypeList;
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/DataCollectionSystemDefPageResponse.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/DataCollectionSystemDefPageResponse.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2.model;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.opennms.netmgt.model.SnmpCollectionSystemDefDto;
+
+import java.util.List;
+
+/**
+ * Documentation-only: describes the paged body the matching /datacollectionconf filter
+ * handler builds from an ad-hoc Map. Nothing returns this type.
+ */
+@Schema(description = "One page of system definitions belonging to a source.")
+public class DataCollectionSystemDefPageResponse {
+
+    @Schema(description = "Total number of matching rows, ignoring offset and limit.", example = "1")
+    private Integer totalRecords;
+
+    @ArraySchema(schema = @Schema(implementation = SnmpCollectionSystemDefDto.class),
+            arraySchema = @Schema(description = "The system definitions on this page."))
+    private List<SnmpCollectionSystemDefDto> dataCollectionSystemDefsList;
+
+    public Integer getTotalRecords() {
+        return totalRecords;
+    }
+
+    public void setTotalRecords(Integer totalRecords) {
+        this.totalRecords = totalRecords;
+    }
+
+    public List<SnmpCollectionSystemDefDto> getDataCollectionSystemDefsList() {
+        return dataCollectionSystemDefsList;
+    }
+
+    public void setDataCollectionSystemDefsList(List<SnmpCollectionSystemDefDto> dataCollectionSystemDefsList) {
+        this.dataCollectionSystemDefsList = dataCollectionSystemDefsList;
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/EventConfErrorResponse.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/EventConfErrorResponse.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+
+package org.opennms.web.rest.v2.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/** Describes the JSON error body that some eventconf endpoints assemble; it is not returned as a type. */
+@Schema(name = "EventConfError", description = "Single-field error body used by the eventconf source and page endpoints.")
+public class EventConfErrorResponse {
+
+    @Schema(description = "Human-readable reason the request failed.", example = "Invalid sourceId provided")
+    public String error;
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/EventConfEventDeletePayload.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/EventConfEventDeletePayload.java
@@ -21,9 +21,15 @@
  */
 package org.opennms.web.rest.v2.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(name = "EventConfEventDeletePayload", description = "Identifies the events to delete from a single EventConf source.")
 public class EventConfEventDeletePayload {
+
+    @Schema(description = "IDs of the events to delete. Must contain at least one ID.",
+            example = "[42, 43]", required = true)
     private List<Long> eventIds;
 
     public EventConfEventDeletePayload() {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/EventConfEventEditRequest.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/EventConfEventEditRequest.java
@@ -21,6 +21,7 @@
  */
 package org.opennms.web.rest.v2.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.opennms.netmgt.xml.eventconf.Event;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -31,10 +32,14 @@ import java.io.Serializable;
 
 @XmlRootElement(name = "eventEdit")
 @XmlAccessorType(XmlAccessType.FIELD)
+@Schema(name = "EventConfEventEditRequest",
+        description = "Updates an existing EventConf event. Both members are optional: send 'event' to replace the event definition, 'enabled' to toggle it, or both.")
 public class EventConfEventEditRequest implements Serializable {
 
+    @Schema(description = "Whether the event participates in event matching.", example = "true")
     private Boolean enabled;
 
+    @Schema(description = "Replacement event definition, using the same structure as an <event> element in an eventconf file.")
     @XmlElement(name = "event", namespace = "http://xmlns.opennms.org/xsd/eventconf")
     private org.opennms.netmgt.xml.eventconf.Event event;
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/EventConfEventEditRequest.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/EventConfEventEditRequest.java
@@ -33,7 +33,7 @@ import java.io.Serializable;
 @XmlRootElement(name = "eventEdit")
 @XmlAccessorType(XmlAccessType.FIELD)
 @Schema(name = "EventConfEventEditRequest",
-        description = "Updates an existing EventConf event. Both members are optional: send 'event' to replace the event definition, 'enabled' to toggle it, or both.")
+        description = "Updates an existing EventConf event. `event` is required: the whole definition is replaced from it and `enabled` is applied with it. A body carrying only `enabled` fails with a 500.")
 public class EventConfEventEditRequest implements Serializable {
 
     @Schema(description = "Whether the event participates in event matching.", example = "true")

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/EventConfEventPageResponse.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/EventConfEventPageResponse.java
@@ -34,7 +34,7 @@ public class EventConfEventPageResponse {
     @Schema(description = "Total number of events matching the filter, ignoring pagination.", example = "132")
     public Integer totalRecords;
 
-    @Schema(description = "The requested page of events. Named after sources for historical reasons."
+    @Schema(description = "The requested page of events, under a key named for sources."
             + " Each entry's createdTime and lastModified come back as epoch milliseconds.")
     public List<EventConfEventDto> eventConfSourceList;
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/EventConfEventPageResponse.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/EventConfEventPageResponse.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+
+package org.opennms.web.rest.v2.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.opennms.netmgt.model.EventConfEventDto;
+
+import java.util.List;
+
+/** Describes the JSON that the event-filter endpoint assembles; it is not returned as a type. */
+@Schema(name = "EventConfEventPage", description = "One page of EventConf events plus the total match count.")
+public class EventConfEventPageResponse {
+
+    @Schema(description = "Total number of events matching the filter, ignoring pagination.", example = "132")
+    public Integer totalRecords;
+
+    @Schema(description = "The requested page of events. Named after sources for historical reasons."
+            + " Each entry's createdTime and lastModified come back as epoch milliseconds.")
+    public List<EventConfEventDto> eventConfSourceList;
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/EventConfSourceCreatedResponse.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/EventConfSourceCreatedResponse.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+
+package org.opennms.web.rest.v2.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/** Describes the JSON that the create-source endpoint assembles; it is not returned as a type. */
+@Schema(name = "EventConfSourceCreated", description = "Identifies a newly created EventConf source.")
+public class EventConfSourceCreatedResponse {
+
+    @Schema(description = "Database identifier assigned to the source.", example = "42")
+    public Long id;
+
+    @Schema(description = "Source name as stored.", example = "Cisco.syslog.events")
+    public String name;
+
+    @Schema(description = "Search order assigned to the source. New sources take the highest value.", example = "25")
+    public Integer fileOrder;
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/EventConfSourceDto.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/EventConfSourceDto.java
@@ -22,6 +22,7 @@
 
 package org.opennms.web.rest.v2.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.opennms.netmgt.model.EventConfSource;
 
 import java.util.Collections;
@@ -29,17 +30,43 @@ import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Schema(name = "EventConfSource", description = "An EventConf source, corresponding to one event configuration file.")
 public class EventConfSourceDto {
 
+    @Schema(description = "Database identifier of the source.", example = "17")
     private Long id;
+
+    @Schema(description = "Source name, normally the event file basename without the '.xml' extension.",
+            example = "Cisco.syslog.events")
     private String name;
+
+    @Schema(description = "Free-form description of the source.",
+            example = "Syslog events forwarded by Cisco IOS devices")
     private String description;
+
+    @Schema(description = "Vendor the source belongs to.", example = "Cisco")
     private String vendor;
+
+    @Schema(description = "Search order, and the tie-breaker when two sources define the same event: the higher fileOrder wins. The catch-all source is pinned at 1.",
+            example = "24")
     private Integer fileOrder;
+
+    @Schema(description = "Whether the source participates in event matching.", example = "true")
     private Boolean enabled;
+
+    @Schema(description = "Number of events the source holds.", example = "132")
     private Integer eventCount;
+
+    @Schema(type = "integer", format = "int64", example = "1787670300817",
+            description = "When the source was first stored, as epoch milliseconds.")
     private Date createdTime;
+
+    @Schema(type = "integer", format = "int64", example = "1787670354466",
+            description = "When the source or one of its events last changed, as epoch milliseconds.")
     private Date lastModified;
+
+    @Schema(description = "User who uploaded or created the source, or 'unknown' when the request carried no principal.",
+            example = "admin")
     private String uploadedBy;
 
     // All-args constructor

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/EventConfSourceDto.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/EventConfSourceDto.java
@@ -36,7 +36,7 @@ public class EventConfSourceDto {
     @Schema(description = "Database identifier of the source.", example = "17")
     private Long id;
 
-    @Schema(description = "Source name, normally the event file basename without the '.xml' extension.",
+    @Schema(description = "Source name.",
             example = "Cisco.syslog.events")
     private String name;
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/EventConfSourcePageResponse.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/EventConfSourcePageResponse.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+
+package org.opennms.web.rest.v2.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+/** Describes the JSON that the source-filter endpoint assembles; it is not returned as a type. */
+@Schema(name = "EventConfSourcePage", description = "One page of EventConf sources plus the total match count.")
+public class EventConfSourcePageResponse {
+
+    @Schema(description = "Total number of sources matching the filter, ignoring pagination.", example = "41")
+    public Integer totalRecords;
+
+    @Schema(description = "The requested page of sources.")
+    public List<EventConfSourceDto> eventConfSourceList;
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/EventConfUploadResponse.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/EventConfUploadResponse.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+
+package org.opennms.web.rest.v2.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+/** Describes the JSON that the upload endpoint assembles; it is not returned as a type. */
+@Schema(name = "EventConfUploadResponse",
+        description = "Per-file outcome of an eventconf upload. A file appears in exactly one of the two lists.")
+public class EventConfUploadResponse {
+
+    @Schema(description = "Files that were parsed and stored.")
+    public List<StoredFile> success;
+
+    @Schema(description = "Files that were rejected. The remaining files are still stored.")
+    public List<RejectedFile> errors;
+
+    @Schema(name = "EventConfUploadStoredFile")
+    public static class StoredFile {
+
+        @Schema(description = "Source name derived from the uploaded filename, without path or extension.",
+                example = "Cisco.syslog.events")
+        public String file;
+
+        @Schema(description = "Number of events the file contained.", example = "132")
+        public Integer eventCount;
+
+        @Schema(description = "Vendor derived from the part of the name before the first dot.", example = "Cisco")
+        public String vendor;
+
+        @Schema(description = "One entry per event in the file.")
+        public List<StoredEvent> events;
+    }
+
+    @Schema(name = "EventConfUploadStoredEvent")
+    public static class StoredEvent {
+
+        @Schema(example = "uei.opennms.org/vendor/cisco/syslog/LINK-3-UPDOWN")
+        public String uei;
+
+        @Schema(example = "Cisco Syslog: LINK-3-UPDOWN")
+        public String label;
+
+        @Schema(description = "Currently mirrors the event label rather than the event description.",
+                example = "Cisco Syslog: LINK-3-UPDOWN")
+        public String description;
+
+        @Schema(example = "true")
+        public Boolean enabled;
+    }
+
+    @Schema(name = "EventConfUploadRejectedFile")
+    public static class RejectedFile {
+
+        @Schema(description = "Source name derived from the uploaded filename.", example = "Broken.events")
+        public String file;
+
+        @Schema(description = "Exception class and message from the failed parse or store.",
+                example = "UnmarshalException: unexpected element (uri:\"\", local:\"evnts\")")
+        public String error;
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/EventConfUploadResponse.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/EventConfUploadResponse.java
@@ -63,7 +63,7 @@ public class EventConfUploadResponse {
         @Schema(example = "Cisco Syslog: LINK-3-UPDOWN")
         public String label;
 
-        @Schema(description = "Currently mirrors the event label rather than the event description.",
+        @Schema(description = "Mirrors the event label rather than the event description.",
                 example = "Cisco Syslog: LINK-3-UPDOWN")
         public String description;
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/NodeServiceTypeDto.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/NodeServiceTypeDto.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Describes one entry of the array returned by {@code GET /nodes/service-types}. The handler builds
+ * that array from ad-hoc maps, so this class documents the shape rather than being returned as a type.
+ */
+@Schema(name = "NodeServiceType", description = "A monitored service type known to the system.")
+public class NodeServiceTypeDto {
+
+    @Schema(description = "Database identifier of the service type.", example = "1")
+    private Integer id;
+
+    @Schema(description = "Service type name, as used by pollerd and by the monitored service resources.", example = "ICMP")
+    private String name;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(final Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/SnmpCollectionCreateSourceDto.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/SnmpCollectionCreateSourceDto.java
@@ -28,8 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Schema(description = """
-        Request body for creating an empty SNMP data collection source. Both fields are required: a
-        source that no profile references would never be scheduled by collectd.""")
+        Request body for creating an empty SNMP data collection source. Both fields are required.""")
 public class SnmpCollectionCreateSourceDto {
     @Schema(description = "Source name, unique across sources. Surrounding whitespace is trimmed. This "
             + "becomes the `<datacollection-group name=...>` of the source and the value profiles "

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/SnmpCollectionCreateSourceDto.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/SnmpCollectionCreateSourceDto.java
@@ -22,11 +22,24 @@
 
 package org.opennms.web.rest.v2.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.ArrayList;
 import java.util.List;
 
+@Schema(description = """
+        Request body for creating an empty SNMP data collection source. Both fields are required: a
+        source that no profile references would never be scheduled by collectd.""")
 public class SnmpCollectionCreateSourceDto {
+    @Schema(description = "Source name, unique across sources. Surrounding whitespace is trimmed. This "
+            + "becomes the `<datacollection-group name=...>` of the source and the value profiles "
+            + "reference in `sourceNames`.",
+            example = "Acme Packet", required = true)
     private String name;
+
+    @Schema(description = "Names of existing profiles to attach the new source to. At least one is "
+            + "required, and every name has to already exist.",
+            example = "[\"default\"]", required = true)
     private List<String> profiles = new ArrayList<>();
 
     public String getName() {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/SnmpCollectionSourceNamesAndIdsResponse.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/SnmpCollectionSourceNamesAndIdsResponse.java
@@ -21,13 +21,19 @@
  */
 package org.opennms.web.rest.v2.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@Schema(description = "One SNMP data collection source reduced to its id and name.")
 public class SnmpCollectionSourceNamesAndIdsResponse {
 
+    @Schema(description = "Source id.", example = "24")
     private Integer id;
+
+    @Schema(description = "Source name.", example = "Cisco")
     private String name;
 
     public SnmpCollectionSourceNamesAndIdsResponse(Integer id, String name) {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/SnmpCollectionSourcePageResponse.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/SnmpCollectionSourcePageResponse.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2.model;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.opennms.netmgt.model.SnmpCollectionSourceDto;
+
+import java.util.List;
+
+/**
+ * Documentation-only: describes the paged body the matching /datacollectionconf filter
+ * handler builds from an ad-hoc Map. Nothing returns this type.
+ */
+@Schema(description = "One page of SNMP data collection sources.")
+public class SnmpCollectionSourcePageResponse {
+
+    @Schema(description = "Total number of matching rows, ignoring offset and limit.", example = "1")
+    private Integer totalRecords;
+
+    @ArraySchema(schema = @Schema(implementation = SnmpCollectionSourceDto.class),
+            arraySchema = @Schema(description = "The sources on this page."))
+    private List<SnmpCollectionSourceDto> snmpCollectionSourceList;
+
+    public Integer getTotalRecords() {
+        return totalRecords;
+    }
+
+    public void setTotalRecords(Integer totalRecords) {
+        this.totalRecords = totalRecords;
+    }
+
+    public List<SnmpCollectionSourceDto> getSnmpCollectionSourceList() {
+        return snmpCollectionSourceList;
+    }
+
+    public void setSnmpCollectionSourceList(List<SnmpCollectionSourceDto> snmpCollectionSourceList) {
+        this.snmpCollectionSourceList = snmpCollectionSourceList;
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/SnmpConfigProfileDto.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/SnmpConfigProfileDto.java
@@ -22,11 +22,22 @@
 
 package org.opennms.web.rest.v2.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.opennms.web.svclayer.model.SnmpInfo;
 import org.opennms.netmgt.config.snmp.SnmpProfile;
 
+@Schema(description = """
+        An SNMP profile expressed with the flatter `SnmpInfo` field names, plus the profile's label and
+        filter. `toSnmpProfile` converts it to the `SnmpProfile` bean that `POST /snmp-config/profile`
+        consumes.""")
 public class SnmpConfigProfileDto extends SnmpInfo {
+    @Schema(description = "Profile label. Identifies the profile for update and delete.",
+            example = "edge-switches", required = true)
     protected String label;
+
+    @Schema(description = "Filter expression deciding which interfaces the profile is tried against. "
+            + "Empty means every interface.",
+            example = "iphostname LIKE '%edge%'")
     protected String filterExpression;
 
     public String getLabel() {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/Snmpv3UserDto.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/Snmpv3UserDto.java
@@ -33,9 +33,9 @@ import org.opennms.web.rest.support.MaskedCredential;
         when `securityLevel` is present it has to agree with which of those pairs are set.
         Passphrases must be at least 8 bytes and must not begin with `*`.""")
 public class Snmpv3UserDto {
-    @Schema(description = "Stable identifier for this user, assigned on first persist. Carry it back on "
-            + "an update so a masked passphrase can be resolved against the stored value. Leave it out "
-            + "for a new user.",
+    @Schema(description = "Stable identifier for this user, assigned on first persist. When it is "
+            + "present on an update, a masked passphrase resolves against the stored value. A new user "
+            + "has none.",
             example = "b0019905-75f8-4856-8c0b-84381e9485a3")
     private String id;
 
@@ -55,8 +55,8 @@ public class Snmpv3UserDto {
             allowableValues = {"MD5", "SHA", "SHA-224", "SHA-256", "SHA-512"})
     private String authProtocol;
 
-    @Schema(description = "Authentication passphrase, at least 8 bytes. Read back as `******`; send that "
-            + "masked value unchanged to keep the stored passphrase.",
+    @Schema(description = "Authentication passphrase, at least 8 bytes. Read back as `******`; that "
+            + "masked value sent back unchanged keeps the stored passphrase.",
             example = "******")
     @MaskedCredential
     private String authPassphrase;
@@ -65,8 +65,8 @@ public class Snmpv3UserDto {
             allowableValues = {"DES", "AES", "AES192", "AES256"})
     private String privacyProtocol;
 
-    @Schema(description = "Privacy passphrase, at least 8 bytes. Read back as `******`; send that masked "
-            + "value unchanged to keep the stored passphrase.",
+    @Schema(description = "Privacy passphrase, at least 8 bytes. Read back as `******`; that masked "
+            + "value sent back unchanged keeps the stored passphrase.",
             example = "******")
     @MaskedCredential
     private String privacyPassphrase;

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/Snmpv3UserDto.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/Snmpv3UserDto.java
@@ -21,18 +21,53 @@
  */
 package org.opennms.web.rest.v2.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.opennms.netmgt.config.trapd.Snmpv3User;
 import org.opennms.web.rest.support.MaskedCredential;
 
+@Schema(description = """
+        An SNMPv3 user that trapd accepts traps from.
+
+        `securityName` is the only required field. `authProtocol`/`authPassphrase` and
+        `privacyProtocol`/`privacyPassphrase` each have to be supplied together or not at all, and
+        when `securityLevel` is present it has to agree with which of those pairs are set.
+        Passphrases must be at least 8 bytes and must not begin with `*`.""")
 public class Snmpv3UserDto {
+    @Schema(description = "Stable identifier for this user, assigned on first persist. Carry it back on "
+            + "an update so a masked passphrase can be resolved against the stored value. Leave it out "
+            + "for a new user.",
+            example = "b0019905-75f8-4856-8c0b-84381e9485a3")
     private String id;
+
+    @Schema(description = "SNMP engine ID this user is scoped to, as a hex string. Optional.",
+            example = "0x0102030405")
     private String engineId;
+
+    @Schema(description = "SNMPv3 user name. Required.", example = "trapUser", required = true)
     private String securityName;
+
+    @Schema(description = "1 = noAuthNoPriv, 2 = authNoPriv, 3 = authPriv. Optional; when present it must "
+            + "match the credentials supplied.",
+            example = "3", allowableValues = {"1", "2", "3"})
     private Integer securityLevel;
+
+    @Schema(description = "Authentication digest.", example = "SHA-256",
+            allowableValues = {"MD5", "SHA", "SHA-224", "SHA-256", "SHA-512"})
     private String authProtocol;
+
+    @Schema(description = "Authentication passphrase, at least 8 bytes. Read back as `******`; send that "
+            + "masked value unchanged to keep the stored passphrase.",
+            example = "******")
     @MaskedCredential
     private String authPassphrase;
+
+    @Schema(description = "Privacy cipher.", example = "AES256",
+            allowableValues = {"DES", "AES", "AES192", "AES256"})
     private String privacyProtocol;
+
+    @Schema(description = "Privacy passphrase, at least 8 bytes. Read back as `******`; send that masked "
+            + "value unchanged to keep the stored passphrase.",
+            example = "******")
     @MaskedCredential
     private String privacyPassphrase;
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/SourceNameDto.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/SourceNameDto.java
@@ -22,12 +22,19 @@
 
 package org.opennms.web.rest.v2.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@Schema(name = "EventConfSourceNameAndId", description = "An EventConf source reduced to its identifier and name.")
 public class SourceNameDto {
+
+    @Schema(description = "Database identifier of the source.", example = "17")
     private Long id;
+
+    @Schema(description = "Source name.", example = "Cisco.syslog.events")
     private String name;
 
     public SourceNameDto(Long id, String name) {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/TrapdConfigDto.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/TrapdConfigDto.java
@@ -21,21 +21,56 @@
  */
 package org.opennms.web.rest.v2.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.opennms.netmgt.config.trapd.TrapdConfiguration;
 
 import java.util.Arrays;
 import java.util.List;
 
+@Schema(description = """
+        Complete trapd configuration. Writes replace the stored document rather than patching it, so a
+        field left out falls back to its XSD default instead of keeping its current value.""")
 public class TrapdConfigDto {
+    @Schema(description = "Address trapd binds its listener to. `*` binds every interface.",
+            example = "*")
     private String snmpTrapAddress;
+
+    @Schema(description = "UDP port trapd listens on. Required, 1 to 65535.",
+            example = "10162", required = true, minimum = "1", maximum = "65535")
     private Integer snmpTrapPort;
+
+    @Schema(description = "Whether a trap from an unknown address raises a newSuspect event. Required.",
+            example = "false", required = true)
     private Boolean newSuspectOnTrap;
+
+    @Schema(description = "Whether the raw trap PDU is attached to the generated event.",
+            example = "false")
     private Boolean includeRawMessage;
+
+    @Schema(description = "Worker threads for trap processing. 0 sizes the pool from the available "
+            + "processors. Must be non-negative.",
+            example = "0", minimum = "0")
     private Integer threads;
+
+    @Schema(description = "Depth of the queue between the listener and the workers. Must be greater "
+            + "than 0.",
+            example = "10000", minimum = "1")
     private Integer queueSize;
+
+    @Schema(description = "Maximum traps sent onward in one batch. Must be greater than 0.",
+            example = "1000", minimum = "1")
     private Integer batchSize;
+
+    @Schema(description = "Milliseconds to wait before flushing a partial batch. Must be non-negative.",
+            example = "500", minimum = "0")
     private Integer batchInterval;
+
+    @Schema(description = "Whether the agent address is taken from the trap's snmpTrapAddress varbind "
+            + "rather than the packet source.",
+            example = "false")
     private Boolean useAddressFromVarbind;
+
+    @Schema(description = "SNMPv3 users trapd accepts traps from. Each `id` must be unique.")
     private List<Snmpv3UserDto> snmpv3User;
 
     public String getSnmpTrapAddress() {


### PR DESCRIPTION
After some user feedback in mattermost it's pretty apparent we need to add response/request examples and schemas to pretty much all of our API docs.  This gets that done in bulk so it's a hefty update but it does not touch any runtime logic.

In theory, every operation in both v1 and v2 APIs now carries a summary, a unique operationId, a request schema and example where it reads a body, and a schema and example for each status code it can actually return. **Each was exercised against a running instance, so the annotations describe observed behavior rather than intent.**

I leveraged multiple claude agents to do this in one go so I would treat this as a bulk operation on the premise that some documentation that could be wrong is better than a complete void of documentation.  

It definitely will need further refinement and review.  I've spot checked a handful of these and they do seem accurate enough that someone can more easily sort out how the API works and it's a meaningful improvement over what we have today.

This one is a "I'd claim _assisted_ but that feels like cheating" by Anthropic Claude Opus 5 (x10).

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20263

