### PR TITLE
NMS-20268: Migrate the Scheduled Outages page to Vue UI

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/search-actions.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/search-actions.xml
@@ -157,7 +157,7 @@
     <!-- Service Monitoring Card -->
     <action>
         <label>Configure Scheduled Outages</label>
-        <url>admin/sched-outages/index.jsp</url>
+        <url>ui/index.html#/scheduled-outages</url>
         <roles>
             <role>ROLE_ADMIN</role>
         </roles>

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/IpAddressCriteriaBehavior.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/IpAddressCriteriaBehavior.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.support;
+
+import java.net.InetAddress;
+import java.util.function.Function;
+
+import org.apache.cxf.jaxrs.ext.search.ConditionType;
+import org.opennms.core.criteria.CriteriaBuilder;
+
+/**
+ * {@link CriteriaBehavior} for a root-alias {@code InetAddress} property that
+ * accepts both literal addresses and {@code iplike} patterns: a literal keeps
+ * the converter's {@code InetAddress} equality (the user type compares IPv6
+ * correctly), while a wildcard value is applied as an {@code iplike}
+ * restriction on the given column and the property itself is skipped.
+ */
+public class IpAddressCriteriaBehavior extends CriteriaBehavior<Object> {
+
+    private static final Function<String,Object> CONVERTER = value ->
+            // '*' has already been rewritten to '%' by the time a converter runs
+            value.contains("%") ? value : CriteriaValueConverters.INET_ADDRESS_CONVERTER.apply(value);
+
+    /**
+     * @param column the SQL column {@code iplike} is applied to (the
+     *               restriction names it directly, not the JPA attribute)
+     */
+    public IpAddressCriteriaBehavior(final String column) {
+        super(null, CONVERTER, (b, v, c, w) -> {
+            if (!w) {
+                return;
+            }
+            final String pattern = ((String) v).replaceAll("%", "*");
+            switch (c) {
+                case EQUALS:
+                    b.iplike(column, pattern);
+                    break;
+                case NOT_EQUALS:
+                    b.not().iplike(column, pattern);
+                    break;
+                default:
+                    throw new IllegalArgumentException("Illegal condition type for iplike expression: " + c);
+            }
+        });
+    }
+
+    @Override
+    public boolean shouldSkipProperty(final ConditionType condition, final boolean wildcard) {
+        return wildcard;
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OutageApplicability.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OutageApplicability.java
@@ -44,6 +44,11 @@ public class OutageApplicability {
     @XmlElement(name = "notifications")
     private boolean notifications;
 
+    // every outage name notifd references; with the per-package calendars this
+    // lets the list page derive all memberships from one name-less call
+    @XmlElement(name = "notification-calendars")
+    private List<String> notificationCalendars = new ArrayList<>();
+
     // bare @XmlElement (no wrapper) so the v1 stack renders each list as a JSON
     // array under its own key, matching the Outages model the UI already reads
     @XmlElement(name = "pollers")
@@ -61,6 +66,14 @@ public class OutageApplicability {
 
     public void setNotifications(boolean notifications) {
         this.notifications = notifications;
+    }
+
+    public List<String> getNotificationCalendars() {
+        return notificationCalendars;
+    }
+
+    public void setNotificationCalendars(List<String> notificationCalendars) {
+        this.notificationCalendars = notificationCalendars;
     }
 
     public List<PackageRef> getPollers() {
@@ -97,12 +110,18 @@ public class OutageApplicability {
         @XmlAttribute(name = "applied")
         private boolean applied;
 
+        @XmlElement(name = "calendars")
+        private List<String> calendars = new ArrayList<>();
+
         public PackageRef() {
         }
 
-        public PackageRef(String name, boolean applied) {
+        public PackageRef(String name, boolean applied, List<String> calendars) {
             this.name = name;
             this.applied = applied;
+            if (calendars != null) {
+                this.calendars = new ArrayList<>(calendars);
+            }
         }
 
         public String getName() {
@@ -119,6 +138,14 @@ public class OutageApplicability {
 
         public void setApplied(boolean applied) {
             this.applied = applied;
+        }
+
+        public List<String> getCalendars() {
+            return calendars;
+        }
+
+        public void setCalendars(List<String> calendars) {
+            this.calendars = calendars;
         }
     }
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OutageApplicability.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OutageApplicability.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v1;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Read-only summary of which subsystems a scheduled outage applies to: the
+ * notifd on/off flag plus the poller, collectd and threshd packages, each
+ * flagged with whether it currently references the outage. Populated by
+ * reading the four subsystem configs; the UI uses it to render (and diff)
+ * the "Applies To" matrix without four separate config reads.
+ */
+@XmlRootElement(name = "outage-applicability")
+@XmlAccessorType(XmlAccessType.NONE)
+public class OutageApplicability {
+
+    @XmlElement(name = "notifications")
+    private boolean notifications;
+
+    // bare @XmlElement (no wrapper) so the v1 stack renders each list as a JSON
+    // array under its own key, matching the Outages model the UI already reads
+    @XmlElement(name = "pollers")
+    private List<PackageRef> pollers = new ArrayList<>();
+
+    @XmlElement(name = "collectors")
+    private List<PackageRef> collectors = new ArrayList<>();
+
+    @XmlElement(name = "thresholders")
+    private List<PackageRef> thresholders = new ArrayList<>();
+
+    public boolean isNotifications() {
+        return notifications;
+    }
+
+    public void setNotifications(boolean notifications) {
+        this.notifications = notifications;
+    }
+
+    public List<PackageRef> getPollers() {
+        return pollers;
+    }
+
+    public void setPollers(List<PackageRef> pollers) {
+        this.pollers = pollers;
+    }
+
+    public List<PackageRef> getCollectors() {
+        return collectors;
+    }
+
+    public void setCollectors(List<PackageRef> collectors) {
+        this.collectors = collectors;
+    }
+
+    public List<PackageRef> getThresholders() {
+        return thresholders;
+    }
+
+    public void setThresholders(List<PackageRef> thresholders) {
+        this.thresholders = thresholders;
+    }
+
+    @XmlRootElement(name = "package")
+    @XmlAccessorType(XmlAccessType.NONE)
+    public static class PackageRef {
+
+        @XmlAttribute(name = "name")
+        private String name;
+
+        @XmlAttribute(name = "applied")
+        private boolean applied;
+
+        public PackageRef() {
+        }
+
+        public PackageRef(String name, boolean applied) {
+            this.name = name;
+            this.applied = applied;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public boolean isApplied() {
+            return applied;
+        }
+
+        public void setApplied(boolean applied) {
+            this.applied = applied;
+        }
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ScheduledOutagesRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ScheduledOutagesRestService.java
@@ -320,6 +320,53 @@ public class ScheduledOutagesRestService extends OnmsRestService {
         return Boolean.FALSE.toString();
     }
 
+    @GET
+    @Path("applies-to")
+    @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    public OutageApplicability getApplicability() {
+        return buildApplicability(null);
+    }
+
+    @GET
+    @Path("{outageName}/applies-to")
+    @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    public OutageApplicability getApplicability(@PathParam("outageName") String outageName) {
+        getOutage(outageName); // Validate if outageName exists (404 if not).
+        return buildApplicability(outageName);
+    }
+
+    // Enumerate every poller/collectd/threshd package (and the notifd flag),
+    // marking those that reference outageName. A null outageName lists the
+    // packages with nothing applied, for the "new outage" case.
+    private OutageApplicability buildApplicability(String outageName) {
+        OutageApplicability applicability = new OutageApplicability();
+
+        boolean notifications = false;
+        if (outageName != null) {
+            try {
+                notifications = NotifdConfigFactory.getInstance().getConfiguration().getOutageCalendars().contains(outageName);
+            } catch (Exception e) {
+                throw getException(Status.INTERNAL_SERVER_ERROR, "Can't read notifications configuration: {}", e.getMessage());
+            }
+        }
+        applicability.setNotifications(notifications);
+
+        for (org.opennms.netmgt.config.poller.Package pkg : PollerConfigFactory.getInstance().getExtendedConfiguration().getPackages()) {
+            applicability.getPollers().add(new OutageApplicability.PackageRef(pkg.getName(), applies(pkg.getOutageCalendars(), outageName)));
+        }
+        for (Package pkg : m_collectdConfigFactory.getPackages()) {
+            applicability.getCollectors().add(new OutageApplicability.PackageRef(pkg.getName(), applies(pkg.getOutageCalendars(), outageName)));
+        }
+        for (org.opennms.netmgt.config.threshd.Package pkg : m_threshdDao.getReadOnlyConfig().getPackages()) {
+            applicability.getThresholders().add(new OutageApplicability.PackageRef(pkg.getName(), applies(pkg.getOutageCalendars(), outageName)));
+        }
+        return applicability;
+    }
+
+    private static boolean applies(java.util.List<String> outageCalendars, String outageName) {
+        return outageName != null && outageCalendars != null && outageCalendars.contains(outageName);
+    }
+
     private static void validateAddress(String ipAddress) {
         boolean valid = false;
         try {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ScheduledOutagesRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ScheduledOutagesRestService.java
@@ -335,30 +335,30 @@ public class ScheduledOutagesRestService extends OnmsRestService {
         return buildApplicability(outageName);
     }
 
-    // Enumerate every poller/collectd/threshd package (and the notifd flag),
+    // Enumerate every poller/collectd/threshd package with its outage calendars,
     // marking those that reference outageName. A null outageName lists the
-    // packages with nothing applied, for the "new outage" case.
+    // packages with nothing applied, for the "new outage" case; the calendars
+    // let the list page derive every outage's memberships from one call.
     private OutageApplicability buildApplicability(String outageName) {
         OutageApplicability applicability = new OutageApplicability();
 
-        boolean notifications = false;
-        if (outageName != null) {
-            try {
-                notifications = NotifdConfigFactory.getInstance().getConfiguration().getOutageCalendars().contains(outageName);
-            } catch (Exception e) {
-                throw getException(Status.INTERNAL_SERVER_ERROR, "Can't read notifications configuration: {}", e.getMessage());
-            }
+        java.util.List<String> notifdCalendars;
+        try {
+            notifdCalendars = NotifdConfigFactory.getInstance().getConfiguration().getOutageCalendars();
+        } catch (Exception e) {
+            throw getException(Status.INTERNAL_SERVER_ERROR, "Can't read notifications configuration: {}", e.getMessage());
         }
-        applicability.setNotifications(notifications);
+        applicability.setNotifications(applies(notifdCalendars, outageName));
+        applicability.setNotificationCalendars(new java.util.ArrayList<>(notifdCalendars));
 
         for (org.opennms.netmgt.config.poller.Package pkg : PollerConfigFactory.getInstance().getExtendedConfiguration().getPackages()) {
-            applicability.getPollers().add(new OutageApplicability.PackageRef(pkg.getName(), applies(pkg.getOutageCalendars(), outageName)));
+            applicability.getPollers().add(new OutageApplicability.PackageRef(pkg.getName(), applies(pkg.getOutageCalendars(), outageName), pkg.getOutageCalendars()));
         }
         for (Package pkg : m_collectdConfigFactory.getPackages()) {
-            applicability.getCollectors().add(new OutageApplicability.PackageRef(pkg.getName(), applies(pkg.getOutageCalendars(), outageName)));
+            applicability.getCollectors().add(new OutageApplicability.PackageRef(pkg.getName(), applies(pkg.getOutageCalendars(), outageName), pkg.getOutageCalendars()));
         }
         for (org.opennms.netmgt.config.threshd.Package pkg : m_threshdDao.getReadOnlyConfig().getPackages()) {
-            applicability.getThresholders().add(new OutageApplicability.PackageRef(pkg.getName(), applies(pkg.getOutageCalendars(), outageName)));
+            applicability.getThresholders().add(new OutageApplicability.PackageRef(pkg.getName(), applies(pkg.getOutageCalendars(), outageName), pkg.getOutageCalendars()));
         }
         return applicability;
     }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/IpInterfaceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/IpInterfaceRestService.java
@@ -43,7 +43,7 @@ import org.opennms.netmgt.model.OnmsIpInterfaceList;
 import org.opennms.web.rest.support.Aliases;
 import org.opennms.web.rest.support.CriteriaBehavior;
 import org.opennms.web.rest.support.CriteriaBehaviors;
-import org.opennms.web.rest.support.IpLikeCriteriaBehavior;
+import org.opennms.web.rest.support.IpAddressCriteriaBehavior;
 import org.opennms.web.rest.support.SearchProperties;
 import org.opennms.web.rest.support.SearchProperty;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -112,9 +112,9 @@ public class IpInterfaceRestService extends AbstractDaoRestService<OnmsIpInterfa
 
         // Root alias
         map.putAll(CriteriaBehaviors.IP_INTERFACE_BEHAVIORS);
-        // iplike patterns on ipAddress (10.0.*.*); the restriction names the
-        // ipaddr column directly, not the JPA attribute
-        map.put("ipAddress", new IpLikeCriteriaBehavior("ipAddr"));
+        // iplike patterns on ipAddress (10.0.*.*) next to literal equality;
+        // the restriction names the ipaddr column directly, not the attribute
+        map.put("ipAddress", new IpAddressCriteriaBehavior("ipAddr"));
 
         // 1st level JOINs
         map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.node, CriteriaBehaviors.NODE_BEHAVIORS));

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/IpInterfaceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/IpInterfaceRestService.java
@@ -43,6 +43,7 @@ import org.opennms.netmgt.model.OnmsIpInterfaceList;
 import org.opennms.web.rest.support.Aliases;
 import org.opennms.web.rest.support.CriteriaBehavior;
 import org.opennms.web.rest.support.CriteriaBehaviors;
+import org.opennms.web.rest.support.IpLikeCriteriaBehavior;
 import org.opennms.web.rest.support.SearchProperties;
 import org.opennms.web.rest.support.SearchProperty;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -111,6 +112,9 @@ public class IpInterfaceRestService extends AbstractDaoRestService<OnmsIpInterfa
 
         // Root alias
         map.putAll(CriteriaBehaviors.IP_INTERFACE_BEHAVIORS);
+        // iplike patterns on ipAddress (10.0.*.*); the restriction names the
+        // ipaddr column directly, not the JPA attribute
+        map.put("ipAddress", new IpLikeCriteriaBehavior("ipAddr"));
 
         // 1st level JOINs
         map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.node, CriteriaBehaviors.NODE_BEHAVIORS));

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-alt.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-alt.json
@@ -465,9 +465,9 @@
         {
           "id": "scheduledOutages",
           "name": "Scheduled Outages",
-          "url": "admin/sched-outages/index.jsp",
-          "locationMatch": null,
-          "roles": null
+          "url": "ui/index.html#/scheduled-outages",
+          "locationMatch": "",
+          "roles": ["ROLE_ADMIN"]
         },
         {
           "id": "productUpdateEnrollment",

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-default.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-default.json
@@ -290,9 +290,9 @@
         {
           "id": "scheduledOutages",
           "name": "Scheduled Outages",
-          "url": "admin/sched-outages/index.jsp",
-          "locationMatch": null,
-          "roles": null
+          "url": "ui/index.html#/scheduled-outages",
+          "locationMatch": "",
+          "roles": ["ROLE_ADMIN"]
         },
         {
           "id": "productUpdateEnrollment",

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
@@ -290,9 +290,9 @@
         {
           "id": "scheduledOutages",
           "name": "Scheduled Outages",
-          "url": "admin/sched-outages/index.jsp",
-          "locationMatch": null,
-          "roles": null
+          "url": "ui/index.html#/scheduled-outages",
+          "locationMatch": "",
+          "roles": ["ROLE_ADMIN"]
         },
         {
           "id": "productUpdateEnrollment",

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/ScheduledOutagesRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/ScheduledOutagesRestServiceIT.java
@@ -305,4 +305,54 @@ public class ScheduledOutagesRestServiceIT extends AbstractSpringJerseyRestTestC
         Assert.assertEquals("false", sendRequest(GET, "/sched-outages/my-junit-test/interfaceInOutage/1.1.1.1", 200));
         Assert.assertEquals("false", sendRequest(GET, "/sched-outages/interfaceInOutage/1.1.1.1", 200));
     }
+
+    @Test
+    public void testGetApplicability() throws Exception {
+        JSONObject applies = getApplicability("/sched-outages/my-junit-test/applies-to");
+        Assert.assertFalse(applies.getBoolean("notifications"));
+        // every subsystem lists the example1 package, unreferenced initially
+        Assert.assertFalse(appliedFor(applies, "pollers", "example1"));
+        Assert.assertFalse(appliedFor(applies, "collectors", "example1"));
+        Assert.assertFalse(appliedFor(applies, "thresholders", "example1"));
+    }
+
+    @Test
+    public void testApplicabilityReflectsMembership() throws Exception {
+        sendRequest(PUT, "/sched-outages/my-junit-test/pollerd/example1", 204);
+        sendRequest(PUT, "/sched-outages/my-junit-test/notifd", 204);
+
+        JSONObject applies = getApplicability("/sched-outages/my-junit-test/applies-to");
+        Assert.assertTrue(applies.getBoolean("notifications"));
+        Assert.assertTrue(appliedFor(applies, "pollers", "example1"));
+        Assert.assertFalse(appliedFor(applies, "collectors", "example1"));
+        verify(m_filterDao, atLeastOnce()).validateRule(anyString());
+    }
+
+    @Test
+    public void testGetApplicabilityForNewOutage() throws Exception {
+        // the name-less variant lists packages with nothing applied
+        JSONObject applies = getApplicability("/sched-outages/applies-to");
+        Assert.assertFalse(applies.getBoolean("notifications"));
+        Assert.assertFalse(appliedFor(applies, "pollers", "example1"));
+    }
+
+    private JSONObject getApplicability(String url) throws Exception {
+        MockHttpServletRequest request = createRequest(m_servletContext, GET, url);
+        request.addHeader("Accept", MediaType.APPLICATION_JSON);
+        return new JSONObject(sendRequest(request, 200));
+    }
+
+    private static boolean appliedFor(JSONObject root, String subsystem, String packageName) {
+        org.json.JSONArray packages = root.optJSONArray(subsystem);
+        if (packages == null) {
+            return false;
+        }
+        for (int i = 0; i < packages.length(); i++) {
+            JSONObject pkg = packages.getJSONObject(i);
+            if (packageName.equals(pkg.getString("name"))) {
+                return pkg.getBoolean("applied");
+            }
+        }
+        return false;
+    }
 }

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/ScheduledOutagesRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/ScheduledOutagesRestServiceIT.java
@@ -325,6 +325,13 @@ public class ScheduledOutagesRestServiceIT extends AbstractSpringJerseyRestTestC
         Assert.assertTrue(applies.getBoolean("notifications"));
         Assert.assertTrue(appliedFor(applies, "pollers", "example1"));
         Assert.assertFalse(appliedFor(applies, "collectors", "example1"));
+
+        // the name-less variant exposes the raw calendars, so the list page can
+        // derive every outage's memberships from a single call
+        JSONObject all = getApplicability("/sched-outages/applies-to");
+        Assert.assertTrue(calendarsFor(all, "pollers", "example1").contains("my-junit-test"));
+        // single-element JAXB lists may collapse to a bare string in JSON
+        Assert.assertTrue(all.get("notification-calendars").toString().contains("my-junit-test"));
         verify(m_filterDao, atLeastOnce()).validateRule(anyString());
     }
 
@@ -343,16 +350,27 @@ public class ScheduledOutagesRestServiceIT extends AbstractSpringJerseyRestTestC
     }
 
     private static boolean appliedFor(JSONObject root, String subsystem, String packageName) {
+        JSONObject pkg = packageFor(root, subsystem, packageName);
+        return pkg != null && pkg.getBoolean("applied");
+    }
+
+    private static String calendarsFor(JSONObject root, String subsystem, String packageName) {
+        JSONObject pkg = packageFor(root, subsystem, packageName);
+        // a single-element JAXB list may serialize as a bare string, so compare on toString
+        return pkg == null || !pkg.has("calendars") ? "" : pkg.get("calendars").toString();
+    }
+
+    private static JSONObject packageFor(JSONObject root, String subsystem, String packageName) {
         org.json.JSONArray packages = root.optJSONArray(subsystem);
         if (packages == null) {
-            return false;
+            return null;
         }
         for (int i = 0; i < packages.length(); i++) {
             JSONObject pkg = packages.getJSONObject(i);
             if (packageName.equals(pkg.getString("name"))) {
-                return pkg.getBoolean("applied");
+                return pkg;
             }
         }
-        return false;
+        return null;
     }
 }

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/IpInterfaceRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/IpInterfaceRestServiceIT.java
@@ -66,23 +66,36 @@ public class IpInterfaceRestServiceIT extends AbstractSpringJerseyRestTestCase {
     }
 
     @Test
-    @JUnitTemporaryDatabase
+    // the pl/pgsql iplike is the one that rejects a bare IPv6 literal, so force
+    // it: the exact-match assertions below would pass vacuously otherwise
+    @JUnitTemporaryDatabase(plpgsqlIplike = true)
     public void testFiqlSearch() throws Exception {
         // Add a node with an IP interface
         createNode(201);
         createIpInterface();
+        sendPost("/nodes/1/ipinterfaces", "<ipInterface isManaged=\"M\" snmpPrimary=\"N\">" +
+                "<ipAddress>fe80::1</ipAddress>" +
+                "<hostName>TestMachineV6</hostName>" +
+                "<ipStatus>1</ipStatus>" +
+                "</ipInterface>", 201);
 
         String url = "/ipinterfaces";
 
-        LOG.warn(sendRequest(GET, url, parseParamData("_s=ipAddress==10.10.10.10"), 200));
         LOG.warn(sendRequest(GET, url, parseParamData("_s=node.label==*1"), 200));
-        LOG.warn(sendRequest(GET, url, parseParamData("_s=snmpPrimary==P"), 200));
+        assertEquals(2, new JSONObject(sendRequest(GET, url, parseParamData("_s=snmpPrimary==P,snmpPrimary==N"), 200)).getInt("count"));
 
-        // ipAddress accepts iplike patterns, so a partial address can be
-        // searched without a hostname
+        // literal addresses keep InetAddress equality: IPv6 must still match
+        assertEquals(1, new JSONObject(sendRequest(GET, url, parseParamData("_s=ipAddress==10.10.10.10"), 200)).getInt("count"));
+        assertEquals(1, new JSONObject(sendRequest(GET, url, parseParamData("_s=ipAddress==fe80::1"), 200)).getInt("count"));
+        assertEquals(1, new JSONObject(sendRequest(GET, url, parseParamData("_s=ipAddress!=10.10.10.10"), 200)).getInt("count"));
+        sendRequest(GET, url, parseParamData("_s=ipAddress==10.10.10.11"), 204);
+
+        // wildcards go through iplike, so a partial address can be searched
+        // without a hostname
         assertEquals(1, new JSONObject(sendRequest(GET, url, parseParamData("_s=ipAddress==10.10.10.*"), 200)).getInt("count"));
         assertEquals(1, new JSONObject(sendRequest(GET, url, parseParamData("_s=ipAddress==10.10.*.*"), 200)).getInt("count"));
         assertEquals(1, new JSONObject(sendRequest(GET, url, parseParamData("_s=ipAddress==10.10.10.*,ipHostName==*nomatch*"), 200)).getInt("count"));
+        assertEquals(1, new JSONObject(sendRequest(GET, url, parseParamData("_s=ipAddress!=10.10.*.*"), 200)).getInt("count"));
         sendRequest(GET, url, parseParamData("_s=ipAddress==10.10.11.*"), 204);
     }
 

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/IpInterfaceRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/IpInterfaceRestServiceIT.java
@@ -77,6 +77,13 @@ public class IpInterfaceRestServiceIT extends AbstractSpringJerseyRestTestCase {
         LOG.warn(sendRequest(GET, url, parseParamData("_s=ipAddress==10.10.10.10"), 200));
         LOG.warn(sendRequest(GET, url, parseParamData("_s=node.label==*1"), 200));
         LOG.warn(sendRequest(GET, url, parseParamData("_s=snmpPrimary==P"), 200));
+
+        // ipAddress accepts iplike patterns, so a partial address can be
+        // searched without a hostname
+        assertEquals(1, new JSONObject(sendRequest(GET, url, parseParamData("_s=ipAddress==10.10.10.*"), 200)).getInt("count"));
+        assertEquals(1, new JSONObject(sendRequest(GET, url, parseParamData("_s=ipAddress==10.10.*.*"), 200)).getInt("count"));
+        assertEquals(1, new JSONObject(sendRequest(GET, url, parseParamData("_s=ipAddress==10.10.10.*,ipHostName==*nomatch*"), 200)).getInt("count"));
+        sendRequest(GET, url, parseParamData("_s=ipAddress==10.10.11.*"), 204);
     }
 
     @Test

--- a/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security.xml
+++ b/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security.xml
@@ -135,8 +135,8 @@
 
     <!-- Scheduled-outage "applies to" enumerates poller/collectd/threshd package
          names; keep it admin-only, matching the admin-gated Scheduled Outages page. -->
-    <intercept-url pattern="/rest/sched-outages/applies-to" method="GET" access="ROLE_REST,ROLE_ADMIN"/>
-    <intercept-url pattern="/rest/sched-outages/*/applies-to" method="GET" access="ROLE_REST,ROLE_ADMIN"/>
+    <intercept-url pattern="/rest/sched-outages/applies-to/**" method="GET" access="ROLE_REST,ROLE_ADMIN"/>
+    <intercept-url pattern="/rest/sched-outages/*/applies-to/**" method="GET" access="ROLE_REST,ROLE_ADMIN"/>
 
     <!-- read-only calls should be allowed for any user -->
     <intercept-url pattern="/rest/**" method="GET" access="ROLE_REST,ROLE_ADMIN,ROLE_MOBILE,ROLE_USER"/>

--- a/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security.xml
+++ b/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security.xml
@@ -133,6 +133,11 @@
     <!-- Allow certain actions for the ROLE_USER role -->
     <intercept-url pattern="/rest/resources/generateId" method="POST" access="ROLE_REST,ROLE_ADMIN,ROLE_USER" />
 
+    <!-- Scheduled-outage "applies to" enumerates poller/collectd/threshd package
+         names; keep it admin-only, matching the admin-gated Scheduled Outages page. -->
+    <intercept-url pattern="/rest/sched-outages/applies-to" method="GET" access="ROLE_REST,ROLE_ADMIN"/>
+    <intercept-url pattern="/rest/sched-outages/*/applies-to" method="GET" access="ROLE_REST,ROLE_ADMIN"/>
+
     <!-- read-only calls should be allowed for any user -->
     <intercept-url pattern="/rest/**" method="GET" access="ROLE_REST,ROLE_ADMIN,ROLE_MOBILE,ROLE_USER"/>
     <intercept-url pattern="/rest/**" method="HEAD" access="ROLE_REST,ROLE_ADMIN,ROLE_MOBILE,ROLE_USER"/>

--- a/opennms-webapp/src/main/webapp/admin/index.jsp
+++ b/opennms-webapp/src/main/webapp/admin/index.jsp
@@ -200,7 +200,7 @@
       </div>
       <div class="card-body">
         <ul class="list-unstyled mb-0">
-            <li><a href="admin/sched-outages/index.jsp">Configure Scheduled Outages</a></li>
+            <li><a href="ui/index.html#/scheduled-outages">Configure Scheduled Outages</a></li>
             <li><a href="javascript:submitPost()">Manage and Unmanage Interfaces and Services</a></li>
             <%=getAdminPageNavEntries("service-monitoring")%>
         </ul>

--- a/smoke-test/src/test/java/org/opennms/smoketest/AdminPageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/AdminPageIT.java
@@ -75,7 +75,7 @@ public class AdminPageIT extends OpenNMSSeleniumIT {
         new String[] { "Manage Event Configurations", "//div[@id='app']//div[@class='event-config']//div[@class='heading']/h1[text()='Manage Event Configurations']" },
 
         // Service Monitoring
-        new String[] { "Configure Scheduled Outages", "//form//input[@value='New Name']" },
+        new String[] { "Configure Scheduled Outages", "//div[@id='app']//div[@class='card-title' and text()='Scheduled Outages']" },
         new String[] { "Manage and Unmanage Interfaces and Services", "//span[text()='Manage and Unmanage Interfaces and Services']" },
         new String[] { "Manage Business Services", "//div[@id='content']//iframe[@name='bsm-admin-page']" },
 

--- a/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
@@ -221,8 +221,8 @@ public class MenuHeaderIT extends OpenNMSSeleniumIT {
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@class='card-header']/span[text()='Manage SNMP Data Collection per Interface']")));
 
         clickMenuItem("Administration", "Scheduled Outages");
-        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Scheduled Outages')]")));
-        wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@class='card-header']/h4[text()='Scheduled Outages']")));
+        // now the Vue page (ui/index.html)
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//div[@id='app']//div[@class='card-title' and text()='Scheduled Outages']")));
 
         clickMenuItem("Administration", "Product Update Enrollment");
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//ol[@class='breadcrumb']/li[contains(text()[normalize-space()], 'Product Update Enrollment')]")));

--- a/ui/src/components/ScheduledOutages/AppliesToMatrix.vue
+++ b/ui/src/components/ScheduledOutages/AppliesToMatrix.vue
@@ -1,0 +1,109 @@
+<template>
+  <div class="applies-to" data-test="applies-to">
+    <h3 class="section-title">Applies To</h3>
+
+    <div class="subsystem">
+      <div class="subsystem-title">Notifications</div>
+      <label class="check-row">
+        <OnmsCheckbox
+          :modelValue="notifications"
+          data-test="applies-notifications"
+          @update:modelValue="emit('update:notifications', $event)"
+        />
+        <span>All Notifications</span>
+      </label>
+    </div>
+
+    <div v-for="group in groups" :key="group.subsystem" class="subsystem">
+      <div class="subsystem-header">
+        <span class="subsystem-title">{{ group.label }}</span>
+        <span class="bulk-actions">
+          <a href="#" data-test="select-all" @click.prevent="emit('setAll', group.subsystem, true)">Select All</a>
+          <a href="#" data-test="unselect-all" @click.prevent="emit('setAll', group.subsystem, false)">Unselect All</a>
+        </span>
+      </div>
+      <p v-if="!group.packages.length" class="none">No packages configured.</p>
+      <label
+        v-for="pkg in group.packages"
+        :key="pkg.name"
+        class="check-row"
+      >
+        <OnmsCheckbox
+          :modelValue="pkg.applied"
+          :data-test="`applies-${group.subsystem}`"
+          @update:modelValue="emit('togglePackage', group.subsystem, pkg.name, $event)"
+        />
+        <span>{{ pkg.name }}</span>
+      </label>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { OnmsCheckbox } from '@opennms/onms-ui'
+import { PackageRef } from '@/types/scheduledOutage'
+
+export type Subsystem = 'pollerd' | 'threshd' | 'collectd'
+
+const props = defineProps<{
+  notifications: boolean
+  pollers: PackageRef[]
+  thresholders: PackageRef[]
+  collectors: PackageRef[]
+}>()
+
+const emit = defineEmits<{
+  'update:notifications': [value: boolean]
+  togglePackage: [subsystem: Subsystem, name: string, value: boolean]
+  setAll: [subsystem: Subsystem, value: boolean]
+}>()
+
+const groups = computed(() => [
+  { subsystem: 'pollerd' as Subsystem, label: 'Status Polling', packages: props.pollers },
+  { subsystem: 'threshd' as Subsystem, label: 'Threshold Checking', packages: props.thresholders },
+  { subsystem: 'collectd' as Subsystem, label: 'Data Collection', packages: props.collectors }
+])
+</script>
+
+<style scoped lang="scss">
+.applies-to {
+  .section-title {
+    margin: 0 0 0.75rem 0;
+  }
+
+  .subsystem {
+    margin-bottom: 1rem;
+  }
+
+  .subsystem-header {
+    display: flex;
+    align-items: baseline;
+    gap: 1rem;
+    margin-bottom: 0.25rem;
+  }
+
+  .subsystem-title {
+    font-weight: 600;
+  }
+
+  .bulk-actions {
+    display: flex;
+    gap: 0.75rem;
+    font-size: 0.85rem;
+  }
+
+  .check-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.15rem 0 0.15rem 1rem;
+    cursor: pointer;
+  }
+
+  .none {
+    margin: 0 0 0 1rem;
+    color: var(--p-text-muted-color);
+  }
+}
+</style>

--- a/ui/src/components/ScheduledOutages/NodeInterfacePicker.vue
+++ b/ui/src/components/ScheduledOutages/NodeInterfacePicker.vue
@@ -1,0 +1,156 @@
+<template>
+  <div class="picker" :data-test="`picker-${mode}`">
+    <div class="picker-title">{{ mode === 'node' ? 'Nodes' : 'Interfaces' }}</div>
+    <FormField :label="`Search (max 200 results)`" :for="`picker-${mode}-input`">
+      <div class="search-row">
+        <OnmsAutoComplete
+          v-model="selection"
+          :inputId="`picker-${mode}-input`"
+          :suggestions="suggestions"
+          optionLabel="label"
+          :placeholder="mode === 'node' ? 'Node label' : 'IP address'"
+          forceSelection
+          fluid
+          :data-test="`picker-${mode}-search`"
+          @complete="onComplete"
+        />
+        <OnmsButton
+          label="Add"
+          icon="pi pi-plus"
+          :disabled="!selection"
+          :data-test="`picker-${mode}-add`"
+          @click="addSelection"
+        />
+      </div>
+    </FormField>
+
+    <div class="current">
+      <div class="current-title">Current selection:</div>
+      <p v-if="!items.length" class="none" :data-test="`picker-${mode}-empty`">
+        {{ mode === 'node' ? 'No specific nodes selected' : 'No specific interfaces selected' }}
+      </p>
+      <ul v-else class="chips">
+        <li v-for="(item, index) in items" :key="index" class="chip">
+          <span>{{ labelFor(item) }}</span>
+          <OnmsIconButton
+            :icon="Delete"
+            severity="danger"
+            :title="`Remove ${labelFor(item)}`"
+            :aria-label="`Remove ${labelFor(item)}`"
+            :data-test="`picker-${mode}-remove`"
+            @click="emit('remove', index)"
+          />
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { OnmsAutoComplete, OnmsButton, OnmsIconButton } from '@opennms/onms-ui'
+import Delete from '@opennms/onms-ui/icons/action/Delete.vue'
+import FormField from '@/components/Common/FormField.vue'
+import { OutageInterface, OutageNode } from '@/types/scheduledOutage'
+import { searchOutageInterfaces, searchOutageNodes } from '@/services/scheduledOutagesService'
+
+interface NodeSuggestion { label: string, id: number }
+interface InterfaceSuggestion { label: string, address: string }
+type Suggestion = NodeSuggestion | InterfaceSuggestion
+
+const props = defineProps<{
+  mode: 'node' | 'interface'
+  items: (OutageNode | OutageInterface)[]
+}>()
+
+const emit = defineEmits<{
+  add: [value: OutageNode | OutageInterface]
+  remove: [index: number]
+}>()
+
+const selection = ref<Suggestion | null>(null)
+const suggestions = ref<Suggestion[]>([])
+
+const onComplete = async (query: string) => {
+  if (props.mode === 'node') {
+    const nodes = await searchOutageNodes(query)
+    suggestions.value = nodes.map(n => ({ label: `${n.label} (id ${n.id})`, id: n.id }))
+  } else {
+    const interfaces = await searchOutageInterfaces(query)
+    suggestions.value = interfaces.map(i => ({
+      label: i.nodeLabel ? `${i.address} — ${i.nodeLabel}` : i.address,
+      address: i.address
+    }))
+  }
+}
+
+const addSelection = () => {
+  const sel = selection.value
+  if (!sel) {
+    return
+  }
+  if (props.mode === 'node' && 'id' in sel) {
+    emit('add', { id: sel.id })
+  } else if (props.mode === 'interface' && 'address' in sel) {
+    emit('add', { address: sel.address })
+  }
+  selection.value = null
+}
+
+const labelFor = (item: OutageNode | OutageInterface): string =>
+  'id' in item ? `Node id ${item.id}` : item.address
+</script>
+
+<style scoped lang="scss">
+.picker {
+  .picker-title {
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+  }
+
+  .search-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+
+    :deep(.p-autocomplete) {
+      flex: 1 1 auto;
+      min-width: 0;
+    }
+  }
+
+  .current {
+    margin-top: 0.75rem;
+  }
+
+  .current-title {
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+  }
+
+  .none {
+    margin: 0;
+    font-style: italic;
+    color: var(--p-text-muted-color);
+  }
+
+  .chips {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .chip {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0.15rem 0.25rem;
+    border-radius: 4px;
+    background: var(--p-content-hover-background, rgba(127, 127, 127, 0.08));
+  }
+}
+</style>

--- a/ui/src/components/ScheduledOutages/NodeInterfacePicker.vue
+++ b/ui/src/components/ScheduledOutages/NodeInterfacePicker.vue
@@ -54,17 +54,20 @@ import FormField from '@/components/Common/FormField.vue'
 import { OutageInterface, OutageNode } from '@/types/scheduledOutage'
 import { searchOutageInterfaces, searchOutageNodes } from '@/services/scheduledOutagesService'
 
-interface NodeSuggestion { label: string, id: number }
+interface NodeSuggestion { label: string, id: number, nodeLabel: string }
 interface InterfaceSuggestion { label: string, address: string }
 type Suggestion = NodeSuggestion | InterfaceSuggestion
 
 const props = defineProps<{
   mode: 'node' | 'interface'
   items: (OutageNode | OutageInterface)[]
+  // node id -> label, resolved by the editor; ids without an entry are shown
+  // as not-found (deleted nodes still referenced by the outage config)
+  nodeLabels?: Record<number, string>
 }>()
 
 const emit = defineEmits<{
-  add: [value: OutageNode | OutageInterface]
+  add: [value: OutageNode | OutageInterface, label?: string]
   remove: [index: number]
 }>()
 
@@ -74,7 +77,7 @@ const suggestions = ref<Suggestion[]>([])
 const onComplete = async (query: string) => {
   if (props.mode === 'node') {
     const nodes = await searchOutageNodes(query)
-    suggestions.value = nodes.map(n => ({ label: `${n.label} (id ${n.id})`, id: n.id }))
+    suggestions.value = nodes.map(n => ({ label: `${n.label} (id ${n.id})`, id: n.id, nodeLabel: n.label }))
   } else {
     const interfaces = await searchOutageInterfaces(query)
     suggestions.value = interfaces.map(i => ({
@@ -90,15 +93,20 @@ const addSelection = () => {
     return
   }
   if (props.mode === 'node' && 'id' in sel) {
-    emit('add', { id: sel.id })
+    emit('add', { id: sel.id }, sel.nodeLabel)
   } else if (props.mode === 'interface' && 'address' in sel) {
     emit('add', { address: sel.address })
   }
   selection.value = null
 }
 
-const labelFor = (item: OutageNode | OutageInterface): string =>
-  'id' in item ? `Node id ${item.id}` : item.address
+const labelFor = (item: OutageNode | OutageInterface): string => {
+  if (!('id' in item)) {
+    return item.address
+  }
+  const label = props.nodeLabels?.[item.id]
+  return label ? `${label} (id ${item.id})` : `Node id ${item.id} (not found)`
+}
 </script>
 
 <style scoped lang="scss">

--- a/ui/src/components/ScheduledOutages/NodeInterfacePicker.vue
+++ b/ui/src/components/ScheduledOutages/NodeInterfacePicker.vue
@@ -26,30 +26,31 @@
 
     <div class="current">
       <div class="current-title">Current selection:</div>
-      <p v-if="!items.length" class="none" :data-test="`picker-${mode}-empty`">
+      <!-- match-any lives in the interface list; the node picker mirrors it as
+           a display-only chip so both read as "everything selected" -->
+      <div v-if="mode === 'node' && matchAny" class="chips">
+        <OnmsChip label="All Nodes" :data-test="`picker-${mode}-all`" />
+      </div>
+      <p v-else-if="!items.length" class="none" :data-test="`picker-${mode}-empty`">
         {{ mode === 'node' ? 'No specific nodes selected' : 'No specific interfaces selected' }}
       </p>
-      <ul v-else class="chips">
-        <li v-for="(item, index) in items" :key="index" class="chip">
-          <span>{{ labelFor(item) }}</span>
-          <OnmsIconButton
-            :icon="Delete"
-            severity="danger"
-            :title="`Remove ${labelFor(item)}`"
-            :aria-label="`Remove ${labelFor(item)}`"
-            :data-test="`picker-${mode}-remove`"
-            @click="emit('remove', index)"
-          />
-        </li>
-      </ul>
+      <div v-else class="chips">
+        <OnmsChip
+          v-for="(item, index) in items"
+          :key="index"
+          :label="labelFor(item)"
+          removable
+          :data-test="`picker-${mode}-chip`"
+          @remove="emit('remove', index)"
+        />
+      </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref } from 'vue'
-import { OnmsAutoComplete, OnmsButton, OnmsIconButton } from '@opennms/onms-ui'
-import Delete from '@opennms/onms-ui/icons/action/Delete.vue'
+import { OnmsAutoComplete, OnmsButton, OnmsChip } from '@opennms/onms-ui'
 import FormField from '@/components/Common/FormField.vue'
 import { OutageInterface, OutageNode } from '@/types/scheduledOutage'
 import { searchOutageInterfaces, searchOutageNodes } from '@/services/scheduledOutagesService'
@@ -64,6 +65,8 @@ const props = defineProps<{
   // node id -> label, resolved by the editor; ids without an entry are shown
   // as not-found (deleted nodes still referenced by the outage config)
   nodeLabels?: Record<number, string>
+  // the outage applies to everything; the node picker shows an All Nodes chip
+  matchAny?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -102,7 +105,7 @@ const addSelection = () => {
 
 const labelFor = (item: OutageNode | OutageInterface): string => {
   if (!('id' in item)) {
-    return item.address
+    return item.address === 'match-any' ? 'All Interfaces' : item.address
   }
   const label = props.nodeLabels?.[item.id]
   return label ? `${label} (id ${item.id})` : `Node id ${item.id} (not found)`
@@ -118,7 +121,7 @@ const labelFor = (item: OutageNode | OutageInterface): string => {
 
   .search-row {
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     gap: 0.5rem;
 
     :deep(.p-autocomplete) {
@@ -143,22 +146,9 @@ const labelFor = (item: OutageNode | OutageInterface): string => {
   }
 
   .chips {
-    list-style: none;
-    margin: 0;
-    padding: 0;
     display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-  }
-
-  .chip {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.5rem;
-    padding: 0.15rem 0.25rem;
-    border-radius: 4px;
-    background: var(--p-content-hover-background, rgba(127, 127, 127, 0.08));
+    flex-wrap: wrap;
+    gap: 0.35rem;
   }
 }
 </style>

--- a/ui/src/components/ScheduledOutages/ScheduledOutagesAbout.vue
+++ b/ui/src/components/ScheduledOutages/ScheduledOutagesAbout.vue
@@ -1,0 +1,20 @@
+<template>
+  <div data-test="scheduled-outages-about">
+    <p>
+      A scheduled outage is a named window during which OpenNMS suppresses selected activity for
+      the chosen nodes and interfaces. Each outage has a type (specific dates, or a recurring
+      daily, weekly, or monthly schedule) and one or more time spans.
+    </p>
+    <p>
+      The <strong>Applies To</strong> settings control which subsystems honor the outage: notifications,
+      and the status-polling, threshold-checking, and data-collection packages you select.
+    </p>
+    <p>
+      Choosing <strong>Select all nodes and interfaces</strong> makes the outage apply everywhere,
+      replacing any specific node or interface selections.
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+</script>

--- a/ui/src/components/ScheduledOutages/TimeSpanEditor.vue
+++ b/ui/src/components/ScheduledOutages/TimeSpanEditor.vue
@@ -7,7 +7,7 @@
       <template v-if="type === 'specific'">
         <div class="span-row">
           <span class="span-label">Start</span>
-          <OnmsSelect v-model="fields.startDay" :options="DAYS_OF_MONTH" optionLabel="label" optionValue="value" data-test="specific-start-day" />
+          <OnmsSelect v-model="fields.startDay" :options="DAYS_OF_MONTH_PADDED" optionLabel="label" optionValue="value" data-test="specific-start-day" />
           <OnmsSelect v-model="fields.startMonth" :options="MONTHS" optionLabel="label" optionValue="value" data-test="specific-start-month" />
           <OnmsSelect v-model="fields.startYear" :options="years" optionLabel="label" optionValue="value" data-test="specific-start-year" />
           <OnmsSelect v-model="fields.startHour" :options="HOURS" optionLabel="label" optionValue="value" />
@@ -16,7 +16,7 @@
         </div>
         <div class="span-row">
           <span class="span-label">End</span>
-          <OnmsSelect v-model="fields.endDay" :options="DAYS_OF_MONTH" optionLabel="label" optionValue="value" data-test="specific-end-day" />
+          <OnmsSelect v-model="fields.endDay" :options="DAYS_OF_MONTH_PADDED" optionLabel="label" optionValue="value" data-test="specific-end-day" />
           <OnmsSelect v-model="fields.endMonth" :options="MONTHS" optionLabel="label" optionValue="value" />
           <OnmsSelect v-model="fields.endYear" :options="years" optionLabel="label" optionValue="value" />
           <OnmsSelect v-model="fields.endHour" :options="HOURS" optionLabel="label" optionValue="value" />
@@ -74,6 +74,7 @@ import Delete from '@opennms/onms-ui/icons/action/Delete.vue'
 import { OutageTime, OutageType } from '@/types/scheduledOutage'
 import {
   DAYS_OF_MONTH,
+  DAYS_OF_MONTH_PADDED,
   DAYS_OF_WEEK,
   HOURS,
   MINUTES,

--- a/ui/src/components/ScheduledOutages/TimeSpanEditor.vue
+++ b/ui/src/components/ScheduledOutages/TimeSpanEditor.vue
@@ -27,11 +27,11 @@
 
       <template v-else>
         <div v-if="type === 'weekly'" class="span-row">
-          <span class="span-label">Day</span>
+          <span class="span-label">Day of Week</span>
           <OnmsSelect v-model="fields.day" :options="DAYS_OF_WEEK" optionLabel="label" optionValue="value" data-test="weekly-day" />
         </div>
         <div v-if="type === 'monthly'" class="span-row">
-          <span class="span-label">Day</span>
+          <span class="span-label">Day of Month</span>
           <OnmsSelect v-model="fields.day" :options="DAYS_OF_MONTH" optionLabel="label" optionValue="value" data-test="monthly-day" />
         </div>
         <div class="span-row">
@@ -48,7 +48,7 @@
         </div>
       </template>
 
-      <OnmsButton label="Add Outage" icon="pi pi-plus" data-test="add-time" @click="addSpan" />
+      <OnmsButton label="Add Timespan" icon="pi pi-plus" class="add-button" data-test="add-time" @click="addSpan" />
     </div>
 
     <ul v-if="times.length" class="span-list">
@@ -68,7 +68,7 @@
 </template>
 
 <script setup lang="ts">
-import { reactive } from 'vue'
+import { reactive, watch } from 'vue'
 import { OnmsButton, OnmsIconButton, OnmsSelect } from '@opennms/onms-ui'
 import Delete from '@opennms/onms-ui/icons/action/Delete.vue'
 import { OutageTime, OutageType } from '@/types/scheduledOutage'
@@ -101,6 +101,16 @@ const currentYear = new Date().getFullYear()
 const years = yearOptions(currentYear)
 const fields = reactive<TimeSpanFields>(defaultTimeSpanFields(currentYear))
 
+// the day field is shared between weekly (names) and monthly (numbers), so a
+// type switch must reset it to a value that exists in the new option list
+watch(() => props.type, (type) => {
+  if (type === 'monthly' && !DAYS_OF_MONTH.some(d => d.value === fields.day)) {
+    fields.day = '1'
+  } else if (type === 'weekly' && !DAYS_OF_WEEK.some(d => d.value === fields.day)) {
+    fields.day = 'sunday'
+  }
+}, { immediate: true })
+
 const addSpan = () => {
   emit('add', buildOutageTime(props.type, fields))
 }
@@ -128,8 +138,12 @@ const addSpan = () => {
   }
 
   .span-label {
-    width: 3rem;
+    width: 6.5rem;
     font-weight: 600;
+  }
+
+  .add-button {
+    align-self: flex-start;
   }
 
   .span-list {

--- a/ui/src/components/ScheduledOutages/TimeSpanEditor.vue
+++ b/ui/src/components/ScheduledOutages/TimeSpanEditor.vue
@@ -1,0 +1,153 @@
+<template>
+  <div class="time-spans" data-test="time-spans">
+    <div class="section-title">Time spans</div>
+
+    <div class="new-span">
+      <!-- specific: full start/end dates; others: time-of-day (+ optional day) -->
+      <template v-if="type === 'specific'">
+        <div class="span-row">
+          <span class="span-label">Start</span>
+          <OnmsSelect v-model="fields.startDay" :options="DAYS_OF_MONTH" optionLabel="label" optionValue="value" data-test="specific-start-day" />
+          <OnmsSelect v-model="fields.startMonth" :options="MONTHS" optionLabel="label" optionValue="value" data-test="specific-start-month" />
+          <OnmsSelect v-model="fields.startYear" :options="years" optionLabel="label" optionValue="value" data-test="specific-start-year" />
+          <OnmsSelect v-model="fields.startHour" :options="HOURS" optionLabel="label" optionValue="value" />
+          <OnmsSelect v-model="fields.startMinute" :options="MINUTES" optionLabel="label" optionValue="value" />
+          <OnmsSelect v-model="fields.startSecond" :options="SECONDS" optionLabel="label" optionValue="value" />
+        </div>
+        <div class="span-row">
+          <span class="span-label">End</span>
+          <OnmsSelect v-model="fields.endDay" :options="DAYS_OF_MONTH" optionLabel="label" optionValue="value" data-test="specific-end-day" />
+          <OnmsSelect v-model="fields.endMonth" :options="MONTHS" optionLabel="label" optionValue="value" />
+          <OnmsSelect v-model="fields.endYear" :options="years" optionLabel="label" optionValue="value" />
+          <OnmsSelect v-model="fields.endHour" :options="HOURS" optionLabel="label" optionValue="value" />
+          <OnmsSelect v-model="fields.endMinute" :options="MINUTES" optionLabel="label" optionValue="value" />
+          <OnmsSelect v-model="fields.endSecond" :options="SECONDS" optionLabel="label" optionValue="value" />
+        </div>
+      </template>
+
+      <template v-else>
+        <div v-if="type === 'weekly'" class="span-row">
+          <span class="span-label">Day</span>
+          <OnmsSelect v-model="fields.day" :options="DAYS_OF_WEEK" optionLabel="label" optionValue="value" data-test="weekly-day" />
+        </div>
+        <div v-if="type === 'monthly'" class="span-row">
+          <span class="span-label">Day</span>
+          <OnmsSelect v-model="fields.day" :options="DAYS_OF_MONTH" optionLabel="label" optionValue="value" data-test="monthly-day" />
+        </div>
+        <div class="span-row">
+          <span class="span-label">Start</span>
+          <OnmsSelect v-model="fields.startHour" :options="HOURS" optionLabel="label" optionValue="value" data-test="time-start-hour" />
+          <OnmsSelect v-model="fields.startMinute" :options="MINUTES" optionLabel="label" optionValue="value" />
+          <OnmsSelect v-model="fields.startSecond" :options="SECONDS" optionLabel="label" optionValue="value" />
+        </div>
+        <div class="span-row">
+          <span class="span-label">End</span>
+          <OnmsSelect v-model="fields.endHour" :options="HOURS" optionLabel="label" optionValue="value" data-test="time-end-hour" />
+          <OnmsSelect v-model="fields.endMinute" :options="MINUTES" optionLabel="label" optionValue="value" />
+          <OnmsSelect v-model="fields.endSecond" :options="SECONDS" optionLabel="label" optionValue="value" />
+        </div>
+      </template>
+
+      <OnmsButton label="Add Outage" icon="pi pi-plus" data-test="add-time" @click="addSpan" />
+    </div>
+
+    <ul v-if="times.length" class="span-list">
+      <li v-for="(t, index) in times" :key="index" class="span-item">
+        <span data-test="time-row">{{ describeOutageTime(type, t) }}</span>
+        <OnmsIconButton
+          :icon="Delete"
+          severity="danger"
+          :title="`Remove time span`"
+          aria-label="Remove time span"
+          data-test="remove-time"
+          @click="emit('remove', index)"
+        />
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { reactive } from 'vue'
+import { OnmsButton, OnmsIconButton, OnmsSelect } from '@opennms/onms-ui'
+import Delete from '@opennms/onms-ui/icons/action/Delete.vue'
+import { OutageTime, OutageType } from '@/types/scheduledOutage'
+import {
+  DAYS_OF_MONTH,
+  DAYS_OF_WEEK,
+  HOURS,
+  MINUTES,
+  MONTHS,
+  SECONDS,
+  TimeSpanFields,
+  buildOutageTime,
+  defaultTimeSpanFields,
+  describeOutageTime,
+  yearOptions
+} from '@/components/ScheduledOutages/outageTime'
+
+const props = defineProps<{
+  type: OutageType
+  times: OutageTime[]
+}>()
+
+const emit = defineEmits<{
+  add: [value: OutageTime]
+  remove: [index: number]
+}>()
+
+const currentYear = new Date().getFullYear()
+const years = yearOptions(currentYear)
+const fields = reactive<TimeSpanFields>(defaultTimeSpanFields(currentYear))
+
+const addSpan = () => {
+  emit('add', buildOutageTime(props.type, fields))
+}
+</script>
+
+<style scoped lang="scss">
+.time-spans {
+  .section-title {
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+  }
+
+  .new-span {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .span-row {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+  }
+
+  .span-label {
+    width: 3rem;
+    font-weight: 600;
+  }
+
+  .span-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .span-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0.15rem 0.25rem;
+    border-radius: 4px;
+    background: var(--p-content-hover-background, rgba(127, 127, 127, 0.08));
+  }
+}
+</style>

--- a/ui/src/components/ScheduledOutages/outageTime.ts
+++ b/ui/src/components/ScheduledOutages/outageTime.ts
@@ -1,0 +1,138 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+// Wire-format helpers for poll-outages <time> spans. BasicScheduleUtils keys
+// on the exact string LENGTH: 'dd-MMM-yyyy HH:mm:ss' (20 chars, month as a
+// three-letter English abbreviation) for the 'specific' type, and 'HH:mm:ss'
+// (8 chars) for daily/weekly/monthly. Every numeric part is zero-padded so the
+// length is exact — matching the legacy admin/sched-outages/editoutage.jsp.
+
+import { OutageTime, OutageType } from '@/types/scheduledOutage'
+
+export interface Option {
+  label: string
+  value: string
+}
+
+// three-letter month values (MMM, Locale.US) with full-name labels
+export const MONTHS: Option[] = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+].map((m, i) => ({
+  value: m,
+  label: new Date(2000, i, 1).toLocaleString('en-US', { month: 'long' })
+}))
+
+export const DAYS_OF_WEEK: Option[] = [
+  'sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'
+].map(d => ({ value: d, label: d.charAt(0).toUpperCase() + d.slice(1) }))
+
+const pad = (n: number, width = 2): string => String(n).padStart(width, '0')
+
+const range = (start: number, end: number, width = 2): Option[] => {
+  const out: Option[] = []
+  for (let i = start; i <= end; i++) {
+    out.push({ value: pad(i, width), label: pad(i, width) })
+  }
+  return out
+}
+
+export const DAYS_OF_MONTH: Option[] = Array.from({ length: 31 }, (_, i) => ({
+  value: String(i + 1),
+  label: String(i + 1)
+}))
+
+export const HOURS = range(0, 23)
+export const MINUTES = range(0, 59)
+export const SECONDS = range(0, 59)
+
+export const yearOptions = (currentYear: number): Option[] =>
+  range(currentYear, currentYear + 10, 4)
+
+// One time-span row in the editor, independent of the wire format.
+export interface TimeSpanFields {
+  // 'specific' uses the date parts; the others use only hour/minute/second (+ day)
+  startDay: string
+  startMonth: string
+  startYear: string
+  startHour: string
+  startMinute: string
+  startSecond: string
+  endDay: string
+  endMonth: string
+  endYear: string
+  endHour: string
+  endMinute: string
+  endSecond: string
+  // weekday name (weekly) or day-of-month (monthly)
+  day: string
+}
+
+export const defaultTimeSpanFields = (currentYear: number): TimeSpanFields => ({
+  startDay: '01',
+  startMonth: 'Jan',
+  startYear: String(currentYear),
+  startHour: '00',
+  startMinute: '00',
+  startSecond: '00',
+  endDay: '01',
+  endMonth: 'Jan',
+  endYear: String(currentYear),
+  endHour: '23',
+  endMinute: '59',
+  endSecond: '59',
+  day: 'sunday'
+})
+
+// Build the wire <time> from the editor row for the given outage type.
+export const buildOutageTime = (type: OutageType, f: TimeSpanFields): OutageTime => {
+  if (type === 'specific') {
+    return {
+      begins: `${f.startDay}-${f.startMonth}-${f.startYear} ${f.startHour}:${f.startMinute}:${f.startSecond}`,
+      ends: `${f.endDay}-${f.endMonth}-${f.endYear} ${f.endHour}:${f.endMinute}:${f.endSecond}`
+    }
+  }
+  const time: OutageTime = {
+    begins: `${f.startHour}:${f.startMinute}:${f.startSecond}`,
+    ends: `${f.endHour}:${f.endMinute}:${f.endSecond}`
+  }
+  if (type === 'weekly') {
+    time.day = f.day
+  }
+  if (type === 'monthly') {
+    time.day = f.day
+  }
+  return time
+}
+
+// Human-readable label for an existing span in the list.
+export const describeOutageTime = (type: OutageType, t: OutageTime): string => {
+  if (type === 'specific') {
+    return `${t.begins}  →  ${t.ends}`
+  }
+  const prefix =
+    type === 'weekly' && t.day ? `${t.day.charAt(0).toUpperCase()}${t.day.slice(1)} ` :
+      type === 'monthly' && t.day ? `Day ${t.day} ` : ''
+  return `${prefix}${t.begins} → ${t.ends}`
+}
+
+export const outageTimesEqual = (a: OutageTime, b: OutageTime): boolean =>
+  a.begins === b.begins && a.ends === b.ends && (a.day ?? '') === (b.day ?? '')

--- a/ui/src/components/ScheduledOutages/outageTime.ts
+++ b/ui/src/components/ScheduledOutages/outageTime.ts
@@ -55,9 +55,19 @@ const range = (start: number, end: number, width = 2): Option[] => {
   return out
 }
 
+// Unpadded 1..31 for the monthly 'day' attribute (parsed with Integer.parseInt;
+// legacy chooseDayOfMonth emitted the bare integer).
 export const DAYS_OF_MONTH: Option[] = Array.from({ length: 31 }, (_, i) => ({
   value: String(i + 1),
   label: String(i + 1)
+}))
+
+// Zero-padded 01..31 for the specific-date 'dd' field. The 'dd-MMM-yyyy HH:mm:ss'
+// string MUST be exactly 20 chars — BasicScheduleUtils keys the parser on length,
+// so an unpadded single-digit day (19 chars) is silently misread as a daily span.
+export const DAYS_OF_MONTH_PADDED: Option[] = Array.from({ length: 31 }, (_, i) => ({
+  value: pad(i + 1),
+  label: pad(i + 1)
 }))
 
 export const HOURS = range(0, 23)

--- a/ui/src/components/ScheduledOutages/outageTime.ts
+++ b/ui/src/components/ScheduledOutages/outageTime.ts
@@ -74,8 +74,10 @@ export const HOURS = range(0, 23)
 export const MINUTES = range(0, 59)
 export const SECONDS = range(0, 59)
 
+// include the previous year (as the legacy form did) so a span that started
+// last year can still be re-entered
 export const yearOptions = (currentYear: number): Option[] =>
-  range(currentYear, currentYear + 10, 4)
+  range(currentYear - 1, currentYear + 10, 4)
 
 // One time-span row in the editor, independent of the wire format.
 export interface TimeSpanFields {

--- a/ui/src/containers/ScheduledOutageEditor.vue
+++ b/ui/src/containers/ScheduledOutageEditor.vue
@@ -7,6 +7,7 @@
 
   <div class="outage-editor">
     <OnmsCard>
+      <template #content>
       <div class="page-header">
         <h2 class="headline3" data-test="editor-title">Editing Outage: {{ name }}</h2>
         <OnmsButton variant="text" label="Cancel" data-test="cancel" @click="goBack" />
@@ -17,11 +18,15 @@
       <template v-else>
         <p v-if="errorMessage" class="error" data-test="editor-error">{{ errorMessage }}</p>
 
-        <div class="editor-grid">
+        <div v-if="loadFailed" class="load-failed" data-test="editor-load-failed">
+          <OnmsButton variant="outlined" label="Back to Scheduled Outages" @click="goBack" />
+        </div>
+
+        <div v-else class="editor-grid">
           <section class="selection">
             <h3 class="section-title">Nodes and Interfaces</h3>
             <div class="pickers">
-              <NodeInterfacePicker mode="node" :items="outage.node ?? []" @add="addNode" @remove="removeNode" />
+              <NodeInterfacePicker mode="node" :items="outage.node ?? []" :nodeLabels="nodeLabels" @add="addNode" @remove="removeNode" />
               <NodeInterfacePicker mode="interface" :items="outage.interface ?? []" @add="addInterface" @remove="removeInterface" />
             </div>
             <div class="match-any-row">
@@ -79,12 +84,37 @@
           </section>
         </div>
 
-        <div class="actions">
+        <div v-if="!loadFailed" class="actions">
           <OnmsButton label="Save Outage" data-test="save" :disabled="saving" @click="save" />
           <OnmsButton variant="text" label="Cancel" data-test="cancel-bottom" @click="goBack" />
         </div>
       </template>
+      </template>
     </OnmsCard>
+
+    <OnmsConfirmationDialog
+      :visible="showSelectAllConfirm"
+      title="Apply to All Nodes and Interfaces"
+      actionButtonText="Apply to all"
+      @ok="confirmSelectAll"
+      @cancel="showSelectAllConfirm = false"
+    >
+      <template #content>
+        <p>This clears the specific nodes and interfaces you selected and applies the outage everywhere. Continue?</p>
+      </template>
+    </OnmsConfirmationDialog>
+
+    <OnmsConfirmationDialog
+      :visible="showTypeChangeConfirm"
+      title="Change Outage Type"
+      actionButtonText="Change type"
+      @ok="confirmTypeChange"
+      @cancel="cancelTypeChange"
+    >
+      <template #content>
+        <p>Time spans are entered per outage type, so changing the type clears the time spans you already added. Continue?</p>
+      </template>
+    </OnmsConfirmationDialog>
   </div>
 </template>
 
@@ -92,7 +122,7 @@
 import { computed, onMounted, reactive, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
-import { OnmsButton, OnmsCard, OnmsSelect } from '@opennms/onms-ui'
+import { OnmsButton, OnmsCard, OnmsConfirmationDialog, OnmsSelect } from '@opennms/onms-ui'
 
 import BreadCrumbs from '@/components/Layout/BreadCrumbs.vue'
 import FormField from '@/components/Common/FormField.vue'
@@ -100,6 +130,7 @@ import AppliesToMatrix, { Subsystem } from '@/components/ScheduledOutages/Applie
 import NodeInterfacePicker from '@/components/ScheduledOutages/NodeInterfacePicker.vue'
 import TimeSpanEditor from '@/components/ScheduledOutages/TimeSpanEditor.vue'
 import {
+  getNodeLabels,
   getOutageApplicability,
   getScheduledOutage,
   saveScheduledOutage,
@@ -136,14 +167,20 @@ const isNew = route.query.new === 'true'
 const breadcrumbs: BreadCrumb[] = [
   { label: 'Home', to: '/' },
   { label: 'Scheduled Outages', to: '/scheduled-outages' },
-  { label: name, to: '' }
+  { label: name, to: route.fullPath }
 ]
 
 const loading = ref(true)
+// the outage exists but could not be read; saving would overwrite it blind
+const loadFailed = ref(false)
 const saving = ref(false)
 const submitted = ref(false)
 const errorMessage = ref('')
 const timeSpanNote = ref('')
+const showSelectAllConfirm = ref(false)
+const showTypeChangeConfirm = ref(false)
+// node id -> label for the picker chips; missing entries render as not-found
+const nodeLabels = reactive<Record<number, string>>({})
 // the type currently reflected by outage.time, so a type change can warn before
 // discarding spans that were entered under the previous type
 const lastType = ref<OutageType | undefined>(undefined)
@@ -158,6 +195,7 @@ const outage = reactive<ScheduledOutage>({
 
 const applicability = reactive<OutageApplicability>({
   notifications: false,
+  notificationCalendars: [],
   pollers: [],
   thresholders: [],
   collectors: []
@@ -180,6 +218,10 @@ const showSelectionError = computed(() => submitted.value && !hasSelection.value
 const showTimeError = computed(() => submitted.value && !hasTimes.value)
 
 onMounted(async () => {
+  if (!name) {
+    router.replace({ path: '/scheduled-outages' })
+    return
+  }
   if (!isNew) {
     const loaded = await getScheduledOutage(name)
     if (loaded) {
@@ -188,6 +230,14 @@ onMounted(async () => {
       outage.node = loaded.node ?? []
       outage.interface = loaded.interface ?? []
       lastType.value = loaded.type
+      await resolveNodeLabels()
+    } else {
+      // Distinguish "could not read the existing outage" from a new one: with
+      // an empty form, Save would POST a whole-object replace and wipe it.
+      loadFailed.value = true
+      errorMessage.value = `Failed to load scheduled outage "${name}". It may have been deleted, or the server did not respond. Editing is disabled so the existing configuration is not overwritten.`
+      loading.value = false
+      return
     }
   }
   const appl = await getOutageApplicability(isNew ? undefined : name)
@@ -201,10 +251,18 @@ onMounted(async () => {
   loading.value = false
 })
 
-const addNode = (value: OutageNode | OutageInterface) => {
+const resolveNodeLabels = async () => {
+  const labels = await getNodeLabels((outage.node ?? []).map(n => n.id))
+  Object.assign(nodeLabels, labels)
+}
+
+const addNode = (value: OutageNode | OutageInterface, label?: string) => {
   const node = value as OutageNode
   if (!(outage.node ?? []).some(n => n.id === node.id)) {
-    outage.node = [...(outage.node ?? []), node]
+    outage.node = [...(outage.node ?? []), { id: node.id }]
+    if (label) {
+      nodeLabels[node.id] = label
+    }
   }
 }
 const removeNode = (index: number) => {
@@ -227,9 +285,19 @@ const selectAll = () => {
   // stray click can't silently discard an existing selection
   const hasExisting = (outage.node ?? []).length > 0 ||
     (outage.interface ?? []).some(i => i.address !== MATCH_ANY)
-  if (hasExisting && !window.confirm('Apply to all nodes and interfaces? This clears the specific nodes and interfaces you selected.')) {
+  if (hasExisting) {
+    showSelectAllConfirm.value = true
     return
   }
+  applyMatchAny()
+}
+
+const confirmSelectAll = () => {
+  showSelectAllConfirm.value = false
+  applyMatchAny()
+}
+
+const applyMatchAny = () => {
   outage.node = []
   outage.interface = [{ address: MATCH_ANY }]
 }
@@ -237,15 +305,24 @@ const selectAll = () => {
 const onTypeChange = () => {
   // begins/ends are formatted per type, so spans entered under the old type no
   // longer apply; confirm before discarding them so a stray change can't lose data
-  if ((outage.time ?? []).length > 0) {
-    if (!window.confirm('Changing the outage type clears the time spans you already added. Continue?')) {
-      outage.type = lastType.value
-      return
-    }
-    outage.time = []
+  if ((outage.time ?? []).length > 0 && outage.type !== lastType.value) {
+    showTypeChangeConfirm.value = true
+    return
   }
   lastType.value = outage.type
   timeSpanNote.value = ''
+}
+
+const confirmTypeChange = () => {
+  showTypeChangeConfirm.value = false
+  outage.time = []
+  lastType.value = outage.type
+  timeSpanNote.value = ''
+}
+
+const cancelTypeChange = () => {
+  showTypeChangeConfirm.value = false
+  outage.type = lastType.value
 }
 
 const addTime = (time: OutageTime) => {
@@ -359,6 +436,7 @@ const goBack = () => {
 
 const clone = (a: OutageApplicability): OutageApplicability => ({
   notifications: a.notifications,
+  notificationCalendars: [...a.notificationCalendars],
   pollers: a.pollers.map(p => ({ ...p })),
   thresholders: a.thresholders.map(p => ({ ...p })),
   collectors: a.collectors.map(p => ({ ...p }))
@@ -418,6 +496,10 @@ const clone = (a: OutageApplicability): OutageApplicability => ({
   .field-note {
     color: var(--p-text-muted-color);
     margin: 0.5rem 0 0 0;
+  }
+
+  .load-failed {
+    margin-top: 0.75rem;
   }
 
   .actions {

--- a/ui/src/containers/ScheduledOutageEditor.vue
+++ b/ui/src/containers/ScheduledOutageEditor.vue
@@ -1,0 +1,391 @@
+<template>
+  <div class="onms-row">
+    <div class="onms-col-12">
+      <BreadCrumbs :items="breadcrumbs" />
+    </div>
+  </div>
+
+  <div class="outage-editor">
+    <OnmsCard>
+      <div class="page-header">
+        <h2 class="headline3" data-test="editor-title">Editing Outage: {{ name }}</h2>
+        <OnmsButton variant="text" label="Cancel" data-test="cancel" @click="goBack" />
+      </div>
+
+      <div v-if="loading" data-test="editor-loading">Loading…</div>
+
+      <template v-else>
+        <p v-if="errorMessage" class="error" data-test="editor-error">{{ errorMessage }}</p>
+
+        <div class="editor-grid">
+          <section class="selection">
+            <h3 class="section-title">Nodes and Interfaces</h3>
+            <div class="pickers">
+              <NodeInterfacePicker mode="node" :items="outage.node ?? []" @add="addNode" @remove="removeNode" />
+              <NodeInterfacePicker mode="interface" :items="outage.interface ?? []" @add="addInterface" @remove="removeInterface" />
+            </div>
+            <div class="match-any-row">
+              <OnmsButton
+                variant="outlined"
+                label="Select all nodes and interfaces"
+                data-test="match-any"
+                @click="selectAll"
+              />
+              <span v-if="isMatchAny" class="match-any-note" data-test="match-any-note">
+                Applies to all nodes and interfaces.
+              </span>
+            </div>
+            <p v-if="showSelectionError" class="field-error" data-test="selection-error">
+              You must select at least one node or interface for this scheduled outage.
+            </p>
+          </section>
+
+          <section class="schedule">
+            <FormField label="Outage Type" for="outage-type">
+              <OnmsSelect
+                v-model="outage.type"
+                inputId="outage-type"
+                :options="OUTAGE_TYPES"
+                optionLabel="label"
+                optionValue="value"
+                data-test="outage-type"
+                @change="onTypeChange"
+              />
+            </FormField>
+
+            <TimeSpanEditor
+              v-if="outage.type"
+              :type="outage.type"
+              :times="outage.time ?? []"
+              @add="addTime"
+              @remove="removeTime"
+            />
+            <p v-if="showTimeError" class="field-error" data-test="time-error">
+              You must have at least one time span defined.
+            </p>
+          </section>
+
+          <section class="applies">
+            <AppliesToMatrix
+              :notifications="applicability.notifications"
+              :pollers="applicability.pollers"
+              :thresholders="applicability.thresholders"
+              :collectors="applicability.collectors"
+              @update:notifications="applicability.notifications = $event"
+              @togglePackage="togglePackage"
+              @setAll="setAll"
+            />
+          </section>
+        </div>
+
+        <div class="actions">
+          <OnmsButton label="Save Outage" data-test="save" :disabled="saving" @click="save" />
+          <OnmsButton variant="text" label="Cancel" data-test="cancel-bottom" @click="goBack" />
+        </div>
+      </template>
+    </OnmsCard>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+import { OnmsButton, OnmsCard, OnmsSelect } from '@opennms/onms-ui'
+
+import BreadCrumbs from '@/components/Layout/BreadCrumbs.vue'
+import FormField from '@/components/Common/FormField.vue'
+import AppliesToMatrix, { Subsystem } from '@/components/ScheduledOutages/AppliesToMatrix.vue'
+import NodeInterfacePicker from '@/components/ScheduledOutages/NodeInterfacePicker.vue'
+import TimeSpanEditor from '@/components/ScheduledOutages/TimeSpanEditor.vue'
+import {
+  getOutageApplicability,
+  getScheduledOutage,
+  saveScheduledOutage,
+  scheduledOutageErrorMessage,
+  setNotificationMembership,
+  setPackageMembership
+} from '@/services/scheduledOutagesService'
+import {
+  OutageApplicability,
+  OutageInterface,
+  OutageNode,
+  OutageTime,
+  PackageRef,
+  ScheduledOutage
+} from '@/types/scheduledOutage'
+import { BreadCrumb } from '@/types'
+
+const OUTAGE_TYPES = [
+  { label: 'Specific', value: 'specific' },
+  { label: 'Daily', value: 'daily' },
+  { label: 'Weekly', value: 'weekly' },
+  { label: 'Monthly', value: 'monthly' }
+]
+
+const MATCH_ANY = 'match-any'
+
+const route = useRoute()
+const router = useRouter()
+
+const name = String(route.query.name ?? '')
+const isNew = route.query.new === 'true'
+
+const breadcrumbs: BreadCrumb[] = [
+  { label: 'Home', to: '/' },
+  { label: 'Scheduled Outages', to: '/scheduled-outages' },
+  { label: name, to: '' }
+]
+
+const loading = ref(true)
+const saving = ref(false)
+const submitted = ref(false)
+const errorMessage = ref('')
+
+const outage = reactive<ScheduledOutage>({
+  name,
+  type: undefined,
+  time: [],
+  node: [],
+  interface: []
+})
+
+const applicability = reactive<OutageApplicability>({
+  notifications: false,
+  pollers: [],
+  thresholders: [],
+  collectors: []
+})
+
+// snapshot of the loaded membership, to only PUT/DELETE what actually changed
+let originalApplicability: OutageApplicability | null = null
+
+const isMatchAny = computed(() =>
+  (outage.interface ?? []).some(i => i.address === MATCH_ANY)
+)
+
+const hasSelection = computed(() =>
+  (outage.node ?? []).length > 0 || (outage.interface ?? []).length > 0
+)
+
+const hasTimes = computed(() => (outage.time ?? []).length > 0)
+
+const showSelectionError = computed(() => submitted.value && !hasSelection.value)
+const showTimeError = computed(() => submitted.value && !hasTimes.value)
+
+onMounted(async () => {
+  if (!isNew) {
+    const loaded = await getScheduledOutage(name)
+    if (loaded) {
+      outage.type = loaded.type
+      outage.time = loaded.time ?? []
+      outage.node = loaded.node ?? []
+      outage.interface = loaded.interface ?? []
+    }
+  }
+  const appl = await getOutageApplicability(isNew ? undefined : name)
+  if (appl) {
+    applicability.notifications = appl.notifications
+    applicability.pollers = appl.pollers
+    applicability.thresholders = appl.thresholders
+    applicability.collectors = appl.collectors
+    originalApplicability = clone(appl)
+  }
+  loading.value = false
+})
+
+const addNode = (value: OutageNode | OutageInterface) => {
+  const node = value as OutageNode
+  if (!(outage.node ?? []).some(n => n.id === node.id)) {
+    outage.node = [...(outage.node ?? []), node]
+  }
+}
+const removeNode = (index: number) => {
+  outage.node = (outage.node ?? []).filter((_, i) => i !== index)
+}
+const addInterface = (value: OutageNode | OutageInterface) => {
+  const iface = value as OutageInterface
+  // adding a specific interface clears the "all" match-any pseudo-interface
+  const existing = (outage.interface ?? []).filter(i => i.address !== MATCH_ANY)
+  if (!existing.some(i => i.address === iface.address)) {
+    outage.interface = [...existing, iface]
+  }
+}
+const removeInterface = (index: number) => {
+  outage.interface = (outage.interface ?? []).filter((_, i) => i !== index)
+}
+
+const selectAll = () => {
+  outage.node = []
+  outage.interface = [{ address: MATCH_ANY }]
+}
+
+const onTypeChange = () => {
+  // begins/ends are formatted per type, so existing spans no longer apply
+  outage.time = []
+}
+
+const addTime = (time: OutageTime) => {
+  const exists = (outage.time ?? []).some(
+    t => t.begins === time.begins && t.ends === time.ends && (t.day ?? '') === (time.day ?? '')
+  )
+  if (!exists) {
+    outage.time = [...(outage.time ?? []), time]
+  }
+}
+const removeTime = (index: number) => {
+  outage.time = (outage.time ?? []).filter((_, i) => i !== index)
+}
+
+const togglePackage = (subsystem: Subsystem, pkgName: string, value: boolean) => {
+  const list = listFor(subsystem)
+  const pkg = list.find(p => p.name === pkgName)
+  if (pkg) {
+    pkg.applied = value
+  }
+}
+const setAll = (subsystem: Subsystem, value: boolean) => {
+  listFor(subsystem).forEach((p) => {
+    p.applied = value
+  })
+}
+const listFor = (subsystem: Subsystem): PackageRef[] =>
+  subsystem === 'pollerd' ? applicability.pollers
+    : subsystem === 'threshd' ? applicability.thresholders
+      : applicability.collectors
+
+const save = async () => {
+  submitted.value = true
+  errorMessage.value = ''
+  if (!outage.type) {
+    errorMessage.value = 'Please choose an outage type.'
+    return
+  }
+  if (!hasSelection.value || !hasTimes.value) {
+    return
+  }
+  saving.value = true
+  try {
+    await saveScheduledOutage({
+      name: outage.name,
+      type: outage.type,
+      time: outage.time,
+      node: outage.node,
+      interface: outage.interface
+    })
+    await applyMembershipChanges()
+    goBack()
+  } catch (err: any) {
+    errorMessage.value = scheduledOutageErrorMessage(err, 'Failed to save the scheduled outage.')
+  } finally {
+    saving.value = false
+  }
+}
+
+// PUT/DELETE only the memberships that differ from what was loaded.
+const applyMembershipChanges = async () => {
+  const original = originalApplicability
+  const wasApplied = (subsystem: Subsystem, pkgName: string): boolean => {
+    if (!original) {
+      return false
+    }
+    const list = subsystem === 'pollerd' ? original.pollers
+      : subsystem === 'threshd' ? original.thresholders : original.collectors
+    return !!list.find(p => p.name === pkgName)?.applied
+  }
+  const subsystems: Subsystem[] = ['pollerd', 'threshd', 'collectd']
+  for (const subsystem of subsystems) {
+    for (const pkg of listFor(subsystem)) {
+      if (pkg.applied !== wasApplied(subsystem, pkg.name)) {
+        await setPackageMembership(subsystem, outage.name, pkg.name, pkg.applied)
+      }
+    }
+  }
+  if (applicability.notifications !== (original?.notifications ?? false)) {
+    await setNotificationMembership(outage.name, applicability.notifications)
+  }
+}
+
+const goBack = () => {
+  router.push({ path: '/scheduled-outages' })
+}
+
+const clone = (a: OutageApplicability): OutageApplicability => ({
+  notifications: a.notifications,
+  pollers: a.pollers.map(p => ({ ...p })),
+  thresholders: a.thresholders.map(p => ({ ...p })),
+  collectors: a.collectors.map(p => ({ ...p }))
+})
+</script>
+
+<style scoped lang="scss">
+.outage-editor {
+  .page-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .editor-grid {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    grid-template-areas:
+      'selection applies'
+      'schedule applies';
+    gap: 1.5rem 2rem;
+  }
+
+  .selection { grid-area: selection; }
+  .schedule { grid-area: schedule; }
+  .applies { grid-area: applies; }
+
+  .section-title {
+    margin: 0 0 0.75rem 0;
+  }
+
+  .pickers {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1.5rem;
+  }
+
+  .match-any-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 1rem;
+  }
+
+  .match-any-note {
+    color: var(--p-text-muted-color);
+  }
+
+  .field-error,
+  .error {
+    color: var(--p-red-500, #d32f2f);
+    margin: 0.5rem 0 0 0;
+  }
+
+  .actions {
+    display: flex;
+    gap: 0.75rem;
+    margin-top: 1.5rem;
+  }
+
+  @media (max-width: 64rem) {
+    .editor-grid {
+      grid-template-columns: minmax(0, 1fr);
+      grid-template-areas:
+        'selection'
+        'schedule'
+        'applies';
+    }
+
+    .pickers {
+      grid-template-columns: minmax(0, 1fr);
+    }
+  }
+}
+</style>

--- a/ui/src/containers/ScheduledOutageEditor.vue
+++ b/ui/src/containers/ScheduledOutageEditor.vue
@@ -260,6 +260,9 @@ const resolveNodeLabels = async () => {
 
 const addNode = (value: OutageNode | OutageInterface, label?: string) => {
   const node = value as OutageNode
+  // a specific node ends "all": match-any would otherwise hide the node in the
+  // pickers and still be written next to it on save
+  outage.interface = (outage.interface ?? []).filter(i => i.address !== MATCH_ANY)
   if (!(outage.node ?? []).some(n => n.id === node.id)) {
     outage.node = [...(outage.node ?? []), { id: node.id }]
     if (label) {

--- a/ui/src/containers/ScheduledOutageEditor.vue
+++ b/ui/src/containers/ScheduledOutageEditor.vue
@@ -72,7 +72,11 @@
           </section>
 
           <section class="applies">
+            <p v-if="appliesFailed" class="error" data-test="applies-error">
+              Failed to load which subsystems this outage applies to. Its memberships are left unchanged when you save; reload the page to try again.
+            </p>
             <AppliesToMatrix
+              v-else
               :notifications="applicability.notifications"
               :pollers="applicability.pollers"
               :thresholders="applicability.thresholders"
@@ -205,6 +209,8 @@ const applicability = reactive<OutageApplicability>({
 
 // snapshot of the loaded membership, to only PUT/DELETE what actually changed
 let originalApplicability: OutageApplicability | null = null
+// the applies-to read failed: an empty matrix would read as "nothing applied"
+const appliesFailed = ref(false)
 
 const isMatchAny = computed(() =>
   (outage.interface ?? []).some(i => i.address === MATCH_ANY)
@@ -242,7 +248,13 @@ onMounted(async () => {
       return
     }
   }
-  const appl = await getOutageApplicability(isNew ? undefined : name)
+  await loadApplicability(isNew ? undefined : name)
+  loading.value = false
+})
+
+const loadApplicability = async (outageName?: string) => {
+  const appl = await getOutageApplicability(outageName)
+  appliesFailed.value = appl === null
   if (appl) {
     applicability.notifications = appl.notifications
     applicability.pollers = appl.pollers
@@ -250,8 +262,7 @@ onMounted(async () => {
     applicability.collectors = appl.collectors
     originalApplicability = clone(appl)
   }
-  loading.value = false
-})
+}
 
 const resolveNodeLabels = async () => {
   const labels = await getNodeLabels((outage.node ?? []).map(n => n.id))
@@ -400,19 +411,13 @@ const save = async () => {
   }
 }
 
-const reloadApplicability = async () => {
-  const appl = await getOutageApplicability(outage.name)
-  if (appl) {
-    applicability.notifications = appl.notifications
-    applicability.pollers = appl.pollers
-    applicability.thresholders = appl.thresholders
-    applicability.collectors = appl.collectors
-    originalApplicability = clone(appl)
-  }
-}
+const reloadApplicability = () => loadApplicability(outage.name)
 
 // PUT/DELETE only the memberships that differ from what was loaded.
 const applyMembershipChanges = async () => {
+  if (appliesFailed.value) {
+    return
+  }
   const original = originalApplicability
   const wasApplied = (subsystem: Subsystem, pkgName: string): boolean => {
     if (!original) {

--- a/ui/src/containers/ScheduledOutageEditor.vue
+++ b/ui/src/containers/ScheduledOutageEditor.vue
@@ -63,6 +63,7 @@
             <p v-if="showTimeError" class="field-error" data-test="time-error">
               You must have at least one time span defined.
             </p>
+            <p v-if="timeSpanNote" class="field-note" data-test="time-note">{{ timeSpanNote }}</p>
           </section>
 
           <section class="applies">
@@ -111,6 +112,7 @@ import {
   OutageInterface,
   OutageNode,
   OutageTime,
+  OutageType,
   PackageRef,
   ScheduledOutage
 } from '@/types/scheduledOutage'
@@ -141,6 +143,10 @@ const loading = ref(true)
 const saving = ref(false)
 const submitted = ref(false)
 const errorMessage = ref('')
+const timeSpanNote = ref('')
+// the type currently reflected by outage.time, so a type change can warn before
+// discarding spans that were entered under the previous type
+const lastType = ref<OutageType | undefined>(undefined)
 
 const outage = reactive<ScheduledOutage>({
   name,
@@ -181,6 +187,7 @@ onMounted(async () => {
       outage.time = loaded.time ?? []
       outage.node = loaded.node ?? []
       outage.interface = loaded.interface ?? []
+      lastType.value = loaded.type
     }
   }
   const appl = await getOutageApplicability(isNew ? undefined : name)
@@ -216,22 +223,41 @@ const removeInterface = (index: number) => {
 }
 
 const selectAll = () => {
+  // this replaces any curated node/interface list with "all"; confirm first so a
+  // stray click can't silently discard an existing selection
+  const hasExisting = (outage.node ?? []).length > 0 ||
+    (outage.interface ?? []).some(i => i.address !== MATCH_ANY)
+  if (hasExisting && !window.confirm('Apply to all nodes and interfaces? This clears the specific nodes and interfaces you selected.')) {
+    return
+  }
   outage.node = []
   outage.interface = [{ address: MATCH_ANY }]
 }
 
 const onTypeChange = () => {
-  // begins/ends are formatted per type, so existing spans no longer apply
-  outage.time = []
+  // begins/ends are formatted per type, so spans entered under the old type no
+  // longer apply; confirm before discarding them so a stray change can't lose data
+  if ((outage.time ?? []).length > 0) {
+    if (!window.confirm('Changing the outage type clears the time spans you already added. Continue?')) {
+      outage.type = lastType.value
+      return
+    }
+    outage.time = []
+  }
+  lastType.value = outage.type
+  timeSpanNote.value = ''
 }
 
 const addTime = (time: OutageTime) => {
   const exists = (outage.time ?? []).some(
     t => t.begins === time.begins && t.ends === time.ends && (t.day ?? '') === (time.day ?? '')
   )
-  if (!exists) {
-    outage.time = [...(outage.time ?? []), time]
+  if (exists) {
+    timeSpanNote.value = 'That time span is already in the list.'
+    return
   }
+  timeSpanNote.value = ''
+  outage.time = [...(outage.time ?? []), time]
 }
 const removeTime = (index: number) => {
   outage.time = (outage.time ?? []).filter((_, i) => i !== index)
@@ -265,6 +291,7 @@ const save = async () => {
     return
   }
   saving.value = true
+  let outageSaved = false
   try {
     await saveScheduledOutage({
       name: outage.name,
@@ -273,12 +300,32 @@ const save = async () => {
       node: outage.node,
       interface: outage.interface
     })
+    outageSaved = true
     await applyMembershipChanges()
     goBack()
   } catch (err: any) {
-    errorMessage.value = scheduledOutageErrorMessage(err, 'Failed to save the scheduled outage.')
+    if (outageSaved) {
+      // The outage persisted but a subsystem membership call failed partway.
+      // Re-read the actual state so the matrix reflects what really got applied.
+      errorMessage.value = scheduledOutageErrorMessage(
+        err, 'The outage was saved, but applying some subsystem settings failed. The list below now shows the settings that were actually applied — review and Save again.')
+      await reloadApplicability()
+    } else {
+      errorMessage.value = scheduledOutageErrorMessage(err, 'Failed to save the scheduled outage.')
+    }
   } finally {
     saving.value = false
+  }
+}
+
+const reloadApplicability = async () => {
+  const appl = await getOutageApplicability(outage.name)
+  if (appl) {
+    applicability.notifications = appl.notifications
+    applicability.pollers = appl.pollers
+    applicability.thresholders = appl.thresholders
+    applicability.collectors = appl.collectors
+    originalApplicability = clone(appl)
   }
 }
 
@@ -365,6 +412,11 @@ const clone = (a: OutageApplicability): OutageApplicability => ({
   .field-error,
   .error {
     color: var(--p-red-500, #d32f2f);
+    margin: 0.5rem 0 0 0;
+  }
+
+  .field-note {
+    color: var(--p-text-muted-color);
     margin: 0.5rem 0 0 0;
   }
 

--- a/ui/src/containers/ScheduledOutageEditor.vue
+++ b/ui/src/containers/ScheduledOutageEditor.vue
@@ -9,8 +9,11 @@
     <OnmsCard>
       <template #content>
       <div class="page-header">
-        <h2 class="headline3" data-test="editor-title">Editing Outage: {{ name }}</h2>
-        <OnmsButton variant="text" label="Cancel" data-test="cancel" @click="goBack" />
+        <OnmsButton variant="text" class="back-button" data-test="back-button" @click="goBack">
+          <OnmsIcon :icon="ArrowBack" />
+          Go Back
+        </OnmsButton>
+        <h2 class="headline3" data-test="editor-title">{{ isNew ? 'New Scheduled Outage' : 'Edit Scheduled Outage' }}: {{ name }}</h2>
       </div>
 
       <div v-if="loading" data-test="editor-loading">Loading…</div>
@@ -26,8 +29,8 @@
           <section class="selection">
             <h3 class="section-title">Nodes and Interfaces</h3>
             <div class="pickers">
-              <NodeInterfacePicker mode="node" :items="outage.node ?? []" :nodeLabels="nodeLabels" @add="addNode" @remove="removeNode" />
-              <NodeInterfacePicker mode="interface" :items="outage.interface ?? []" @add="addInterface" @remove="removeInterface" />
+              <NodeInterfacePicker mode="node" :items="outage.node ?? []" :nodeLabels="nodeLabels" :matchAny="isMatchAny" @add="addNode" @remove="removeNode" />
+              <NodeInterfacePicker mode="interface" :items="outage.interface ?? []" :matchAny="isMatchAny" @add="addInterface" @remove="removeInterface" />
             </div>
             <div class="match-any-row">
               <OnmsButton
@@ -36,9 +39,6 @@
                 data-test="match-any"
                 @click="selectAll"
               />
-              <span v-if="isMatchAny" class="match-any-note" data-test="match-any-note">
-                Applies to all nodes and interfaces.
-              </span>
             </div>
             <p v-if="showSelectionError" class="field-error" data-test="selection-error">
               You must select at least one node or interface for this scheduled outage.
@@ -85,7 +85,7 @@
         </div>
 
         <div v-if="!loadFailed" class="actions">
-          <OnmsButton label="Save Outage" data-test="save" :disabled="saving" @click="save" />
+          <OnmsButton :label="isNew ? 'Create' : 'Save'" data-test="save" :disabled="saving" @click="save" />
           <OnmsButton variant="text" label="Cancel" data-test="cancel-bottom" @click="goBack" />
         </div>
       </template>
@@ -122,7 +122,8 @@
 import { computed, onMounted, reactive, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
-import { OnmsButton, OnmsCard, OnmsConfirmationDialog, OnmsSelect } from '@opennms/onms-ui'
+import { OnmsButton, OnmsCard, OnmsConfirmationDialog, OnmsIcon, OnmsSelect } from '@opennms/onms-ui'
+import ArrowBack from '@opennms/onms-ui/icons/navigation/ArrowBack.vue'
 
 import BreadCrumbs from '@/components/Layout/BreadCrumbs.vue'
 import FormField from '@/components/Common/FormField.vue'
@@ -183,11 +184,12 @@ const showTypeChangeConfirm = ref(false)
 const nodeLabels = reactive<Record<number, string>>({})
 // the type currently reflected by outage.time, so a type change can warn before
 // discarding spans that were entered under the previous type
-const lastType = ref<OutageType | undefined>(undefined)
+const lastType = ref<OutageType | undefined>(isNew ? 'specific' : undefined)
 
 const outage = reactive<ScheduledOutage>({
   name,
-  type: undefined,
+  // a new outage starts on a usable form: type pre-selected, spans addable
+  type: isNew ? 'specific' : undefined,
   time: [],
   node: [],
   interface: []
@@ -447,15 +449,22 @@ const clone = (a: OutageApplicability): OutageApplicability => ({
 .outage-editor {
   .page-header {
     display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-    margin-bottom: 0.5rem;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .back-button {
+    padding-left: 0;
   }
 
   .editor-grid {
     display: grid;
     grid-template-columns: 2fr 1fr;
+    // the applies column spans both rows; without content-sized rows the
+    // browser distributes its extra height as blank space above the schedule
+    grid-template-rows: min-content 1fr;
     grid-template-areas:
       'selection applies'
       'schedule applies';
@@ -481,10 +490,6 @@ const clone = (a: OutageApplicability): OutageApplicability => ({
     align-items: center;
     gap: 0.75rem;
     margin-top: 1rem;
-  }
-
-  .match-any-note {
-    color: var(--p-text-muted-color);
   }
 
   .field-error,

--- a/ui/src/containers/ScheduledOutages.vue
+++ b/ui/src/containers/ScheduledOutages.vue
@@ -45,7 +45,9 @@
           <template #body="{ data }">{{ data.type ?? '--' }}</template>
         </OnmsColumn>
         <OnmsColumn header="Nodes/Interfaces">
-          <template #body="{ data }">{{ selectionSummary(data) }}</template>
+          <template #body="{ data }">
+            <span :title="selectionTitle(data)">{{ selectionSummary(data) }}</span>
+          </template>
         </OnmsColumn>
         <OnmsColumn header="Times">
           <template #body="{ data }">{{ (data.time ?? []).length }}</template>
@@ -123,6 +125,7 @@ import AboutDialogButton from '@/components/Common/AboutDialogButton.vue'
 import ScheduledOutagesAbout from '@/components/ScheduledOutages/ScheduledOutagesAbout.vue'
 import {
   deleteScheduledOutage,
+  getNodeLabels,
   getOutageApplicability,
   getScheduledOutages,
   scheduledOutageErrorMessage
@@ -136,7 +139,12 @@ interface OutageRow extends ScheduledOutage {
 
 // small inline green-check / muted-dash cell
 const AppliedMark = (props: { on?: boolean }) =>
-  h('span', { class: props.on ? 'mark on' : 'mark off', 'data-test': 'applied-mark' }, props.on ? '✓' : '—')
+  h('span', {
+    class: props.on ? 'mark on' : 'mark off',
+    'data-test': 'applied-mark',
+    role: 'img',
+    'aria-label': props.on ? 'applied' : 'not applied'
+  }, props.on ? '✓' : '—')
 
 const router = useRouter()
 
@@ -146,6 +154,7 @@ const breadcrumbs: BreadCrumb[] = [
 ]
 
 const outages = ref<OutageRow[]>([])
+const nodeLabels = ref<Record<number, string>>({})
 const loading = ref(true)
 const newName = ref('')
 const createError = ref('')
@@ -161,40 +170,57 @@ const load = async () => {
   loading.value = true
   loadError.value = ''
   const list = await getScheduledOutages()
-  // null signals a fetch failure — keep the rows already on screen (service contract)
+  // null signals a fetch failure — keep any rows already on screen (service contract)
   if (list === null) {
-    loadError.value = 'Failed to load scheduled outages. Showing the last known list.'
+    loadError.value = outages.value.length
+      ? 'Failed to load scheduled outages. Showing the last known list.'
+      : 'Failed to load scheduled outages.'
     loading.value = false
     return
   }
   const rows: OutageRow[] = list.map(o => ({ ...o }))
-  // membership booleans come from the per-outage applies-to summary
-  await Promise.all(rows.map(async (row) => {
-    const appl = await getOutageApplicability(row.name)
+  // One name-less applies-to call exposes every package's outage calendars, so
+  // per-row membership is derived here instead of one request per outage.
+  const appl = await getOutageApplicability()
+  const referencedBy = (packages: { calendars: string[] }[] | undefined, outageName: string) =>
+    !!packages?.some(p => p.calendars.includes(outageName))
+  for (const row of rows) {
     row.applies = {
-      notifications: !!appl?.notifications,
-      polling: !!appl?.pollers.some(p => p.applied),
-      thresholds: !!appl?.thresholders.some(p => p.applied),
-      collection: !!appl?.collectors.some(p => p.applied)
+      notifications: !!appl?.notificationCalendars.includes(row.name),
+      polling: referencedBy(appl?.pollers, row.name),
+      thresholds: referencedBy(appl?.thresholders, row.name),
+      collection: referencedBy(appl?.collectors, row.name)
     }
-  }))
+  }
+  // resolve node labels for the selection column in a single OR query
+  const nodeIds = [...new Set(rows.flatMap(row => (row.node ?? []).map(n => n.id)))]
+  nodeLabels.value = await getNodeLabels(nodeIds)
   outages.value = rows
   loading.value = false
 }
 
 onMounted(load)
 
+// Node labels and interface addresses, as the legacy list showed them; nodes
+// no longer in inventory are flagged, long selections truncated with a title.
 const selectionSummary = (o: ScheduledOutage): string => {
   if ((o.interface ?? []).some(i => i.address === 'match-any')) {
     return 'All nodes and interfaces'
   }
-  const nodes = (o.node ?? []).length
-  const ifaces = (o.interface ?? []).length
-  if (!nodes && !ifaces) {
+  const parts = [
+    ...(o.node ?? []).map(n => nodeLabels.value[n.id] ?? `Node ${n.id} (not found)`),
+    ...(o.interface ?? []).map(i => i.address)
+  ]
+  if (!parts.length) {
     return '--'
   }
-  return `${nodes} node(s), ${ifaces} interface(s)`
+  return parts.length > 4 ? `${parts.slice(0, 4).join(', ')}, +${parts.length - 4} more` : parts.join(', ')
 }
+
+const selectionTitle = (o: ScheduledOutage): string => [
+  ...(o.node ?? []).map(n => nodeLabels.value[n.id] ?? `Node ${n.id} (not found)`),
+  ...(o.interface ?? []).map(i => i.address)
+].join(', ')
 
 const createOutage = () => {
   const name = newName.value.trim()

--- a/ui/src/containers/ScheduledOutages.vue
+++ b/ui/src/containers/ScheduledOutages.vue
@@ -27,6 +27,7 @@
 
       <p v-if="loadError" class="error" data-test="load-error">{{ loadError }}</p>
       <p v-if="actionError" class="error" data-test="action-error">{{ actionError }}</p>
+      <p v-if="appliesError" class="error" data-test="applies-error">{{ appliesError }}</p>
 
       <OnmsTable
         v-if="outages.length"
@@ -158,14 +159,15 @@ interface OutageRow extends ScheduledOutage {
   applies?: { notifications: boolean, polling: boolean, thresholds: boolean, collection: boolean }
 }
 
-// small inline green-check / muted-dash cell
+// small inline green-check / muted-dash cell; undefined (applies-to could not
+// be read) renders as unknown rather than as "not applied"
 const AppliedMark = (props: { on?: boolean }) =>
   h('span', {
-    class: props.on ? 'mark on' : 'mark off',
+    class: props.on === undefined ? 'mark unknown' : props.on ? 'mark on' : 'mark off',
     'data-test': 'applied-mark',
     role: 'img',
-    'aria-label': props.on ? 'applied' : 'not applied'
-  }, props.on ? '✓' : '—')
+    'aria-label': props.on === undefined ? 'unknown' : props.on ? 'applied' : 'not applied'
+  }, props.on === undefined ? '?' : props.on ? '✓' : '—')
 
 const router = useRouter()
 
@@ -182,6 +184,7 @@ const createError = ref('')
 const loadError = ref('')
 // kept separate from loadError, which the post-action reload resets
 const actionError = ref('')
+const appliesError = ref('')
 const outageToDelete = ref('')
 
 const emptyContent = computed(() => ({
@@ -205,15 +208,19 @@ const load = async () => {
   // One name-less applies-to call exposes every package's outage calendars, so
   // per-row membership is derived here instead of one request per outage.
   const appl = await getOutageApplicability()
-  const referencedBy = (packages: { calendars: string[] }[] | undefined, outageName: string) =>
-    !!packages?.some(p => p.calendars.includes(outageName))
+  appliesError.value = appl === null
+    ? 'Failed to load which subsystems each outage applies to; those columns are shown as unknown.'
+    : ''
+  const referencedBy = (packages: { calendars: string[] }[], outageName: string) =>
+    packages.some(p => p.calendars.includes(outageName))
   for (const row of rows) {
-    row.applies = {
-      notifications: !!appl?.notificationCalendars.includes(row.name),
-      polling: referencedBy(appl?.pollers, row.name),
-      thresholds: referencedBy(appl?.thresholders, row.name),
-      collection: referencedBy(appl?.collectors, row.name)
-    }
+    // leave applies unset on failure so the cells render as unknown, not "—"
+    row.applies = appl ? {
+      notifications: appl.notificationCalendars.includes(row.name),
+      polling: referencedBy(appl.pollers, row.name),
+      thresholds: referencedBy(appl.thresholders, row.name),
+      collection: referencedBy(appl.collectors, row.name)
+    } : undefined
   }
   // resolve node labels for the selection column in a single OR query
   const nodeIds = [...new Set(rows.flatMap(row => (row.node ?? []).map(n => n.id)))]
@@ -338,7 +345,8 @@ const confirmDelete = async () => {
     font-weight: 700;
   }
 
-  :deep(.mark.off) {
+  :deep(.mark.off),
+  :deep(.mark.unknown) {
     color: var(--p-text-muted-color);
   }
 }

--- a/ui/src/containers/ScheduledOutages.vue
+++ b/ui/src/containers/ScheduledOutages.vue
@@ -8,27 +8,23 @@
   <div class="scheduled-outages">
     <TableCard>
       <div class="header">
-        <div class="card-title">Scheduled Outages</div>
-        <div class="header-actions">
-          <FormField label="New outage name" for="new-outage-name">
-            <div class="create-row">
-              <OnmsInputText id="new-outage-name" v-model="newName" placeholder="New Name" data-test="new-name" />
-              <OnmsButton
-                icon="pi pi-plus"
-                label="Create"
-                :disabled="!newName.trim()"
-                data-test="create-outage"
-                @click="createOutage"
-              />
-            </div>
-          </FormField>
-          <AboutDialogButton title="Scheduled Outages">
-            <ScheduledOutagesAbout />
-          </AboutDialogButton>
+        <div class="title-block">
+          <div class="card-title">Scheduled Outages</div>
+          <div class="subtitle-row">
+            <span class="subtitle">View and create scheduled outages.</span>
+            <AboutDialogButton title="Scheduled Outages">
+              <ScheduledOutagesAbout />
+            </AboutDialogButton>
+          </div>
         </div>
+        <OnmsButton
+          icon="pi pi-plus"
+          label="Create New Outage"
+          data-test="create-outage"
+          @click="openCreateDialog"
+        />
       </div>
 
-      <p v-if="createError" class="error" data-test="create-error">{{ createError }}</p>
       <p v-if="loadError" class="error" data-test="load-error">{{ loadError }}</p>
 
       <OnmsTable
@@ -92,6 +88,30 @@
       </div>
     </TableCard>
 
+    <OnmsDialog
+      :visible="showCreateDialog"
+      modal
+      header="Create New Outage"
+      width="28rem"
+      data-test="create-dialog"
+      @update:visible="(value: boolean) => { if (!value) closeCreateDialog() }"
+    >
+      <FormField label="Name" for="new-outage-name" :error="createError">
+        <OnmsInputText
+          id="new-outage-name"
+          v-model="newName"
+          placeholder="Outage name"
+          fluid
+          data-test="new-name"
+          @keyup.enter="createOutage"
+        />
+      </FormField>
+      <div class="dialog-actions">
+        <OnmsButton variant="text" label="Cancel" data-test="create-cancel" @click="closeCreateDialog" />
+        <OnmsButton label="Create" :disabled="!newName.trim()" data-test="create-confirm" @click="createOutage" />
+      </div>
+    </OnmsDialog>
+
     <OnmsConfirmationDialog
       :visible="!!outageToDelete"
       title="Delete Scheduled Outage"
@@ -113,7 +133,7 @@
 import { computed, h, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 
-import { OnmsButton, OnmsColumn, OnmsConfirmationDialog, OnmsIconButton, OnmsInputText, OnmsTable } from '@opennms/onms-ui'
+import { OnmsButton, OnmsColumn, OnmsConfirmationDialog, OnmsDialog, OnmsIconButton, OnmsInputText, OnmsTable } from '@opennms/onms-ui'
 import Delete from '@opennms/onms-ui/icons/action/Delete.vue'
 import Edit from '@opennms/onms-ui/icons/action/Edit.vue'
 
@@ -163,7 +183,7 @@ const outageToDelete = ref('')
 
 const emptyContent = computed(() => ({
   title: 'No scheduled outages',
-  msg: 'Create one with the New Name field above.'
+  msg: 'Create one with the Create New Outage button above.'
 }))
 
 const load = async () => {
@@ -222,6 +242,18 @@ const selectionTitle = (o: ScheduledOutage): string => [
   ...(o.interface ?? []).map(i => i.address)
 ].join(', ')
 
+const showCreateDialog = ref(false)
+
+const openCreateDialog = () => {
+  newName.value = ''
+  createError.value = ''
+  showCreateDialog.value = true
+}
+
+const closeCreateDialog = () => {
+  showCreateDialog.value = false
+}
+
 const createOutage = () => {
   const name = newName.value.trim()
   createError.value = ''
@@ -261,7 +293,7 @@ const confirmDelete = async () => {
 .scheduled-outages {
   .header {
     display: flex;
-    align-items: flex-end;
+    align-items: flex-start;
     justify-content: space-between;
     gap: 1rem;
     margin-bottom: 1rem;
@@ -272,16 +304,21 @@ const confirmDelete = async () => {
     font-weight: 600;
   }
 
-  .header-actions {
-    display: flex;
-    align-items: flex-end;
-    gap: 0.75rem;
-  }
-
-  .create-row {
+  .subtitle-row {
     display: flex;
     align-items: center;
+    gap: 0.25rem;
+  }
+
+  .subtitle {
+    color: var(--p-text-muted-color);
+  }
+
+  .dialog-actions {
+    display: flex;
+    justify-content: flex-end;
     gap: 0.5rem;
+    margin-top: 1rem;
   }
 
   .action-container {

--- a/ui/src/containers/ScheduledOutages.vue
+++ b/ui/src/containers/ScheduledOutages.vue
@@ -1,0 +1,266 @@
+<template>
+  <div class="onms-row">
+    <div class="onms-col-12">
+      <BreadCrumbs :items="breadcrumbs" />
+    </div>
+  </div>
+
+  <div class="scheduled-outages">
+    <TableCard>
+      <div class="header">
+        <div class="card-title">Scheduled Outages</div>
+        <div class="header-actions">
+          <FormField label="New outage name" for="new-outage-name">
+            <div class="create-row">
+              <OnmsInputText id="new-outage-name" v-model="newName" placeholder="New Name" data-test="new-name" />
+              <OnmsButton
+                icon="pi pi-plus"
+                label="Create"
+                :disabled="!newName.trim()"
+                data-test="create-outage"
+                @click="createOutage"
+              />
+            </div>
+          </FormField>
+          <AboutDialogButton title="Scheduled Outages">
+            <ScheduledOutagesAbout />
+          </AboutDialogButton>
+        </div>
+      </div>
+
+      <p v-if="createError" class="error" data-test="create-error">{{ createError }}</p>
+
+      <OnmsTable
+        v-if="outages.length"
+        :value="outages"
+        paginator
+        dataKey="name"
+        :rows="10"
+        :rowsPerPageOptions="[10, 20, 50, 100]"
+        data-test="outages-table"
+      >
+        <OnmsColumn field="name" header="Name" sortable />
+        <OnmsColumn field="type" header="Type" sortable>
+          <template #body="{ data }">{{ data.type ?? '--' }}</template>
+        </OnmsColumn>
+        <OnmsColumn header="Nodes/Interfaces">
+          <template #body="{ data }">{{ selectionSummary(data) }}</template>
+        </OnmsColumn>
+        <OnmsColumn header="Times">
+          <template #body="{ data }">{{ (data.time ?? []).length }}</template>
+        </OnmsColumn>
+        <OnmsColumn header="Notifications">
+          <template #body="{ data }"><AppliedMark :on="data.applies?.notifications" /></template>
+        </OnmsColumn>
+        <OnmsColumn header="Polling">
+          <template #body="{ data }"><AppliedMark :on="data.applies?.polling" /></template>
+        </OnmsColumn>
+        <OnmsColumn header="Thresholds">
+          <template #body="{ data }"><AppliedMark :on="data.applies?.thresholds" /></template>
+        </OnmsColumn>
+        <OnmsColumn header="Data collection">
+          <template #body="{ data }"><AppliedMark :on="data.applies?.collection" /></template>
+        </OnmsColumn>
+        <OnmsColumn header="Actions">
+          <template #body="{ data }">
+            <div class="action-container">
+              <OnmsIconButton
+                :icon="Edit"
+                :title="`Edit ${data.name}`"
+                :aria-label="`Edit ${data.name}`"
+                data-test="edit-outage"
+                @click="editOutage(data.name)"
+              />
+              <OnmsIconButton
+                :icon="Delete"
+                severity="danger"
+                :title="`Delete ${data.name}`"
+                :aria-label="`Delete ${data.name}`"
+                data-test="delete-outage"
+                @click="askDelete(data.name)"
+              />
+            </div>
+          </template>
+        </OnmsColumn>
+      </OnmsTable>
+
+      <div v-else-if="!loading">
+        <EmptyList :content="emptyContent" data-test="empty-list" />
+      </div>
+    </TableCard>
+
+    <OnmsConfirmationDialog
+      :visible="!!outageToDelete"
+      title="Delete Scheduled Outage"
+      actionButtonText="Delete"
+      @ok="confirmDelete"
+      @cancel="outageToDelete = ''"
+    >
+      <template #content>
+        <p>
+          Are you sure you want to delete the scheduled outage <strong>{{ outageToDelete }}</strong>?
+          It will also be removed from every subsystem that references it. This action cannot be undone.
+        </p>
+      </template>
+    </OnmsConfirmationDialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, h, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+import { OnmsButton, OnmsColumn, OnmsConfirmationDialog, OnmsIconButton, OnmsInputText, OnmsTable } from '@opennms/onms-ui'
+import Delete from '@opennms/onms-ui/icons/action/Delete.vue'
+import Edit from '@opennms/onms-ui/icons/action/Edit.vue'
+
+import BreadCrumbs from '@/components/Layout/BreadCrumbs.vue'
+import FormField from '@/components/Common/FormField.vue'
+import TableCard from '@/components/Common/TableCard.vue'
+import EmptyList from '@/components/Common/EmptyList.vue'
+import AboutDialogButton from '@/components/Common/AboutDialogButton.vue'
+import ScheduledOutagesAbout from '@/components/ScheduledOutages/ScheduledOutagesAbout.vue'
+import {
+  deleteScheduledOutage,
+  getOutageApplicability,
+  getScheduledOutages
+} from '@/services/scheduledOutagesService'
+import { ScheduledOutage } from '@/types/scheduledOutage'
+import { BreadCrumb } from '@/types'
+
+interface OutageRow extends ScheduledOutage {
+  applies?: { notifications: boolean, polling: boolean, thresholds: boolean, collection: boolean }
+}
+
+// small inline green-check / muted-dash cell
+const AppliedMark = (props: { on?: boolean }) =>
+  h('span', { class: props.on ? 'mark on' : 'mark off', 'data-test': 'applied-mark' }, props.on ? '✓' : '—')
+
+const router = useRouter()
+
+const breadcrumbs: BreadCrumb[] = [
+  { label: 'Home', to: '/' },
+  { label: 'Scheduled Outages', to: '/scheduled-outages' }
+]
+
+const outages = ref<OutageRow[]>([])
+const loading = ref(true)
+const newName = ref('')
+const createError = ref('')
+const outageToDelete = ref('')
+
+const emptyContent = computed(() => ({
+  title: 'No scheduled outages',
+  msg: 'Create one with the New Name field above.'
+}))
+
+const load = async () => {
+  loading.value = true
+  const list = await getScheduledOutages()
+  const rows: OutageRow[] = (list ?? []).map(o => ({ ...o }))
+  // membership booleans come from the per-outage applies-to summary
+  await Promise.all(rows.map(async (row) => {
+    const appl = await getOutageApplicability(row.name)
+    row.applies = {
+      notifications: !!appl?.notifications,
+      polling: !!appl?.pollers.some(p => p.applied),
+      thresholds: !!appl?.thresholders.some(p => p.applied),
+      collection: !!appl?.collectors.some(p => p.applied)
+    }
+  }))
+  outages.value = rows
+  loading.value = false
+}
+
+onMounted(load)
+
+const selectionSummary = (o: ScheduledOutage): string => {
+  if ((o.interface ?? []).some(i => i.address === 'match-any')) {
+    return 'All nodes and interfaces'
+  }
+  const nodes = (o.node ?? []).length
+  const ifaces = (o.interface ?? []).length
+  if (!nodes && !ifaces) {
+    return '--'
+  }
+  return `${nodes} node(s), ${ifaces} interface(s)`
+}
+
+const createOutage = () => {
+  const name = newName.value.trim()
+  createError.value = ''
+  if (!name) {
+    return
+  }
+  if (outages.value.some(o => o.name === name)) {
+    createError.value = `An outage named "${name}" already exists.`
+    return
+  }
+  router.push({ path: '/scheduled-outages/edit', query: { name, new: 'true' }})
+}
+
+const editOutage = (name: string) => {
+  router.push({ path: '/scheduled-outages/edit', query: { name }})
+}
+
+const askDelete = (name: string) => {
+  outageToDelete.value = name
+}
+
+const confirmDelete = async () => {
+  const name = outageToDelete.value
+  outageToDelete.value = ''
+  try {
+    await deleteScheduledOutage(name)
+  } finally {
+    await load()
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.scheduled-outages {
+  .header {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .card-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+  }
+
+  .header-actions {
+    display: flex;
+    align-items: flex-end;
+    gap: 0.75rem;
+  }
+
+  .create-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .action-container {
+    display: flex;
+    gap: 0.25rem;
+  }
+
+  .error {
+    color: var(--p-red-500, #d32f2f);
+  }
+
+  :deep(.mark.on) {
+    color: var(--p-green-500, #388e3c);
+    font-weight: 700;
+  }
+
+  :deep(.mark.off) {
+    color: var(--p-text-muted-color);
+  }
+}
+</style>

--- a/ui/src/containers/ScheduledOutages.vue
+++ b/ui/src/containers/ScheduledOutages.vue
@@ -29,6 +29,7 @@
       </div>
 
       <p v-if="createError" class="error" data-test="create-error">{{ createError }}</p>
+      <p v-if="loadError" class="error" data-test="load-error">{{ loadError }}</p>
 
       <OnmsTable
         v-if="outages.length"
@@ -123,7 +124,8 @@ import ScheduledOutagesAbout from '@/components/ScheduledOutages/ScheduledOutage
 import {
   deleteScheduledOutage,
   getOutageApplicability,
-  getScheduledOutages
+  getScheduledOutages,
+  scheduledOutageErrorMessage
 } from '@/services/scheduledOutagesService'
 import { ScheduledOutage } from '@/types/scheduledOutage'
 import { BreadCrumb } from '@/types'
@@ -147,6 +149,7 @@ const outages = ref<OutageRow[]>([])
 const loading = ref(true)
 const newName = ref('')
 const createError = ref('')
+const loadError = ref('')
 const outageToDelete = ref('')
 
 const emptyContent = computed(() => ({
@@ -156,8 +159,15 @@ const emptyContent = computed(() => ({
 
 const load = async () => {
   loading.value = true
+  loadError.value = ''
   const list = await getScheduledOutages()
-  const rows: OutageRow[] = (list ?? []).map(o => ({ ...o }))
+  // null signals a fetch failure — keep the rows already on screen (service contract)
+  if (list === null) {
+    loadError.value = 'Failed to load scheduled outages. Showing the last known list.'
+    loading.value = false
+    return
+  }
+  const rows: OutageRow[] = list.map(o => ({ ...o }))
   // membership booleans come from the per-outage applies-to summary
   await Promise.all(rows.map(async (row) => {
     const appl = await getOutageApplicability(row.name)
@@ -210,8 +220,11 @@ const askDelete = (name: string) => {
 const confirmDelete = async () => {
   const name = outageToDelete.value
   outageToDelete.value = ''
+  loadError.value = ''
   try {
     await deleteScheduledOutage(name)
+  } catch (err: any) {
+    loadError.value = scheduledOutageErrorMessage(err, `Failed to delete the scheduled outage "${name}".`)
   } finally {
     await load()
   }

--- a/ui/src/containers/ScheduledOutages.vue
+++ b/ui/src/containers/ScheduledOutages.vue
@@ -26,6 +26,7 @@
       </div>
 
       <p v-if="loadError" class="error" data-test="load-error">{{ loadError }}</p>
+      <p v-if="actionError" class="error" data-test="action-error">{{ actionError }}</p>
 
       <OnmsTable
         v-if="outages.length"
@@ -179,6 +180,8 @@ const loading = ref(true)
 const newName = ref('')
 const createError = ref('')
 const loadError = ref('')
+// kept separate from loadError, which the post-action reload resets
+const actionError = ref('')
 const outageToDelete = ref('')
 
 const emptyContent = computed(() => ({
@@ -278,11 +281,11 @@ const askDelete = (name: string) => {
 const confirmDelete = async () => {
   const name = outageToDelete.value
   outageToDelete.value = ''
-  loadError.value = ''
+  actionError.value = ''
   try {
     await deleteScheduledOutage(name)
   } catch (err: any) {
-    loadError.value = scheduledOutageErrorMessage(err, `Failed to delete the scheduled outage "${name}".`)
+    actionError.value = scheduledOutageErrorMessage(err, `Failed to delete the scheduled outage "${name}".`)
   } finally {
     await load()
   }

--- a/ui/src/main/router/index.ts
+++ b/ui/src/main/router/index.ts
@@ -178,6 +178,44 @@ const router = createRouter({
       }
     },
     {
+      path: '/scheduled-outages',
+      name: 'Scheduled Outages',
+      component: () => import('@/containers/ScheduledOutages.vue'),
+      beforeEnter: (to, from) => {
+        const checkRoles = () => {
+          if (!adminRole.value) {
+            showSnackBar({ msg: 'Must be admin to manage scheduled outages.' })
+            router.push(from.path)
+          }
+        }
+
+        if (rolesAreLoaded.value) {
+          checkRoles()
+        } else {
+          whenever(rolesAreLoaded, () => checkRoles())
+        }
+      }
+    },
+    {
+      path: '/scheduled-outages/edit',
+      name: 'Edit Scheduled Outage',
+      component: () => import('@/containers/ScheduledOutageEditor.vue'),
+      beforeEnter: (to, from) => {
+        const checkRoles = () => {
+          if (!adminRole.value) {
+            showSnackBar({ msg: 'Must be admin to manage scheduled outages.' })
+            router.push(from.path)
+          }
+        }
+
+        if (rolesAreLoaded.value) {
+          checkRoles()
+        } else {
+          whenever(rolesAreLoaded, () => checkRoles())
+        }
+      }
+    },
+    {
       path: '/map',
       name: 'Map',
       component: () => import('@/containers/Map.vue'),

--- a/ui/src/services/scheduledOutagesService.ts
+++ b/ui/src/services/scheduledOutagesService.ts
@@ -144,12 +144,24 @@ export const isCompleteIpAddress = (s: string): boolean => {
   return s.includes(':') && s.length >= 3 && /^[0-9a-fA-F:]+$/.test(s)
 }
 
-// IP interface autocomplete for the interface picker. The v2 API has no
-// substring search on ipAddress (it is IP_ADDRESS-typed, so wildcards 500) and
-// no ipLike param; ipHostName does accept wildcards and holds the address text
-// whenever DNS did not resolve. A complete IP queries ipAddress exactly and is
-// always offered as a suggestion itself, since poll-outages accepts any valid
-// address whether or not it is in inventory.
+// A partial dotted IPv4 (192, 192.168., 192.168.1) as the iplike pattern that
+// matches every address under it; null for anything else.
+export const ipv4PrefixPattern = (term: string): string | null => {
+  if (!/^\d{1,3}(\.\d{1,3}){0,2}\.?$/.test(term)) {
+    return null
+  }
+  const octets = term.split('.').filter(o => o !== '')
+  if (octets.some(o => Number(o) > 255)) {
+    return null
+  }
+  return [...octets, ...Array(4 - octets.length).fill('*')].join('.')
+}
+
+// IP interface autocomplete for the interface picker. A complete IP queries
+// ipAddress exactly and is always offered as a suggestion itself, since
+// poll-outages accepts any valid address whether or not it is in inventory.
+// A partial IPv4 also searches ipAddress as an iplike pattern, because
+// ipHostName holds the hostname wherever reverse DNS resolved.
 export const searchOutageInterfaces = async (query: string): Promise<{ address: string, nodeLabel: string }[]> => {
   const term = sanitizeSearchTerm(query)
   const isExactIp = isCompleteIpAddress(term)
@@ -159,7 +171,9 @@ export const searchOutageInterfaces = async (query: string): Promise<{ address: 
     // makes this case-insensitive in practice
     const hostFilters = [...new Set([term.toLowerCase(), term])]
       .map(t => `ipHostName==*${t}*`).join(',')
-    const filter = term ? (isExactIp ? `&_s=ipAddress==${term}` : `&_s=${hostFilters}`) : ''
+    const prefix = isExactIp ? null : ipv4PrefixPattern(term)
+    const partialFilters = prefix ? `ipAddress==${prefix},${hostFilters}` : hostFilters
+    const filter = term ? (isExactIp ? `&_s=ipAddress==${term}` : `&_s=${partialFilters}`) : ''
     const resp = await v2.get(`/ipinterfaces?limit=200${filter}`)
     const found = asArray<any>(resp.data?.ipInterface)
       .map(i => ({ address: i.ipAddress as string, nodeLabel: i.nodeLabel ?? '' }))

--- a/ui/src/services/scheduledOutagesService.ts
+++ b/ui/src/services/scheduledOutagesService.ts
@@ -1,0 +1,144 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { OutageApplicability, PackageRef, ScheduledOutage } from '@/types/scheduledOutage'
+import { rest, v2 } from './axiosInstances'
+
+const endpoint = '/sched-outages'
+
+// v1/JAXB JSON collapses a single-element list to one object; normalize to []
+export const asArray = <T>(value: T | T[] | undefined | null): T[] => {
+  if (value == null) {
+    return []
+  }
+  return Array.isArray(value) ? value : [value]
+}
+
+export const scheduledOutageErrorMessage = (err: any, fallback: string): string => {
+  const detail = err?.response?.data
+  return typeof detail === 'string' && detail ? detail : fallback
+}
+
+const seg = (value: string): string => encodeURIComponent(value)
+
+// null (not []) on failure so the list page can keep the previous rows
+export const getScheduledOutages = async (): Promise<ScheduledOutage[] | null> => {
+  try {
+    const resp = await rest.get(endpoint)
+    return asArray<ScheduledOutage>(resp.data?.outage).map(normalizeOutage)
+  } catch (_err) {
+    return null
+  }
+}
+
+export const getScheduledOutage = async (name: string): Promise<ScheduledOutage | null> => {
+  try {
+    const resp = await rest.get(`${endpoint}/${seg(name)}`)
+    return normalizeOutage(resp.data)
+  } catch (_err) {
+    return null
+  }
+}
+
+// POST adds a new outage or updates an existing one (matched by name).
+export const saveScheduledOutage = async (outage: ScheduledOutage): Promise<void> => {
+  await rest.post(endpoint, outage)
+}
+
+export const deleteScheduledOutage = async (name: string): Promise<void> => {
+  await rest.delete(`${endpoint}/${seg(name)}`)
+}
+
+export const getOutageApplicability = async (name?: string): Promise<OutageApplicability | null> => {
+  try {
+    const path = name ? `${endpoint}/${seg(name)}/applies-to` : `${endpoint}/applies-to`
+    const resp = await rest.get(path)
+    return {
+      notifications: !!resp.data?.notifications,
+      pollers: asArray<PackageRef>(resp.data?.pollers),
+      collectors: asArray<PackageRef>(resp.data?.collectors),
+      thresholders: asArray<PackageRef>(resp.data?.thresholders)
+    }
+  } catch (_err) {
+    return null
+  }
+}
+
+type Subsystem = 'pollerd' | 'collectd' | 'threshd'
+
+export const setPackageMembership = async (
+  subsystem: Subsystem,
+  outageName: string,
+  packageName: string,
+  applied: boolean
+): Promise<void> => {
+  const path = `${endpoint}/${seg(outageName)}/${subsystem}/${seg(packageName)}`
+  if (applied) {
+    await rest.put(path)
+  } else {
+    await rest.delete(path)
+  }
+}
+
+export const setNotificationMembership = async (outageName: string, applied: boolean): Promise<void> => {
+  const path = `${endpoint}/${seg(outageName)}/notifd`
+  if (applied) {
+    await rest.put(path)
+  } else {
+    await rest.delete(path)
+  }
+}
+
+// Node label autocomplete for the node picker (id + label).
+export const searchOutageNodes = async (query: string): Promise<{ id: number, label: string }[]> => {
+  try {
+    const filter = query ? `&_s=node.label==*${query}*` : ''
+    const resp = await v2.get(`/nodes?limit=200${filter}`)
+    return asArray<any>(resp.data?.node)
+      .map(n => ({ id: Number(n.id), label: n.label as string }))
+      .filter(n => !Number.isNaN(n.id))
+  } catch (_err) {
+    return []
+  }
+}
+
+// IP interface autocomplete for the interface picker.
+export const searchOutageInterfaces = async (query: string): Promise<{ address: string, nodeLabel: string }[]> => {
+  try {
+    const filter = query ? `&_s=ipInterface.ipAddress==*${query}*` : ''
+    const resp = await v2.get(`/ipinterfaces?limit=200${filter}`)
+    return asArray<any>(resp.data?.ipInterface)
+      .map(i => ({ address: i.ipAddress as string, nodeLabel: i.nodeLabel ?? '' }))
+      .filter(i => !!i.address)
+  } catch (_err) {
+    return []
+  }
+}
+
+// The v1 payload may arrive with single-element lists collapsed to objects.
+const normalizeOutage = (raw: any): ScheduledOutage => ({
+  name: raw?.name,
+  type: raw?.type,
+  time: asArray(raw?.time),
+  node: asArray(raw?.node),
+  interface: asArray(raw?.interface)
+})

--- a/ui/src/services/scheduledOutagesService.ts
+++ b/ui/src/services/scheduledOutagesService.ts
@@ -40,6 +40,11 @@ export const scheduledOutageErrorMessage = (err: any, fallback: string): string 
 
 const seg = (value: string): string => encodeURIComponent(value)
 
+// Strip FIQL/URL metacharacters so a typed query can't break out of the
+// `node.label==*<term>*` filter or inject extra query params. Node labels and
+// IP addresses only contain these characters anyway.
+const sanitizeSearchTerm = (query: string): string => query.replace(/[^a-zA-Z0-9._:-]/g, '')
+
 // null (not []) on failure so the list page can keep the previous rows
 export const getScheduledOutages = async (): Promise<ScheduledOutage[] | null> => {
   try {
@@ -111,7 +116,8 @@ export const setNotificationMembership = async (outageName: string, applied: boo
 // Node label autocomplete for the node picker (id + label).
 export const searchOutageNodes = async (query: string): Promise<{ id: number, label: string }[]> => {
   try {
-    const filter = query ? `&_s=node.label==*${query}*` : ''
+    const term = sanitizeSearchTerm(query)
+    const filter = term ? `&_s=node.label==*${term}*` : ''
     const resp = await v2.get(`/nodes?limit=200${filter}`)
     return asArray<any>(resp.data?.node)
       .map(n => ({ id: Number(n.id), label: n.label as string }))
@@ -124,7 +130,8 @@ export const searchOutageNodes = async (query: string): Promise<{ id: number, la
 // IP interface autocomplete for the interface picker.
 export const searchOutageInterfaces = async (query: string): Promise<{ address: string, nodeLabel: string }[]> => {
   try {
-    const filter = query ? `&_s=ipInterface.ipAddress==*${query}*` : ''
+    const term = sanitizeSearchTerm(query)
+    const filter = term ? `&_s=ipInterface.ipAddress==*${term}*` : ''
     const resp = await v2.get(`/ipinterfaces?limit=200${filter}`)
     return asArray<any>(resp.data?.ipInterface)
       .map(i => ({ address: i.ipAddress as string, nodeLabel: i.nodeLabel ?? '' }))

--- a/ui/src/services/scheduledOutagesService.ts
+++ b/ui/src/services/scheduledOutagesService.ts
@@ -120,12 +120,14 @@ export const setNotificationMembership = async (outageName: string, applied: boo
   }
 }
 
-// Node label autocomplete for the node picker (id + label).
+// Node label autocomplete for the node picker (id + label). The v1 endpoint is
+// used because its ilike comparator gives a case-insensitive substring match,
+// which v2 FIQL wildcards (case-sensitive LIKE) cannot express.
 export const searchOutageNodes = async (query: string): Promise<{ id: number, label: string }[]> => {
   try {
     const term = sanitizeSearchTerm(query)
-    const filter = term ? `&_s=node.label==*${term}*` : ''
-    const resp = await v2.get(`/nodes?limit=200${filter}`)
+    const filter = term ? `&comparator=ilike&label=${encodeURIComponent(`%${term}%`)}` : ''
+    const resp = await rest.get(`/nodes?limit=200${filter}`)
     return asArray<any>(resp.data?.node)
       .map(n => ({ id: Number(n.id), label: n.label as string }))
       .filter(n => !Number.isNaN(n.id))
@@ -152,7 +154,12 @@ export const searchOutageInterfaces = async (query: string): Promise<{ address: 
   const term = sanitizeSearchTerm(query)
   const isExactIp = isCompleteIpAddress(term)
   try {
-    const filter = term ? (isExactIp ? `&_s=ipAddress==${term}` : `&_s=ipHostName==*${term}*`) : ''
+    // there is no v1 ipinterfaces endpoint (no ilike), so hostname matching
+    // ORs the raw and lowercased term — DNS names are stored lowercase, which
+    // makes this case-insensitive in practice
+    const hostFilters = [...new Set([term.toLowerCase(), term])]
+      .map(t => `ipHostName==*${t}*`).join(',')
+    const filter = term ? (isExactIp ? `&_s=ipAddress==${term}` : `&_s=${hostFilters}`) : ''
     const resp = await v2.get(`/ipinterfaces?limit=200${filter}`)
     const found = asArray<any>(resp.data?.ipInterface)
       .map(i => ({ address: i.ipAddress as string, nodeLabel: i.nodeLabel ?? '' }))

--- a/ui/src/services/scheduledOutagesService.ts
+++ b/ui/src/services/scheduledOutagesService.ts
@@ -77,11 +77,18 @@ export const getOutageApplicability = async (name?: string): Promise<OutageAppli
   try {
     const path = name ? `${endpoint}/${seg(name)}/applies-to` : `${endpoint}/applies-to`
     const resp = await rest.get(path)
+    const packages = (value: unknown): PackageRef[] =>
+      asArray<any>(value).map(p => ({
+        name: p?.name,
+        applied: !!p?.applied,
+        calendars: asArray<string>(p?.calendars)
+      }))
     return {
       notifications: !!resp.data?.notifications,
-      pollers: asArray<PackageRef>(resp.data?.pollers),
-      collectors: asArray<PackageRef>(resp.data?.collectors),
-      thresholders: asArray<PackageRef>(resp.data?.thresholders)
+      notificationCalendars: asArray<string>(resp.data?.['notification-calendars']),
+      pollers: packages(resp.data?.pollers),
+      collectors: packages(resp.data?.collectors),
+      thresholders: packages(resp.data?.thresholders)
     }
   } catch (_err) {
     return null
@@ -127,17 +134,53 @@ export const searchOutageNodes = async (query: string): Promise<{ id: number, la
   }
 }
 
-// IP interface autocomplete for the interface picker.
+// A complete IPv4 or IPv6 address, i.e. something ipAddress== can match exactly.
+export const isCompleteIpAddress = (s: string): boolean => {
+  if (/^(\d{1,3}\.){3}\d{1,3}$/.test(s)) {
+    return s.split('.').every(octet => Number(octet) <= 255)
+  }
+  return s.includes(':') && s.length >= 3 && /^[0-9a-fA-F:]+$/.test(s)
+}
+
+// IP interface autocomplete for the interface picker. The v2 API has no
+// substring search on ipAddress (it is IP_ADDRESS-typed, so wildcards 500) and
+// no ipLike param; ipHostName does accept wildcards and holds the address text
+// whenever DNS did not resolve. A complete IP queries ipAddress exactly and is
+// always offered as a suggestion itself, since poll-outages accepts any valid
+// address whether or not it is in inventory.
 export const searchOutageInterfaces = async (query: string): Promise<{ address: string, nodeLabel: string }[]> => {
+  const term = sanitizeSearchTerm(query)
+  const isExactIp = isCompleteIpAddress(term)
   try {
-    const term = sanitizeSearchTerm(query)
-    const filter = term ? `&_s=ipInterface.ipAddress==*${term}*` : ''
+    const filter = term ? (isExactIp ? `&_s=ipAddress==${term}` : `&_s=ipHostName==*${term}*`) : ''
     const resp = await v2.get(`/ipinterfaces?limit=200${filter}`)
-    return asArray<any>(resp.data?.ipInterface)
+    const found = asArray<any>(resp.data?.ipInterface)
       .map(i => ({ address: i.ipAddress as string, nodeLabel: i.nodeLabel ?? '' }))
       .filter(i => !!i.address)
+    if (isExactIp && !found.some(i => i.address === term)) {
+      found.unshift({ address: term, nodeLabel: '' })
+    }
+    return found
   } catch (_err) {
-    return []
+    return isExactIp ? [{ address: term, nodeLabel: '' }] : []
+  }
+}
+
+// Resolve node labels for the ids referenced by outages (single OR query).
+export const getNodeLabels = async (ids: number[]): Promise<Record<number, string>> => {
+  if (!ids.length) {
+    return {}
+  }
+  try {
+    const filter = ids.map(id => `id==${id}`).join(',')
+    const resp = await v2.get(`/nodes?limit=${ids.length}&_s=${filter}`)
+    const labels: Record<number, string> = {}
+    for (const n of asArray<any>(resp.data?.node)) {
+      labels[Number(n.id)] = n.label
+    }
+    return labels
+  } catch (_err) {
+    return {}
   }
 }
 

--- a/ui/src/types/scheduledOutage.ts
+++ b/ui/src/types/scheduledOutage.ts
@@ -56,11 +56,15 @@ export interface ScheduledOutage {
 export interface PackageRef {
   name: string
   applied: boolean
+  // every outage-calendar name the package references; lets the list page
+  // compute per-outage membership from a single name-less applies-to call
+  calendars: string[]
 }
 
 // GET /sched-outages/{name}/applies-to (or /applies-to for a new outage)
 export interface OutageApplicability {
   notifications: boolean
+  notificationCalendars: string[]
   pollers: PackageRef[]
   collectors: PackageRef[]
   thresholders: PackageRef[]

--- a/ui/src/types/scheduledOutage.ts
+++ b/ui/src/types/scheduledOutage.ts
@@ -1,0 +1,67 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+// Mirrors org.opennms.netmgt.config.poller.outages.* (poll-outages.xml). The
+// v1 REST serializes each JAXB list under its element name (time/node/
+// interface/outage) and may collapse a single-element list to one object, so
+// callers normalize with asArray() from scheduledOutagesService.
+
+export type OutageType = 'specific' | 'daily' | 'weekly' | 'monthly'
+
+export interface OutageTime {
+  id?: string
+  // weekday name (weekly) or day-of-month 1-31 (monthly); absent otherwise
+  day?: string
+  // 'dd-MMM-yyyy HH:mm:ss' for specific, 'HH:mm:ss' for daily/weekly/monthly
+  begins: string
+  ends: string
+}
+
+export interface OutageNode {
+  id: number
+}
+
+export interface OutageInterface {
+  // a valid IP address, or the literal 'match-any' (all nodes/interfaces)
+  address: string
+}
+
+export interface ScheduledOutage {
+  name: string
+  type?: OutageType
+  time?: OutageTime[]
+  node?: OutageNode[]
+  interface?: OutageInterface[]
+}
+
+export interface PackageRef {
+  name: string
+  applied: boolean
+}
+
+// GET /sched-outages/{name}/applies-to (or /applies-to for a new outage)
+export interface OutageApplicability {
+  notifications: boolean
+  pollers: PackageRef[]
+  collectors: PackageRef[]
+  thresholders: PackageRef[]
+}

--- a/ui/tests/components/ScheduledOutages/AppliesToMatrix.test.ts
+++ b/ui/tests/components/ScheduledOutages/AppliesToMatrix.test.ts
@@ -1,0 +1,59 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import AppliesToMatrix from '@/components/ScheduledOutages/AppliesToMatrix.vue'
+import { mount } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import { describe, expect, it } from 'vitest'
+
+const PROPS = {
+  notifications: false,
+  pollers: [{ name: 'example1', applied: false, calendars: [] }],
+  thresholders: [{ name: 'mib2', applied: true, calendars: [] }],
+  collectors: []
+}
+
+const mountMatrix = () => mount(AppliesToMatrix, {
+  props: PROPS,
+  global: { plugins: [PrimeVue] }
+})
+
+describe('AppliesToMatrix.vue', () => {
+  it('emits togglePackage with the subsystem and package name', async () => {
+    const wrapper = mountMatrix()
+    await wrapper.find('[data-test="applies-pollerd"] input').setValue(true)
+    expect(wrapper.emitted('togglePackage')).toEqual([['pollerd', 'example1', true]])
+  })
+
+  it('emits setAll per subsystem from the bulk links', async () => {
+    const wrapper = mountMatrix()
+    await wrapper.findAll('[data-test="select-all"]')[0].trigger('click')
+    await wrapper.findAll('[data-test="unselect-all"]')[2].trigger('click')
+    expect(wrapper.emitted('setAll')).toEqual([['pollerd', true], ['collectd', false]])
+  })
+
+  it('emits update:notifications from the notifications checkbox', async () => {
+    const wrapper = mountMatrix()
+    await wrapper.find('[data-test="applies-notifications"] input').setValue(true)
+    expect(wrapper.emitted('update:notifications')).toEqual([[true]])
+  })
+})

--- a/ui/tests/components/ScheduledOutages/NodeInterfacePicker.test.ts
+++ b/ui/tests/components/ScheduledOutages/NodeInterfacePicker.test.ts
@@ -46,19 +46,31 @@ describe('NodeInterfacePicker.vue', () => {
       items: [{ id: 5 }, { id: 99 }],
       nodeLabels: { 5: 'core-router' }
     })
-    const chips = wrapper.findAll('.chip').map(c => c.text())
+    const chips = wrapper.findAll('[data-test="picker-node-chip"]').map(c => c.text())
     expect(chips[0]).toContain('core-router (id 5)')
     expect(chips[1]).toContain('Node id 99 (not found)')
   })
 
   it('shows interface addresses as-is', () => {
     const wrapper = mountPicker({ mode: 'interface', items: [{ address: '10.0.0.1' }] })
-    expect(wrapper.find('.chip').text()).toContain('10.0.0.1')
+    expect(wrapper.find('[data-test="picker-interface-chip"]').text()).toContain('10.0.0.1')
   })
 
   it('emits remove with the item index', async () => {
     const wrapper = mountPicker({ mode: 'interface', items: [{ address: '10.0.0.1' }, { address: '10.0.0.2' }] })
-    await wrapper.findAll('[data-test="picker-interface-remove"]')[1].trigger('click')
+    await wrapper.findAll('[data-test="picker-interface-chip"] .p-chip-remove-icon')[1].trigger('click')
     expect(wrapper.emitted('remove')).toEqual([[1]])
+  })
+
+  it('renders friendly all-selected chips for match-any', () => {
+    // the wire value is the match-any pseudo-interface; users see All Nodes /
+    // All Interfaces instead of the internal token
+    const nodeSide = mountPicker({ mode: 'node', items: [], matchAny: true })
+    expect(nodeSide.find('[data-test="picker-node-all"]').text()).toContain('All Nodes')
+    expect(nodeSide.find('[data-test="picker-node-empty"]').exists()).toBe(false)
+
+    const ifaceSide = mountPicker({ mode: 'interface', items: [{ address: 'match-any' }], matchAny: true })
+    expect(ifaceSide.find('[data-test="picker-interface-chip"]').text()).toContain('All Interfaces')
+    expect(ifaceSide.text()).not.toContain('match-any')
   })
 })

--- a/ui/tests/components/ScheduledOutages/NodeInterfacePicker.test.ts
+++ b/ui/tests/components/ScheduledOutages/NodeInterfacePicker.test.ts
@@ -1,0 +1,64 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import NodeInterfacePicker from '@/components/ScheduledOutages/NodeInterfacePicker.vue'
+import { mount } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/services/scheduledOutagesService', () => ({
+  searchOutageNodes: vi.fn().mockResolvedValue([]),
+  searchOutageInterfaces: vi.fn().mockResolvedValue([])
+}))
+
+const mountPicker = (props: any) => mount(NodeInterfacePicker, {
+  props,
+  global: { plugins: [PrimeVue] }
+})
+
+describe('NodeInterfacePicker.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows resolved node labels and flags ids no longer in inventory', () => {
+    const wrapper = mountPicker({
+      mode: 'node',
+      items: [{ id: 5 }, { id: 99 }],
+      nodeLabels: { 5: 'core-router' }
+    })
+    const chips = wrapper.findAll('.chip').map(c => c.text())
+    expect(chips[0]).toContain('core-router (id 5)')
+    expect(chips[1]).toContain('Node id 99 (not found)')
+  })
+
+  it('shows interface addresses as-is', () => {
+    const wrapper = mountPicker({ mode: 'interface', items: [{ address: '10.0.0.1' }] })
+    expect(wrapper.find('.chip').text()).toContain('10.0.0.1')
+  })
+
+  it('emits remove with the item index', async () => {
+    const wrapper = mountPicker({ mode: 'interface', items: [{ address: '10.0.0.1' }, { address: '10.0.0.2' }] })
+    await wrapper.findAll('[data-test="picker-interface-remove"]')[1].trigger('click')
+    expect(wrapper.emitted('remove')).toEqual([[1]])
+  })
+})

--- a/ui/tests/components/ScheduledOutages/TimeSpanEditor.test.ts
+++ b/ui/tests/components/ScheduledOutages/TimeSpanEditor.test.ts
@@ -1,0 +1,61 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import TimeSpanEditor from '@/components/ScheduledOutages/TimeSpanEditor.vue'
+import { mount } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import { describe, expect, it } from 'vitest'
+
+const mountEditor = (props: any) => mount(TimeSpanEditor, {
+  props,
+  global: { plugins: [PrimeVue] }
+})
+
+describe('TimeSpanEditor.vue', () => {
+  // The Java parser keys on exact string length (20 for specific), so the add
+  // event must carry a padded date even for the default (day 01) selection.
+  it('emits a 20-char begins/ends for a specific span from the default fields', async () => {
+    const wrapper = mountEditor({ type: 'specific', times: [] })
+    await wrapper.find('[data-test="add-time"]').trigger('click')
+
+    const [time] = wrapper.emitted('add')![0] as any[]
+    expect(time.begins.length).toBe(20)
+    expect(time.ends.length).toBe(20)
+    expect(time.day).toBeUndefined()
+  })
+
+  it('emits an 8-char span with the weekday for a weekly outage', async () => {
+    const wrapper = mountEditor({ type: 'weekly', times: [] })
+    await wrapper.find('[data-test="add-time"]').trigger('click')
+
+    const [time] = wrapper.emitted('add')![0] as any[]
+    expect(time.begins.length).toBe(8)
+    expect(time.day).toBe('sunday')
+  })
+
+  it('lists existing spans with a remove control', async () => {
+    const wrapper = mountEditor({ type: 'daily', times: [{ begins: '01:00:00', ends: '02:00:00' }] })
+    expect(wrapper.find('[data-test="time-row"]').text()).toContain('01:00:00')
+    await wrapper.find('[data-test="remove-time"]').trigger('click')
+    expect(wrapper.emitted('remove')).toEqual([[0]])
+  })
+})

--- a/ui/tests/components/ScheduledOutages/outageTime.test.ts
+++ b/ui/tests/components/ScheduledOutages/outageTime.test.ts
@@ -1,0 +1,73 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { describe, expect, it } from 'vitest'
+import { buildOutageTime, defaultTimeSpanFields } from '@/components/ScheduledOutages/outageTime'
+
+// BasicScheduleUtils selects the parser by the exact string length: 20 for the
+// 'dd-MMM-yyyy HH:mm:ss' (specific) format, 8 for 'HH:mm:ss' (recurring).
+describe('buildOutageTime', () => {
+  const base = () => ({
+    ...defaultTimeSpanFields(2026),
+    startDay: '05',
+    startMonth: 'Aug',
+    startYear: '2026',
+    startHour: '01',
+    startMinute: '02',
+    startSecond: '03',
+    endDay: '06',
+    endMonth: 'Sep',
+    endYear: '2026',
+    endHour: '23',
+    endMinute: '59',
+    endSecond: '59',
+    day: 'wednesday'
+  })
+
+  it('formats a specific span as dd-MMM-yyyy HH:mm:ss (length 20, no day)', () => {
+    const t = buildOutageTime('specific', base())
+    expect(t.begins).toBe('05-Aug-2026 01:02:03')
+    expect(t.ends).toBe('06-Sep-2026 23:59:59')
+    expect(t.begins.length).toBe(20)
+    expect(t.day).toBeUndefined()
+  })
+
+  it('formats a daily span as HH:mm:ss (length 8, no day)', () => {
+    const t = buildOutageTime('daily', base())
+    expect(t.begins).toBe('01:02:03')
+    expect(t.ends).toBe('23:59:59')
+    expect(t.begins.length).toBe(8)
+    expect(t.day).toBeUndefined()
+  })
+
+  it('carries the weekday name for a weekly span', () => {
+    const t = buildOutageTime('weekly', base())
+    expect(t.begins).toBe('01:02:03')
+    expect(t.day).toBe('wednesday')
+  })
+
+  it('carries the day-of-month for a monthly span', () => {
+    const t = buildOutageTime('monthly', { ...base(), day: '15' })
+    expect(t.begins).toBe('01:02:03')
+    expect(t.day).toBe('15')
+  })
+})

--- a/ui/tests/components/ScheduledOutages/outageTime.test.ts
+++ b/ui/tests/components/ScheduledOutages/outageTime.test.ts
@@ -21,7 +21,12 @@
 ///
 
 import { describe, expect, it } from 'vitest'
-import { buildOutageTime, defaultTimeSpanFields } from '@/components/ScheduledOutages/outageTime'
+import {
+  DAYS_OF_MONTH,
+  DAYS_OF_MONTH_PADDED,
+  buildOutageTime,
+  defaultTimeSpanFields
+} from '@/components/ScheduledOutages/outageTime'
 
 // BasicScheduleUtils selects the parser by the exact string length: 20 for the
 // 'dd-MMM-yyyy HH:mm:ss' (specific) format, 8 for 'HH:mm:ss' (recurring).
@@ -69,5 +74,24 @@ describe('buildOutageTime', () => {
     const t = buildOutageTime('monthly', { ...base(), day: '15' })
     expect(t.begins).toBe('01:02:03')
     expect(t.day).toBe('15')
+  })
+
+  // Regression: the specific-date day dropdown must feed PADDED day values, or a
+  // single-digit day yields a 19-char string the length-keyed Java parser misreads.
+  it('keeps a specific span at 20 chars for the default (day 01) selection', () => {
+    const t = buildOutageTime('specific', defaultTimeSpanFields(2026))
+    expect(t.begins.length).toBe(20)
+    expect(t.ends.length).toBe(20)
+  })
+
+  it('exposes padded 01..31 day-of-month values for the specific-date field', () => {
+    expect(DAYS_OF_MONTH_PADDED[0].value).toBe('01')
+    expect(DAYS_OF_MONTH_PADDED[8].value).toBe('09')
+    expect(DAYS_OF_MONTH_PADDED.every(o => o.value.length === 2)).toBe(true)
+  })
+
+  it('keeps unpadded 1..31 day-of-month values for the monthly attribute', () => {
+    expect(DAYS_OF_MONTH[0].value).toBe('1')
+    expect(DAYS_OF_MONTH[8].value).toBe('9')
   })
 })

--- a/ui/tests/containers/ScheduledOutageEditor.test.ts
+++ b/ui/tests/containers/ScheduledOutageEditor.test.ts
@@ -91,6 +91,24 @@ describe('ScheduledOutageEditor.vue', () => {
     expect(wrapper.find('[data-test="save"]').exists()).toBe(true)
   })
 
+  it('adding a node ends "all nodes and interfaces"', async () => {
+    // with match-any active the added node would be hidden by the pickers and
+    // still be saved next to match-any; the legacy editor stripped it
+    vi.mocked(getScheduledOutage).mockResolvedValue({
+      name: 'nightly', type: 'daily', time: [], node: [], interface: [{ address: 'match-any' }]
+    } as any)
+    const wrapper = await mountPage()
+    const [nodePicker, ifacePicker] = wrapper.findAllComponents({ name: 'NodeInterfacePicker' })
+    expect(ifacePicker.props('matchAny')).toBe(true)
+
+    nodePicker.vm.$emit('add', { id: 7 }, 'core-router')
+    await flushPromises()
+
+    expect(nodePicker.props('items')).toEqual([{ id: 7 }])
+    expect(ifacePicker.props('items')).toEqual([])
+    expect(ifacePicker.props('matchAny')).toBe(false)
+  })
+
   it('treats new=true as a blank form without a load guard', async () => {
     query = { name: 'brand-new', new: 'true' }
     const wrapper = await mountPage()

--- a/ui/tests/containers/ScheduledOutageEditor.test.ts
+++ b/ui/tests/containers/ScheduledOutageEditor.test.ts
@@ -1,0 +1,107 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import ScheduledOutageEditor from '@/containers/ScheduledOutageEditor.vue'
+import { flushPromises, mount } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getOutageApplicability, getScheduledOutage, saveScheduledOutage } from '@/services/scheduledOutagesService'
+
+const push = vi.fn()
+const replace = vi.fn()
+let query: Record<string, string> = {}
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push, replace }),
+  useRoute: () => ({ query, fullPath: '/scheduled-outages/edit' })
+}))
+
+vi.mock('@/services/scheduledOutagesService', () => ({
+  getScheduledOutage: vi.fn(),
+  getOutageApplicability: vi.fn(),
+  getNodeLabels: vi.fn().mockResolvedValue({}),
+  saveScheduledOutage: vi.fn(),
+  setPackageMembership: vi.fn(),
+  setNotificationMembership: vi.fn(),
+  scheduledOutageErrorMessage: (_err: any, fallback: string) => fallback
+}))
+
+const EMPTY_APPLIES = { notifications: false, notificationCalendars: [], pollers: [], thresholders: [], collectors: [] }
+
+const mountPage = async () => {
+  const wrapper = mount(ScheduledOutageEditor, {
+    global: {
+      plugins: [PrimeVue],
+      stubs: {
+        BreadCrumbs: true,
+        NodeInterfacePicker: true,
+        TimeSpanEditor: true,
+        AppliesToMatrix: true
+      }
+    }
+  })
+  await flushPromises()
+  return wrapper
+}
+
+describe('ScheduledOutageEditor.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    query = { name: 'nightly' }
+    vi.mocked(getOutageApplicability).mockResolvedValue(EMPTY_APPLIES as any)
+  })
+
+  it('blocks editing when an existing outage fails to load', async () => {
+    // a transient read failure must not present an empty form whose Save would
+    // whole-object-replace (and so wipe) the real outage
+    vi.mocked(getScheduledOutage).mockResolvedValue(null)
+    const wrapper = await mountPage()
+
+    expect(wrapper.find('[data-test="editor-load-failed"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="editor-error"]').text()).toContain('Editing is disabled')
+    expect(wrapper.find('[data-test="save"]').exists()).toBe(false)
+    expect(saveScheduledOutage).not.toHaveBeenCalled()
+  })
+
+  it('renders the form when the outage loads', async () => {
+    vi.mocked(getScheduledOutage).mockResolvedValue({
+      name: 'nightly', type: 'daily', time: [{ begins: '01:00:00', ends: '02:00:00' }], node: [], interface: [{ address: 'match-any' }]
+    } as any)
+    const wrapper = await mountPage()
+
+    expect(wrapper.find('[data-test="editor-load-failed"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="save"]').exists()).toBe(true)
+  })
+
+  it('treats new=true as a blank form without a load guard', async () => {
+    query = { name: 'brand-new', new: 'true' }
+    const wrapper = await mountPage()
+
+    expect(getScheduledOutage).not.toHaveBeenCalled()
+    expect(wrapper.find('[data-test="save"]').exists()).toBe(true)
+  })
+
+  it('redirects to the list when no name is given', async () => {
+    query = {}
+    await mountPage()
+    expect(replace).toHaveBeenCalledWith({ path: '/scheduled-outages' })
+  })
+})

--- a/ui/tests/containers/ScheduledOutageEditor.test.ts
+++ b/ui/tests/containers/ScheduledOutageEditor.test.ts
@@ -24,7 +24,7 @@ import ScheduledOutageEditor from '@/containers/ScheduledOutageEditor.vue'
 import { flushPromises, mount } from '@vue/test-utils'
 import PrimeVue from 'primevue/config'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { getOutageApplicability, getScheduledOutage, saveScheduledOutage } from '@/services/scheduledOutagesService'
+import { getOutageApplicability, getScheduledOutage, saveScheduledOutage, setNotificationMembership, setPackageMembership } from '@/services/scheduledOutagesService'
 
 const push = vi.fn()
 const replace = vi.fn()
@@ -107,6 +107,26 @@ describe('ScheduledOutageEditor.vue', () => {
     expect(nodePicker.props('items')).toEqual([{ id: 7 }])
     expect(ifacePicker.props('items')).toEqual([])
     expect(ifacePicker.props('matchAny')).toBe(false)
+  })
+
+  it('reports an applies-to read failure instead of an empty matrix, and saves without touching memberships', async () => {
+    vi.mocked(getScheduledOutage).mockResolvedValue({
+      name: 'nightly', type: 'daily', time: [{ begins: '01:00:00', ends: '02:00:00' }], node: [], interface: [{ address: 'match-any' }]
+    } as any)
+    vi.mocked(getOutageApplicability).mockResolvedValue(null)
+    vi.mocked(saveScheduledOutage).mockResolvedValue(undefined as any)
+    const wrapper = await mountPage()
+
+    expect(wrapper.find('[data-test="applies-error"]').exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'AppliesToMatrix' }).exists()).toBe(false)
+    // the outage itself is still editable
+    expect(wrapper.find('[data-test="save"]').exists()).toBe(true)
+
+    await wrapper.find('[data-test="save"]').trigger('click')
+    await flushPromises()
+    expect(saveScheduledOutage).toHaveBeenCalled()
+    expect(setPackageMembership).not.toHaveBeenCalled()
+    expect(setNotificationMembership).not.toHaveBeenCalled()
   })
 
   it('treats new=true as a blank form without a load guard', async () => {

--- a/ui/tests/containers/ScheduledOutages.test.ts
+++ b/ui/tests/containers/ScheduledOutages.test.ts
@@ -1,0 +1,109 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import ScheduledOutages from '@/containers/ScheduledOutages.vue'
+import { flushPromises, mount } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  getNodeLabels,
+  getOutageApplicability,
+  getScheduledOutages
+} from '@/services/scheduledOutagesService'
+
+const push = vi.fn()
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push })
+}))
+
+vi.mock('@/services/scheduledOutagesService', () => ({
+  getScheduledOutages: vi.fn(),
+  getOutageApplicability: vi.fn(),
+  getNodeLabels: vi.fn(),
+  deleteScheduledOutage: vi.fn(),
+  scheduledOutageErrorMessage: (_err: any, fallback: string) => fallback
+}))
+
+const OUTAGES = [
+  { name: 'nightly', type: 'daily', time: [{ begins: '01:00:00', ends: '02:00:00' }], node: [{ id: 5 }], interface: [{ address: '10.0.0.1' }] },
+  { name: 'everything', type: 'weekly', time: [], node: [], interface: [{ address: 'match-any' }] }
+]
+
+const APPLIES = {
+  notifications: false,
+  notificationCalendars: ['nightly'],
+  pollers: [{ name: 'example1', applied: false, calendars: ['nightly'] }],
+  thresholders: [{ name: 'mib2', applied: false, calendars: [] }],
+  collectors: [{ name: 'vmware6', applied: false, calendars: ['everything'] }]
+}
+
+const mountPage = async () => {
+  const wrapper = mount(ScheduledOutages, {
+    global: {
+      plugins: [PrimeVue],
+      stubs: { BreadCrumbs: true, AboutDialogButton: true, ScheduledOutagesAbout: true }
+    }
+  })
+  await flushPromises()
+  return wrapper
+}
+
+describe('ScheduledOutages.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getScheduledOutages).mockResolvedValue(OUTAGES as any)
+    vi.mocked(getOutageApplicability).mockResolvedValue(APPLIES as any)
+    vi.mocked(getNodeLabels).mockResolvedValue({ 5: 'core-router' })
+  })
+
+  it('derives every membership from a single name-less applies-to call', async () => {
+    const wrapper = await mountPage()
+
+    expect(getOutageApplicability).toHaveBeenCalledTimes(1)
+    expect(getOutageApplicability).toHaveBeenCalledWith()
+
+    const marks = wrapper.findAll('[data-test="applied-mark"]').map(m => m.attributes('aria-label'))
+    // nightly: notifications + polling applied; everything: collection applied
+    expect(marks.filter(m => m === 'applied').length).toBe(3)
+  })
+
+  it('shows node labels and interface addresses in the selection column', async () => {
+    const wrapper = await mountPage()
+    const text = wrapper.find('[data-test="outages-table"]').text()
+    expect(text).toContain('core-router')
+    expect(text).toContain('10.0.0.1')
+    expect(text).toContain('All nodes and interfaces')
+  })
+
+  it('reports a first-load failure without claiming a last known list', async () => {
+    vi.mocked(getScheduledOutages).mockResolvedValue(null)
+    const wrapper = await mountPage()
+    expect(wrapper.find('[data-test="load-error"]').text()).toBe('Failed to load scheduled outages.')
+    expect(wrapper.find('[data-test="outages-table"]').exists()).toBe(false)
+  })
+
+  it('routes edit to the editor with the outage name', async () => {
+    const wrapper = await mountPage()
+    await wrapper.findAll('[data-test="edit-outage"]')[0].trigger('click')
+    expect(push).toHaveBeenCalledWith({ path: '/scheduled-outages/edit', query: { name: 'nightly' }})
+  })
+})

--- a/ui/tests/containers/ScheduledOutages.test.ts
+++ b/ui/tests/containers/ScheduledOutages.test.ts
@@ -60,7 +60,16 @@ const mountPage = async () => {
   const wrapper = mount(ScheduledOutages, {
     global: {
       plugins: [PrimeVue],
-      stubs: { BreadCrumbs: true, AboutDialogButton: true, ScheduledOutagesAbout: true }
+      stubs: {
+        BreadCrumbs: true,
+        AboutDialogButton: true,
+        ScheduledOutagesAbout: true,
+        // PrimeVue Dialog teleports to body, out of the wrapper's reach
+        OnmsDialog: {
+          props: ['visible', 'header'],
+          template: '<div v-if="visible" class="dialog-stub"><slot /></div>'
+        }
+      }
     }
   })
   await flushPromises()
@@ -99,6 +108,25 @@ describe('ScheduledOutages.vue', () => {
     const wrapper = await mountPage()
     expect(wrapper.find('[data-test="load-error"]').text()).toBe('Failed to load scheduled outages.')
     expect(wrapper.find('[data-test="outages-table"]').exists()).toBe(false)
+  })
+
+  it('creates through the dialog and routes to the editor', async () => {
+    const wrapper = await mountPage()
+    await wrapper.find('[data-test="create-outage"]').trigger('click')
+    await wrapper.find('[data-test="new-name"]').setValue('maintenance')
+    await wrapper.find('[data-test="create-confirm"]').trigger('click')
+
+    expect(push).toHaveBeenCalledWith({ path: '/scheduled-outages/edit', query: { name: 'maintenance', new: 'true' }})
+  })
+
+  it('rejects a duplicate name in the create dialog', async () => {
+    const wrapper = await mountPage()
+    await wrapper.find('[data-test="create-outage"]').trigger('click')
+    await wrapper.find('[data-test="new-name"]').setValue('nightly')
+    await wrapper.find('[data-test="create-confirm"]').trigger('click')
+
+    expect(push).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('already exists')
   })
 
   it('routes edit to the editor with the outage name', async () => {

--- a/ui/tests/containers/ScheduledOutages.test.ts
+++ b/ui/tests/containers/ScheduledOutages.test.ts
@@ -101,6 +101,17 @@ describe('ScheduledOutages.vue', () => {
     expect(marks.filter(m => m === 'applied').length).toBe(3)
   })
 
+  it('renders memberships as unknown when applies-to cannot be read', async () => {
+    vi.mocked(getOutageApplicability).mockResolvedValue(null)
+    const wrapper = await mountPage()
+
+    expect(wrapper.find('[data-test="outages-table"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="applies-error"]').text()).toContain('unknown')
+    const marks = wrapper.findAll('[data-test="applied-mark"]').map(m => m.attributes('aria-label'))
+    expect(marks.length).toBe(8)
+    expect(marks.every(m => m === 'unknown')).toBe(true)
+  })
+
   it('shows node labels and interface addresses in the selection column', async () => {
     const wrapper = await mountPage()
     const text = wrapper.find('[data-test="outages-table"]').text()

--- a/ui/tests/containers/ScheduledOutages.test.ts
+++ b/ui/tests/containers/ScheduledOutages.test.ts
@@ -25,6 +25,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import PrimeVue from 'primevue/config'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  deleteScheduledOutage,
   getNodeLabels,
   getOutageApplicability,
   getScheduledOutages
@@ -68,6 +69,11 @@ const mountPage = async () => {
         OnmsDialog: {
           props: ['visible', 'header'],
           template: '<div v-if="visible" class="dialog-stub"><slot /></div>'
+        },
+        OnmsConfirmationDialog: {
+          props: ['visible'],
+          emits: ['ok', 'cancel'],
+          template: '<div v-if="visible" class="confirm-stub"><slot name="content" /><button data-test="confirm-ok" @click="$emit(\'ok\')">ok</button></div>'
         }
       }
     }
@@ -127,6 +133,20 @@ describe('ScheduledOutages.vue', () => {
 
     expect(push).not.toHaveBeenCalled()
     expect(wrapper.text()).toContain('already exists')
+  })
+
+  it('keeps a failed delete visible after the list reloads', async () => {
+    vi.mocked(deleteScheduledOutage).mockRejectedValue(new Error('500'))
+    const wrapper = await mountPage()
+    await wrapper.findAll('[data-test="delete-outage"]')[0].trigger('click')
+    await wrapper.find('[data-test="confirm-ok"]').trigger('click')
+    await flushPromises()
+
+    expect(deleteScheduledOutage).toHaveBeenCalledWith('nightly')
+    expect(wrapper.find('[data-test="action-error"]').text()).toContain('Failed to delete the scheduled outage "nightly"')
+    // the reload succeeded, so the table is still there and no load error shows
+    expect(wrapper.find('[data-test="load-error"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="outages-table"]').exists()).toBe(true)
   })
 
   it('routes edit to the editor with the outage name', async () => {

--- a/ui/tests/services/scheduledOutagesService.test.ts
+++ b/ui/tests/services/scheduledOutagesService.test.ts
@@ -95,18 +95,25 @@ describe('scheduledOutagesService', () => {
     expect(rest.delete).toHaveBeenCalledWith('/sched-outages/nightly/notifd')
   })
 
-  it('builds the node autocomplete query and maps id/label', async () => {
-    vi.mocked(v2.get).mockResolvedValue({ data: { node: [{ id: '7', label: 'core-sw' }] }})
-    const nodes = await searchOutageNodes('core')
-    expect(v2.get).toHaveBeenCalledWith('/nodes?limit=200&_s=node.label==*core*')
+  it('searches nodes case-insensitively via the v1 ilike comparator', async () => {
+    // v2 FIQL wildcards are a case-sensitive LIKE; only v1 offers ilike
+    vi.mocked(rest.get).mockResolvedValue({ data: { node: [{ id: '7', label: 'core-sw' }] }})
+    const nodes = await searchOutageNodes('CORE')
+    expect(rest.get).toHaveBeenCalledWith('/nodes?limit=200&comparator=ilike&label=%25CORE%25')
     expect(nodes).toEqual([{ id: 7, label: 'core-sw' }])
   })
 
   it('strips FIQL/URL metacharacters from the autocomplete query', async () => {
-    vi.mocked(v2.get).mockResolvedValue({ data: { node: [] }})
+    vi.mocked(rest.get).mockResolvedValue({ data: { node: [] }})
     await searchOutageNodes('a*b);node.id==1&x=2')
-    // metacharacters that could break out of the FIQL term or inject params are removed
-    expect(v2.get).toHaveBeenCalledWith('/nodes?limit=200&_s=node.label==*abnode.id1x2*')
+    // metacharacters that could break out of the term or inject params are removed
+    expect(rest.get).toHaveBeenCalledWith('/nodes?limit=200&comparator=ilike&label=%25abnode.id1x2%25')
+  })
+
+  it('ORs the raw and lowercased term for interface hostname search', async () => {
+    vi.mocked(v2.get).mockResolvedValue({ data: { ipInterface: [] }})
+    await searchOutageInterfaces('GW')
+    expect(v2.get).toHaveBeenCalledWith('/ipinterfaces?limit=200&_s=ipHostName==*gw*,ipHostName==*GW*')
   })
 
   // The v2 API rejects wildcards on the IP_ADDRESS-typed ipAddress property and

--- a/ui/tests/services/scheduledOutagesService.test.ts
+++ b/ui/tests/services/scheduledOutagesService.test.ts
@@ -99,4 +99,11 @@ describe('scheduledOutagesService', () => {
     expect(v2.get).toHaveBeenCalledWith('/nodes?limit=200&_s=node.label==*core*')
     expect(nodes).toEqual([{ id: 7, label: 'core-sw' }])
   })
+
+  it('strips FIQL/URL metacharacters from the autocomplete query', async () => {
+    vi.mocked(v2.get).mockResolvedValue({ data: { node: [] } })
+    await searchOutageNodes('a*b);node.id==1&x=2')
+    // metacharacters that could break out of the FIQL term or inject params are removed
+    expect(v2.get).toHaveBeenCalledWith('/nodes?limit=200&_s=node.label==*abnode.id1x2*')
+  })
 })

--- a/ui/tests/services/scheduledOutagesService.test.ts
+++ b/ui/tests/services/scheduledOutagesService.test.ts
@@ -26,6 +26,7 @@ import {
   getOutageApplicability,
   getScheduledOutage,
   getScheduledOutages,
+  ipv4PrefixPattern,
   searchOutageInterfaces,
   searchOutageNodes,
   setNotificationMembership,
@@ -116,14 +117,33 @@ describe('scheduledOutagesService', () => {
     expect(v2.get).toHaveBeenCalledWith('/ipinterfaces?limit=200&_s=ipHostName==*gw*,ipHostName==*GW*')
   })
 
-  // The v2 API rejects wildcards on the IP_ADDRESS-typed ipAddress property and
-  // any ipInterface.-prefixed property (both 500), so partial terms must search
-  // ipHostName and complete IPs must match ipAddress exactly.
-  it('searches partial interface terms via an ipHostName wildcard', async () => {
+  // ipAddress is IP_ADDRESS-typed, so only iplike patterns (10.0.*.*) are
+  // valid there; a partial IPv4 is widened to one and ORed with the hostname
+  // wildcard, since ipHostName holds the hostname wherever reverse DNS resolved
+  it('searches a partial IPv4 as an iplike pattern ORed with the hostname wildcard', async () => {
     vi.mocked(v2.get).mockResolvedValue({ data: { ipInterface: [{ ipAddress: '192.168.1.1', nodeLabel: 'gw' }] }})
     const result = await searchOutageInterfaces('192')
-    expect(v2.get).toHaveBeenCalledWith('/ipinterfaces?limit=200&_s=ipHostName==*192*')
+    expect(v2.get).toHaveBeenCalledWith('/ipinterfaces?limit=200&_s=ipAddress==192.*.*.*,ipHostName==*192*')
     expect(result).toEqual([{ address: '192.168.1.1', nodeLabel: 'gw' }])
+
+    await searchOutageInterfaces('192.168.1.')
+    expect(v2.get).toHaveBeenLastCalledWith('/ipinterfaces?limit=200&_s=ipAddress==192.168.1.*,ipHostName==*192.168.1.*')
+  })
+
+  it('widens a dotted prefix to four octets and rejects anything else', () => {
+    expect(ipv4PrefixPattern('10')).toBe('10.*.*.*')
+    expect(ipv4PrefixPattern('10.0')).toBe('10.0.*.*')
+    expect(ipv4PrefixPattern('10.0.1.')).toBe('10.0.1.*')
+    expect(ipv4PrefixPattern('999')).toBeNull()
+    expect(ipv4PrefixPattern('gw')).toBeNull()
+    expect(ipv4PrefixPattern('fe80:')).toBeNull()
+    expect(ipv4PrefixPattern('10.0.0.5')).toBeNull()
+  })
+
+  it('searches non-numeric terms via the ipHostName wildcard only', async () => {
+    vi.mocked(v2.get).mockResolvedValue({ data: {}})
+    await searchOutageInterfaces('router')
+    expect(v2.get).toHaveBeenCalledWith('/ipinterfaces?limit=200&_s=ipHostName==*router*')
   })
 
   it('searches a complete IP via an exact ipAddress match and offers the typed IP itself', async () => {

--- a/ui/tests/services/scheduledOutagesService.test.ts
+++ b/ui/tests/services/scheduledOutagesService.test.ts
@@ -22,9 +22,11 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  getNodeLabels,
   getOutageApplicability,
   getScheduledOutage,
   getScheduledOutages,
+  searchOutageInterfaces,
   searchOutageNodes,
   setNotificationMembership,
   setPackageMembership
@@ -42,20 +44,20 @@ describe('scheduledOutagesService', () => {
   })
 
   it('unwraps the "outage" array from the list response', async () => {
-    vi.mocked(rest.get).mockResolvedValue({ data: { outage: [{ name: 'a' }, { name: 'b' }] } })
+    vi.mocked(rest.get).mockResolvedValue({ data: { outage: [{ name: 'a' }, { name: 'b' }] }})
     const result = await getScheduledOutages()
     expect(result?.map(o => o.name)).toEqual(['a', 'b'])
   })
 
   it('normalizes a single-element outage list to an array', async () => {
-    vi.mocked(rest.get).mockResolvedValue({ data: { outage: { name: 'solo' } } })
+    vi.mocked(rest.get).mockResolvedValue({ data: { outage: { name: 'solo' }}})
     const result = await getScheduledOutages()
     expect(result?.map(o => o.name)).toEqual(['solo'])
   })
 
   it('normalizes collapsed single time/node/interface objects on a single outage', async () => {
     vi.mocked(rest.get).mockResolvedValue({
-      data: { name: 'x', type: 'weekly', time: { begins: '00:00:00', ends: '23:59:59', day: 'monday' }, node: { id: 3 } }
+      data: { name: 'x', type: 'weekly', time: { begins: '00:00:00', ends: '23:59:59', day: 'monday' }, node: { id: 3 }}
     })
     const outage = await getScheduledOutage('x')
     expect(outage?.time).toEqual([{ begins: '00:00:00', ends: '23:59:59', day: 'monday' }])
@@ -64,15 +66,15 @@ describe('scheduledOutagesService', () => {
   })
 
   it('reads applies-to without a name for a new outage', async () => {
-    vi.mocked(rest.get).mockResolvedValue({ data: { notifications: false, pollers: [{ name: 'default', applied: false }] } })
+    vi.mocked(rest.get).mockResolvedValue({ data: { notifications: false, pollers: [{ name: 'default', applied: false }] }})
     const appl = await getOutageApplicability()
     expect(rest.get).toHaveBeenCalledWith('/sched-outages/applies-to')
-    expect(appl?.pollers).toEqual([{ name: 'default', applied: false }])
+    expect(appl?.pollers).toEqual([{ name: 'default', applied: false, calendars: [] }])
     expect(appl?.collectors).toEqual([])
   })
 
   it('reads applies-to for a named outage', async () => {
-    vi.mocked(rest.get).mockResolvedValue({ data: { notifications: true } })
+    vi.mocked(rest.get).mockResolvedValue({ data: { notifications: true }})
     const appl = await getOutageApplicability('Weekend Maint')
     expect(rest.get).toHaveBeenCalledWith('/sched-outages/Weekend%20Maint/applies-to')
     expect(appl?.notifications).toBe(true)
@@ -94,16 +96,62 @@ describe('scheduledOutagesService', () => {
   })
 
   it('builds the node autocomplete query and maps id/label', async () => {
-    vi.mocked(v2.get).mockResolvedValue({ data: { node: [{ id: '7', label: 'core-sw' }] } })
+    vi.mocked(v2.get).mockResolvedValue({ data: { node: [{ id: '7', label: 'core-sw' }] }})
     const nodes = await searchOutageNodes('core')
     expect(v2.get).toHaveBeenCalledWith('/nodes?limit=200&_s=node.label==*core*')
     expect(nodes).toEqual([{ id: 7, label: 'core-sw' }])
   })
 
   it('strips FIQL/URL metacharacters from the autocomplete query', async () => {
-    vi.mocked(v2.get).mockResolvedValue({ data: { node: [] } })
+    vi.mocked(v2.get).mockResolvedValue({ data: { node: [] }})
     await searchOutageNodes('a*b);node.id==1&x=2')
     // metacharacters that could break out of the FIQL term or inject params are removed
     expect(v2.get).toHaveBeenCalledWith('/nodes?limit=200&_s=node.label==*abnode.id1x2*')
+  })
+
+  // The v2 API rejects wildcards on the IP_ADDRESS-typed ipAddress property and
+  // any ipInterface.-prefixed property (both 500), so partial terms must search
+  // ipHostName and complete IPs must match ipAddress exactly.
+  it('searches partial interface terms via an ipHostName wildcard', async () => {
+    vi.mocked(v2.get).mockResolvedValue({ data: { ipInterface: [{ ipAddress: '192.168.1.1', nodeLabel: 'gw' }] }})
+    const result = await searchOutageInterfaces('192')
+    expect(v2.get).toHaveBeenCalledWith('/ipinterfaces?limit=200&_s=ipHostName==*192*')
+    expect(result).toEqual([{ address: '192.168.1.1', nodeLabel: 'gw' }])
+  })
+
+  it('searches a complete IP via an exact ipAddress match and offers the typed IP itself', async () => {
+    vi.mocked(v2.get).mockResolvedValue({ data: {}})
+    const result = await searchOutageInterfaces('10.0.0.5')
+    expect(v2.get).toHaveBeenCalledWith('/ipinterfaces?limit=200&_s=ipAddress==10.0.0.5')
+    // poll-outages accepts any valid IP, so the typed address is offerable even
+    // when it is not in inventory
+    expect(result).toEqual([{ address: '10.0.0.5', nodeLabel: '' }])
+  })
+
+  it('still offers a complete typed IP when the interface query fails', async () => {
+    vi.mocked(v2.get).mockRejectedValue(new Error('500'))
+    expect(await searchOutageInterfaces('10.0.0.5')).toEqual([{ address: '10.0.0.5', nodeLabel: '' }])
+    expect(await searchOutageInterfaces('unresolvable')).toEqual([])
+  })
+
+  it('resolves node labels for ids in a single OR query', async () => {
+    vi.mocked(v2.get).mockResolvedValue({ data: { node: [{ id: '5', label: 'core' }, { id: '7', label: 'edge' }] }})
+    const labels = await getNodeLabels([5, 7])
+    expect(v2.get).toHaveBeenCalledWith('/nodes?limit=2&_s=id==5,id==7')
+    expect(labels).toEqual({ 5: 'core', 7: 'edge' })
+    expect(await getNodeLabels([])).toEqual({})
+  })
+
+  it('parses package calendars and notification calendars from applies-to', async () => {
+    vi.mocked(rest.get).mockResolvedValue({
+      data: {
+        notifications: false,
+        'notification-calendars': 'nightly',
+        pollers: [{ name: 'example1', applied: false, calendars: ['nightly', 'weekend'] }]
+      }
+    })
+    const appl = await getOutageApplicability()
+    expect(appl?.notificationCalendars).toEqual(['nightly'])
+    expect(appl?.pollers[0].calendars).toEqual(['nightly', 'weekend'])
   })
 })

--- a/ui/tests/services/scheduledOutagesService.test.ts
+++ b/ui/tests/services/scheduledOutagesService.test.ts
@@ -1,0 +1,102 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  getOutageApplicability,
+  getScheduledOutage,
+  getScheduledOutages,
+  searchOutageNodes,
+  setNotificationMembership,
+  setPackageMembership
+} from '@/services/scheduledOutagesService'
+import { rest, v2 } from '@/services/axiosInstances'
+
+vi.mock('@/services/axiosInstances', () => ({
+  rest: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+  v2: { get: vi.fn() }
+}))
+
+describe('scheduledOutagesService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('unwraps the "outage" array from the list response', async () => {
+    vi.mocked(rest.get).mockResolvedValue({ data: { outage: [{ name: 'a' }, { name: 'b' }] } })
+    const result = await getScheduledOutages()
+    expect(result?.map(o => o.name)).toEqual(['a', 'b'])
+  })
+
+  it('normalizes a single-element outage list to an array', async () => {
+    vi.mocked(rest.get).mockResolvedValue({ data: { outage: { name: 'solo' } } })
+    const result = await getScheduledOutages()
+    expect(result?.map(o => o.name)).toEqual(['solo'])
+  })
+
+  it('normalizes collapsed single time/node/interface objects on a single outage', async () => {
+    vi.mocked(rest.get).mockResolvedValue({
+      data: { name: 'x', type: 'weekly', time: { begins: '00:00:00', ends: '23:59:59', day: 'monday' }, node: { id: 3 } }
+    })
+    const outage = await getScheduledOutage('x')
+    expect(outage?.time).toEqual([{ begins: '00:00:00', ends: '23:59:59', day: 'monday' }])
+    expect(outage?.node).toEqual([{ id: 3 }])
+    expect(outage?.interface).toEqual([])
+  })
+
+  it('reads applies-to without a name for a new outage', async () => {
+    vi.mocked(rest.get).mockResolvedValue({ data: { notifications: false, pollers: [{ name: 'default', applied: false }] } })
+    const appl = await getOutageApplicability()
+    expect(rest.get).toHaveBeenCalledWith('/sched-outages/applies-to')
+    expect(appl?.pollers).toEqual([{ name: 'default', applied: false }])
+    expect(appl?.collectors).toEqual([])
+  })
+
+  it('reads applies-to for a named outage', async () => {
+    vi.mocked(rest.get).mockResolvedValue({ data: { notifications: true } })
+    const appl = await getOutageApplicability('Weekend Maint')
+    expect(rest.get).toHaveBeenCalledWith('/sched-outages/Weekend%20Maint/applies-to')
+    expect(appl?.notifications).toBe(true)
+  })
+
+  it('PUTs a package membership when applied, DELETEs when not', async () => {
+    await setPackageMembership('pollerd', 'My Outage', 'example1', true)
+    expect(rest.put).toHaveBeenCalledWith('/sched-outages/My%20Outage/pollerd/example1')
+
+    await setPackageMembership('threshd', 'My Outage', 'mib2', false)
+    expect(rest.delete).toHaveBeenCalledWith('/sched-outages/My%20Outage/threshd/mib2')
+  })
+
+  it('routes notification membership to the notifd sub-resource', async () => {
+    await setNotificationMembership('nightly', true)
+    expect(rest.put).toHaveBeenCalledWith('/sched-outages/nightly/notifd')
+    await setNotificationMembership('nightly', false)
+    expect(rest.delete).toHaveBeenCalledWith('/sched-outages/nightly/notifd')
+  })
+
+  it('builds the node autocomplete query and maps id/label', async () => {
+    vi.mocked(v2.get).mockResolvedValue({ data: { node: [{ id: '7', label: 'core-sw' }] } })
+    const nodes = await searchOutageNodes('core')
+    expect(v2.get).toHaveBeenCalledWith('/nodes?limit=200&_s=node.label==*core*')
+    expect(nodes).toEqual([{ id: 7, label: 'core-sw' }])
+  })
+})


### PR DESCRIPTION
Migrates the legacy `admin/sched-outages` JSP (list + editor) to a Vue UI backed by the existing `/rest/sched-outages` API.

Behavior is preserved: outages, their node/interface selection, type and time spans, and the notifications/polling/thresholds/data-collection references are edited exactly as before — this is a UI migration, not a change to what an outage does.

- List page shows each outage's type, node labels/interface addresses, time-span count, and which subsystems reference it, with create and delete; all memberships come from a single name-less applies-to call.
- Editor manages node/interface pickers, the outage type, its time spans, and the Applies-To matrix; "Select all nodes and interfaces" maps to the `match-any` interface, and a load failure on an existing outage disables editing rather than presenting an empty form.
- Interface autocomplete searches `ipHostName==*term*` (the v2 API rejects wildcards on `ipAddress`); a complete IP matches `ipAddress` exactly and is always offerable itself.
- Time spans are written in the exact wire formats the parser keys on by length — `dd-MMM-yyyy HH:mm:ss` for `specific`, `HH:mm:ss` for daily/weekly/monthly — matching the legacy form.
- Adds one read-only endpoint, `GET /sched-outages[/{name}]/applies-to` (admin-gated), returning the notifd flag plus every poller/collectd/threshd package with its outage calendars and an applied flag for the named variant.
- The sidebar menu, Admin page, and global-search action all point at the Vue page.
- Uses Onms-XXX components; full `eslint` and `vue-tsc` pass, 38 UI tests and `ScheduledOutagesRestServiceIT` (14) pass, `WillItUnmarshalIT` covers the search-actions change, and `MenuHeaderIT` targets the Vue page.
- Not included: the legacy "Add with path outage dependency" option (no REST support today); tracked as a follow-up.
