### PR TITLE
NMS-20265: Add PostgreSQL health metrics to the default JDBC collection

### DIFF
--- a/core/schema/src/main/java/org/opennms/core/schema/Migrator.java
+++ b/core/schema/src/main/java/org/opennms/core/schema/Migrator.java
@@ -461,6 +461,38 @@ public class Migrator {
     }
 
     /**
+     * <p>grantPgMonitorToUser</p>
+     *
+     * Grants the built-in pg_monitor role to the OpenNMS database user so the
+     * PostgreSQL data collection queries in the default JDBC collection can see
+     * sessions owned by other roles in pg_stat_activity. The grant is idempotent
+     * and runs on every install and upgrade. A failure is logged as a warning
+     * instead of aborting the migration, because the database may be managed
+     * externally with a restricted admin account; in that case the grant must be
+     * applied manually.
+     */
+    public void grantPgMonitorToUser() {
+        if (!m_createUser) {
+            return;
+        }
+
+        LOG.info("granting pg_monitor to the OpenNMS user");
+        Statement st = null;
+        Connection c = null;
+        try {
+            c = m_adminDataSource.getConnection();
+            st = c.createStatement();
+            st.execute("GRANT pg_monitor TO " + getUserForONMSDB());
+        } catch (final SQLException e) {
+            LOG.warn("Unable to grant pg_monitor to {}. PostgreSQL monitoring metrics based on pg_stat_activity"
+                    + " will be incomplete until \"GRANT pg_monitor TO {}\" is run manually.",
+                    getUserForONMSDB(), getUserForONMSDB(), e);
+        } finally {
+            cleanUpDatabase(c, null, st, null);
+        }
+    }
+
+    /**
      * <p>databaseExists</p>
      *
      * @return a boolean.
@@ -900,6 +932,7 @@ public class Migrator {
     public void prepareDatabase() throws MigrationException {
         validateDatabaseVersion();
         createUser();
+        grantPgMonitorToUser();
         createSchema();
         createDatabase();
         createLangPlPgsql();

--- a/opennms-base-assembly/src/main/filtered/etc/jdbc-datacollection-config.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/jdbc-datacollection-config.xml
@@ -33,6 +33,102 @@
                <column name="nodeCount" data-source-name="NodeCount" type="gauge" alias="OnmsNodeCount"/>
             </columns>
          </query>
+         <query name="pg_dead_tuples" recheckInterval="0" ifType="all">
+            <statement>
+               <queryString>
+                    SELECT COALESCE(SUM(n_dead_tup), 0) AS n_dead_tup
+                    FROM pg_stat_all_tables
+                    WHERE schemaname NOT IN ('pg_catalog', 'information_schema') AND schemaname NOT LIKE 'pg_toast%'
+                    </queryString>
+            </statement>
+            <columns>
+               <column name="n_dead_tup" data-source-name="n_dead_tup" type="gauge" alias="pg_n_dead_tup"/>
+            </columns>
+         </query>
+         <!--
+              The pg_stat_activity based queries below (backend states, xid horizon,
+              autovacuum workers) need full visibility into other sessions, which
+              PostgreSQL only gives to superusers and members of the pg_monitor role.
+              The OpenNMS installer grants pg_monitor to the OpenNMS database user
+              when it prepares the database; on databases managed outside the
+              installer, run "GRANT pg_monitor TO <opennms-user>;" manually. Without
+              the grant, PostgreSQL nulls out state, backend_xmin, and backend_type
+              for sessions the role does not own: the state counts and horizon ages
+              silently under-report, their thresholds can never fire, and autovacuum
+              workers are never visible at all. The pg_sa_masked datasource counts
+              sessions hidden from the monitoring role and must be 0 on a correctly
+              configured server; a nonzero value means the grant is missing.
+         -->
+         <query name="pg_stat_activity_state" recheckInterval="0" ifType="all">
+            <statement>
+               <queryString>
+                    SELECT COUNT(*) FILTER (WHERE state = 'starting') AS starting,
+                           COUNT(*) FILTER (WHERE state = 'active') AS active,
+                           COUNT(*) FILTER (WHERE state = 'idle') AS idle,
+                           COUNT(*) FILTER (WHERE state = 'idle in transaction') AS idle_in_txn,
+                           COUNT(*) FILTER (WHERE state = 'idle in transaction (aborted)') AS idle_in_txn_abrt,
+                           COUNT(*) FILTER (WHERE state = 'fastpath function call') AS fastpath,
+                           COUNT(*) FILTER (WHERE state = 'disabled') AS disabled,
+                           COUNT(*) FILTER (WHERE backend_type IS NULL) AS masked
+                    FROM pg_stat_activity
+                    </queryString>
+            </statement>
+            <columns>
+               <column name="masked" data-source-name="masked" type="gauge" alias="pg_sa_masked"/>
+               <column name="starting" data-source-name="starting" type="gauge" alias="pg_sa_starting"/>
+               <column name="active" data-source-name="active" type="gauge" alias="pg_sa_active"/>
+               <column name="idle" data-source-name="idle" type="gauge" alias="pg_sa_idle"/>
+               <column name="idle_in_txn" data-source-name="idle_in_txn" type="gauge" alias="pg_sa_idle_txn"/>
+               <column name="idle_in_txn_abrt" data-source-name="idle_in_txn_abrt" type="gauge" alias="pg_sa_idle_txn_abrt"/>
+               <column name="fastpath" data-source-name="fastpath" type="gauge" alias="pg_sa_fastpath"/>
+               <column name="disabled" data-source-name="disabled" type="gauge" alias="pg_sa_disabled"/>
+            </columns>
+         </query>
+         <query name="pg_xid_horizon" recheckInterval="0" ifType="all">
+            <statement>
+               <queryString>
+                    WITH ages AS (
+                        SELECT
+                            (SELECT MAX(AGE(backend_xmin)) FROM pg_stat_activity) AS backend_xmin_age,
+                            (SELECT MAX(AGE(xmin)) FROM pg_replication_slots) AS slot_xmin_age,
+                            (SELECT MAX(AGE(catalog_xmin)) FROM pg_replication_slots) AS slot_catalog_age,
+                            (SELECT MAX(AGE(backend_xmin)) FROM pg_stat_replication) AS standby_xmin_age,
+                            (SELECT MAX(AGE(transaction)) FROM pg_prepared_xacts) AS prepared_xact_age
+                    )
+                    SELECT
+                        COALESCE(backend_xmin_age, 0) AS backend_xmin_age,
+                        COALESCE(slot_xmin_age, 0) AS slot_xmin_age,
+                        COALESCE(slot_catalog_age, 0) AS slot_catalog_age,
+                        COALESCE(standby_xmin_age, 0) AS standby_xmin_age,
+                        COALESCE(prepared_xact_age, 0) AS prepared_xact_age,
+                        COALESCE(GREATEST(backend_xmin_age, slot_xmin_age, standby_xmin_age, prepared_xact_age), 0) AS data_horizon_age,
+                        COALESCE(GREATEST(backend_xmin_age, slot_xmin_age, standby_xmin_age, prepared_xact_age, slot_catalog_age), 0) AS catalog_horizon_age
+                    FROM ages
+                    </queryString>
+            </statement>
+            <columns>
+               <column name="backend_xmin_age" data-source-name="backend_xmin_age" type="gauge" alias="pg_backend_xmin_age"/>
+               <column name="slot_xmin_age" data-source-name="slot_xmin_age" type="gauge" alias="pg_slot_xmin_age"/>
+               <column name="slot_catalog_age" data-source-name="slot_catalog_age" type="gauge" alias="pg_slot_catalog_age"/>
+               <column name="standby_xmin_age" data-source-name="standby_xmin_age" type="gauge" alias="pg_standby_xmin_age"/>
+               <column name="prepared_xact_age" data-source-name="prepared_xact_age" type="gauge" alias="pg_prepared_age"/>
+               <column name="data_horizon_age" data-source-name="data_horizon_age" type="gauge" alias="pg_data_horizon_age"/>
+               <column name="catalog_horizon_age" data-source-name="catalog_horizon_age" type="gauge" alias="pg_cat_horizon_age"/>
+            </columns>
+         </query>
+         <query name="pg_autovacuum" recheckInterval="0" ifType="all">
+            <statement>
+               <queryString>
+                    SELECT
+                        (SELECT COUNT(*) FROM pg_stat_activity WHERE backend_type = 'autovacuum worker') AS av_workers,
+                        current_setting('autovacuum_max_workers')::int AS av_max_workers
+                    </queryString>
+            </statement>
+            <columns>
+               <column name="av_workers" data-source-name="av_workers" type="gauge" alias="pg_av_workers"/>
+               <column name="av_max_workers" data-source-name="av_max_workers" type="gauge" alias="pg_av_max_workers"/>
+            </columns>
+         </query>
       </queries>
    </jdbc-collection>
 </jdbc-datacollection-config>

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/postgresql-activity-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/postgresql-activity-graph.properties
@@ -1,0 +1,67 @@
+#
+# PostgreSQL Backend Activity Reports
+#
+
+reports=pgsql.backendstates, pgsql.autovacuum
+
+report.pgsql.backendstates.name=PostgreSQL Backend States
+report.pgsql.backendstates.type=nodeSnmp
+report.pgsql.backendstates.columns=pg_sa_active,pg_sa_idle,pg_sa_idle_txn,pg_sa_idle_txn_abrt,pg_sa_fastpath,pg_sa_disabled,pg_sa_starting,pg_sa_masked
+report.pgsql.backendstates.command=--title="PostgreSQL Backend States" \
+ --vertical-label="backends" \
+ DEF:active={rrd1}:pg_sa_active:AVERAGE \
+ DEF:idle={rrd2}:pg_sa_idle:AVERAGE \
+ DEF:idletxn={rrd3}:pg_sa_idle_txn:AVERAGE \
+ DEF:idletxnabrt={rrd4}:pg_sa_idle_txn_abrt:AVERAGE \
+ DEF:fastpath={rrd5}:pg_sa_fastpath:AVERAGE \
+ DEF:disabled={rrd6}:pg_sa_disabled:AVERAGE \
+ DEF:starting={rrd7}:pg_sa_starting:AVERAGE \
+ DEF:masked={rrd8}:pg_sa_masked:AVERAGE \
+ AREA:active#7EE600:"Active                 " \
+ GPRINT:active:AVERAGE:" Avg\\: %8.2lf %s" \
+ GPRINT:active:MIN:"Min\\: %8.2lf %s" \
+ GPRINT:active:MAX:"Max\\: %8.2lf %s\\n" \
+ STACK:idle#00A0C1:"Idle                   " \
+ GPRINT:idle:AVERAGE:" Avg\\: %8.2lf %s" \
+ GPRINT:idle:MIN:"Min\\: %8.2lf %s" \
+ GPRINT:idle:MAX:"Max\\: %8.2lf %s\\n" \
+ STACK:idletxn#FFCC00:"Idle in Txn            " \
+ GPRINT:idletxn:AVERAGE:" Avg\\: %8.2lf %s" \
+ GPRINT:idletxn:MIN:"Min\\: %8.2lf %s" \
+ GPRINT:idletxn:MAX:"Max\\: %8.2lf %s\\n" \
+ STACK:idletxnabrt#FF0000:"Idle in Txn (aborted)  " \
+ GPRINT:idletxnabrt:AVERAGE:" Avg\\: %8.2lf %s" \
+ GPRINT:idletxnabrt:MIN:"Min\\: %8.2lf %s" \
+ GPRINT:idletxnabrt:MAX:"Max\\: %8.2lf %s\\n" \
+ STACK:fastpath#B575E5:"Fastpath Function Call " \
+ GPRINT:fastpath:AVERAGE:" Avg\\: %8.2lf %s" \
+ GPRINT:fastpath:MIN:"Min\\: %8.2lf %s" \
+ GPRINT:fastpath:MAX:"Max\\: %8.2lf %s\\n" \
+ STACK:disabled#888888:"Disabled               " \
+ GPRINT:disabled:AVERAGE:" Avg\\: %8.2lf %s" \
+ GPRINT:disabled:MIN:"Min\\: %8.2lf %s" \
+ GPRINT:disabled:MAX:"Max\\: %8.2lf %s\\n" \
+ STACK:starting#F5B26B:"Starting               " \
+ GPRINT:starting:AVERAGE:" Avg\\: %8.2lf %s" \
+ GPRINT:starting:MIN:"Min\\: %8.2lf %s" \
+ GPRINT:starting:MAX:"Max\\: %8.2lf %s\\n" \
+ STACK:masked#000000:"Masked (no pg_monitor) " \
+ GPRINT:masked:AVERAGE:" Avg\\: %8.2lf %s" \
+ GPRINT:masked:MIN:"Min\\: %8.2lf %s" \
+ GPRINT:masked:MAX:"Max\\: %8.2lf %s\\n"
+
+report.pgsql.autovacuum.name=PostgreSQL Autovacuum Workers
+report.pgsql.autovacuum.type=nodeSnmp
+report.pgsql.autovacuum.columns=pg_av_workers,pg_av_max_workers
+report.pgsql.autovacuum.command=--title="PostgreSQL Autovacuum Workers" \
+ --vertical-label="workers" \
+ DEF:workers={rrd1}:pg_av_workers:AVERAGE \
+ DEF:maxworkers={rrd2}:pg_av_max_workers:AVERAGE \
+ AREA:workers#7EE600:"Active Workers" \
+ GPRINT:workers:AVERAGE:" Avg\\: %8.2lf %s" \
+ GPRINT:workers:MIN:"Min\\: %8.2lf %s" \
+ GPRINT:workers:MAX:"Max\\: %8.2lf %s\\n" \
+ LINE2:maxworkers#FF0000:"Max Workers   " \
+ GPRINT:maxworkers:AVERAGE:" Avg\\: %8.2lf %s" \
+ GPRINT:maxworkers:MIN:"Min\\: %8.2lf %s" \
+ GPRINT:maxworkers:MAX:"Max\\: %8.2lf %s\\n"

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/postgresql-dead-tuples-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/postgresql-dead-tuples-graph.properties
@@ -1,0 +1,16 @@
+#
+# PostgreSQL Dead Tuples Reports
+#
+
+reports=pgsql.deadtuples
+
+report.pgsql.deadtuples.name=PostgreSQL Dead Tuples
+report.pgsql.deadtuples.type=nodeSnmp
+report.pgsql.deadtuples.columns=pg_n_dead_tup
+report.pgsql.deadtuples.command=--title="PostgreSQL Dead Tuples" \
+ --vertical-label="dead tuples" \
+ DEF:dead={rrd1}:pg_n_dead_tup:AVERAGE \
+ AREA:dead#7EE600:"Dead Tuples" \
+ GPRINT:dead:AVERAGE:" Avg\\: %8.2lf %s" \
+ GPRINT:dead:MIN:"Min\\: %8.2lf %s" \
+ GPRINT:dead:MAX:"Max\\: %8.2lf %s\\n"

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/postgresql-xid-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/postgresql-xid-graph.properties
@@ -1,0 +1,52 @@
+#
+# PostgreSQL XID Horizon Reports
+#
+
+reports=pgsql.xidhorizon, pgsql.xidholders
+
+report.pgsql.xidhorizon.name=PostgreSQL XID Horizon Age
+report.pgsql.xidhorizon.type=nodeSnmp
+report.pgsql.xidhorizon.columns=pg_data_horizon_age,pg_cat_horizon_age
+report.pgsql.xidhorizon.command=--title="PostgreSQL XID Horizon Age" \
+ --vertical-label="transactions" \
+ DEF:datahorizon={rrd1}:pg_data_horizon_age:AVERAGE \
+ DEF:cathorizon={rrd2}:pg_cat_horizon_age:AVERAGE \
+ LINE2:datahorizon#FF0000:"Data Horizon   " \
+ GPRINT:datahorizon:AVERAGE:" Avg\\: %8.2lf %s" \
+ GPRINT:datahorizon:MIN:"Min\\: %8.2lf %s" \
+ GPRINT:datahorizon:MAX:"Max\\: %8.2lf %s\\n" \
+ LINE2:cathorizon#B575E5:"Catalog Horizon" \
+ GPRINT:cathorizon:AVERAGE:" Avg\\: %8.2lf %s" \
+ GPRINT:cathorizon:MIN:"Min\\: %8.2lf %s" \
+ GPRINT:cathorizon:MAX:"Max\\: %8.2lf %s\\n"
+
+report.pgsql.xidholders.name=PostgreSQL XID Horizon Holders
+report.pgsql.xidholders.type=nodeSnmp
+report.pgsql.xidholders.columns=pg_backend_xmin_age,pg_slot_xmin_age,pg_slot_catalog_age,pg_standby_xmin_age,pg_prepared_age
+report.pgsql.xidholders.command=--title="PostgreSQL XID Horizon Holders" \
+ --vertical-label="transactions" \
+ DEF:backends={rrd1}:pg_backend_xmin_age:AVERAGE \
+ DEF:slotxmin={rrd2}:pg_slot_xmin_age:AVERAGE \
+ DEF:slotcat={rrd3}:pg_slot_catalog_age:AVERAGE \
+ DEF:standby={rrd4}:pg_standby_xmin_age:AVERAGE \
+ DEF:prepared={rrd5}:pg_prepared_age:AVERAGE \
+ LINE2:backends#7EE600:"Backend Snapshots   " \
+ GPRINT:backends:AVERAGE:" Avg\\: %8.2lf %s" \
+ GPRINT:backends:MIN:"Min\\: %8.2lf %s" \
+ GPRINT:backends:MAX:"Max\\: %8.2lf %s\\n" \
+ LINE2:slotxmin#00A0C1:"Slot xmin           " \
+ GPRINT:slotxmin:AVERAGE:" Avg\\: %8.2lf %s" \
+ GPRINT:slotxmin:MIN:"Min\\: %8.2lf %s" \
+ GPRINT:slotxmin:MAX:"Max\\: %8.2lf %s\\n" \
+ LINE2:slotcat#B575E5:"Slot catalog_xmin   " \
+ GPRINT:slotcat:AVERAGE:" Avg\\: %8.2lf %s" \
+ GPRINT:slotcat:MIN:"Min\\: %8.2lf %s" \
+ GPRINT:slotcat:MAX:"Max\\: %8.2lf %s\\n" \
+ LINE2:standby#FFCC00:"Standby Feedback    " \
+ GPRINT:standby:AVERAGE:" Avg\\: %8.2lf %s" \
+ GPRINT:standby:MIN:"Min\\: %8.2lf %s" \
+ GPRINT:standby:MAX:"Max\\: %8.2lf %s\\n" \
+ LINE2:prepared#FF0000:"Prepared Xacts      " \
+ GPRINT:prepared:AVERAGE:" Avg\\: %8.2lf %s" \
+ GPRINT:prepared:MIN:"Min\\: %8.2lf %s" \
+ GPRINT:prepared:MAX:"Max\\: %8.2lf %s\\n"

--- a/opennms-base-assembly/src/main/filtered/etc/threshd-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/threshd-configuration.xml
@@ -63,4 +63,12 @@
          <parameter key="thresholding-group" value="opennms-jvm-jmx"/>
       </service>
    </package>
+   <package name="postgresql">
+      <filter>IPADDR != '0.0.0.0'</filter>
+      <include-range begin="1.1.1.1" end="254.254.254.254"/>
+      <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"/>
+      <service name="OpenNMS-DB" interval="300000" user-defined="false" status="on">
+         <parameter key="thresholding-group" value="postgresql"/>
+      </service>
+   </package>
 </threshd-configuration>

--- a/opennms-base-assembly/src/main/filtered/etc/thresholds.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/thresholds.xml
@@ -64,6 +64,11 @@
       <expression description="Trigger an alarm when the number of active pollerd threads exceeds 95% of the maximum thread pool size for three samples" type="high" ds-type="node" value="95" rearm="90" trigger="3" expr-label="Above 95% Pollerd Threadpool Usage" filterOperator="OR" expression="(ONMSPollerThreadAct / ONMSPollerPoolThrd) * 100"/>
       <expression description="Trigger an alarm when the number of active collectd threads exceeds 95% of the maximum thread pool size for three samples" type="high" ds-type="node" value="95" rearm="90" trigger="3" expr-label="Above 95% Collectd Threadpool Usage" filterOperator="OR" expression="(ONMSCollectThrdAct / ONMSCollectPoolThrd) * 100"/>
    </group>
+   <group name="postgresql" rrdRepository="${install.share.dir}/rrd/snmp/">
+      <threshold description="Trigger an alert when the oldest transaction ID horizon holder (backend snapshot, replication slot, standby feedback, or prepared transaction) is holding back vacuum cleanup by 50 million or more transactions for two consecutive measurement intervals" type="high" ds-type="node" value="50000000.0" rearm="25000000.0" trigger="2" filterOperator="OR" ds-name="pg_data_horizon_age"/>
+      <expression description="Trigger an alert when more than 10 backends are idle in an open transaction (including aborted transactions) for two consecutive measurement intervals" type="high" ds-type="node" value="11.0" rearm="5.0" trigger="2" expr-label="Idle in Transaction Backends" filterOperator="OR" expression="pg_sa_idle_txn + pg_sa_idle_txn_abrt"/>
+      <expression description="Trigger an alert when all configured autovacuum workers are busy for three consecutive measurement intervals, indicating autovacuum may not be keeping up" type="high" ds-type="node" value="100.0" rearm="75.0" trigger="3" expr-label="Autovacuum Workers Saturated" filterOperator="OR" expression="pg_av_workers / pg_av_max_workers * 100.0"/>
+   </group>
    <group name="coffee" rrdRepository="${install.share.dir}/rrd/snmp/">
       <expression description="Trigger an alert when the coffee pot level reaches or goes below 25% in one measurement interval" type="low" ds-type="node" value="25.0" rearm="100.0" trigger="1" expr-label="Coffee Pot Below 25%" filterOperator="OR" expression="coffeePotLevel / coffeePotCapacity * 100.0"/>
    </group>


### PR DESCRIPTION
Collect dead tuples, backend states by pg_stat_activity state, xid horizon ages (backend snapshots, replication slots, standby feedback, prepared xacts), and autovacuum worker usage vs autovacuum_max_workers via the OpenNMS-DB service, so the queries run against the opennms database and datasource. Add matching graph definitions and a "postgresql" threshold group covering xid horizon age, idle-in- transaction backends, and autovacuum worker saturation.

The pg_stat_activity queries need the pg_monitor role, so the installer now grants it to the OpenNMS user during database preparation, and a `pg_sa_masked` canary datasource counts sessions hidden from the monitoring role (nonzero means the grant is missing / user cannot read the views).

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20265

