### PR TITLE
NMS-20271: Intermittent deadlock in DataBlocksOffHeapQueue during memory to off-heap transition

### DIFF
--- a/core/ipc/sink/off-heap/src/main/java/org/opennms/core/ipc/sink/offheap/DataBlocksOffHeapQueue.java
+++ b/core/ipc/sink/off-heap/src/main/java/org/opennms/core/ipc/sink/offheap/DataBlocksOffHeapQueue.java
@@ -293,15 +293,14 @@ public class DataBlocksOffHeapQueue<T> implements DispatchQueue<T> {
         var head = mainQueue.peek();
         if (head.size() > 0) {
             data = head.dequeue();
-            if (headTailEqual) {
-                tailLock.unlock();
-            } else {
-                removeHeadBlockIfNeeded();
-            }
+        }
+        if (headTailEqual) {
+            tailLock.unlock();
         } else {
-            if (headTailEqual) {
-                tailLock.unlock();
-            }
+            // Also runs when the head was already empty: a block drained while it was still the
+            // tail is never evicted at drain time, so without this it stays head forever and
+            // every dequeue() spins on it.
+            removeHeadBlockIfNeeded();
         }
         return data;
     }

--- a/core/ipc/sink/off-heap/src/main/java/org/opennms/core/ipc/sink/offheap/DataBlocksOffHeapQueue.java
+++ b/core/ipc/sink/off-heap/src/main/java/org/opennms/core/ipc/sink/offheap/DataBlocksOffHeapQueue.java
@@ -69,6 +69,10 @@ public class DataBlocksOffHeapQueue<T> implements DispatchQueue<T> {
 
     private final Lock headLock = new ReentrantLock(true);
     private final Lock tailLock = new ReentrantLock(true);
+    // dedicated lock for the isFull() backpressure wait in enqueue(); must NOT be a DataBlock's own
+    // monitor, since DataBlock.enqueue()/dequeue() are themselves synchronized(this) and dequeue()
+    // can otherwise deadlock while holding that monitor waiting for data the producer can't add.
+    private final Object backpressureLock = new Object();
 
     private final Function<T, byte[]> serializer;
     private final Function<byte[], T> deserializer;
@@ -237,9 +241,9 @@ public class DataBlocksOffHeapQueue<T> implements DispatchQueue<T> {
     @Override
     public EnqueueResult enqueue(T message, String key) throws WriteFailedException {
         try {
-            synchronized (tailBlock) {
+            synchronized (backpressureLock) {
                 while (isFull()) {
-                    tailBlock.wait(10);
+                    backpressureLock.wait(10);
                 }
             }
         } catch (InterruptedException e) {

--- a/core/ipc/sink/off-heap/src/main/java/org/opennms/core/ipc/sink/offheap/MemoryDataBlock.java
+++ b/core/ipc/sink/off-heap/src/main/java/org/opennms/core/ipc/sink/offheap/MemoryDataBlock.java
@@ -71,7 +71,7 @@ public class MemoryDataBlock<T> implements DataBlock<T> {
 
     @Override
     public synchronized Map.Entry<String, T> dequeue() throws InterruptedException {
-        return queue.take();
+        return queue.poll();
     }
 
     @Override

--- a/core/ipc/sink/off-heap/src/main/java/org/opennms/core/ipc/sink/offheap/MemoryDataBlock.java
+++ b/core/ipc/sink/off-heap/src/main/java/org/opennms/core/ipc/sink/offheap/MemoryDataBlock.java
@@ -80,7 +80,7 @@ public class MemoryDataBlock<T> implements DataBlock<T> {
             return;
         }
         if (nextDataBlock instanceof OffHeapDataBlock) {
-            OffHeapDataBlock.executorService.submit(() -> {
+            OffHeapDataBlock.prefetchExecutorService.submit(() -> {
                 try {
                     ((OffHeapDataBlock<T>) nextDataBlock).enableQueue();
                 } catch (ReadFailedException | InterruptedException e) {

--- a/core/ipc/sink/off-heap/src/main/java/org/opennms/core/ipc/sink/offheap/OffHeapDataBlock.java
+++ b/core/ipc/sink/off-heap/src/main/java/org/opennms/core/ipc/sink/offheap/OffHeapDataBlock.java
@@ -122,7 +122,7 @@ public abstract class OffHeapDataBlock<T> implements DataBlock<T> {
     @Override
     public synchronized Map.Entry<String, T> dequeue() throws InterruptedException, ReadFailedException {
         enableQueue();
-        return queue.take();
+        return queue.poll();
     }
 
     @Override

--- a/core/ipc/sink/off-heap/src/main/java/org/opennms/core/ipc/sink/offheap/OffHeapDataBlock.java
+++ b/core/ipc/sink/off-heap/src/main/java/org/opennms/core/ipc/sink/offheap/OffHeapDataBlock.java
@@ -159,8 +159,8 @@ public abstract class OffHeapDataBlock<T> implements DataBlock<T> {
         if (future != null) {
             return;
         }
-        diskLock.lock();
-        // it will return the size of the bytes
+        // Do not take diskLock here: the submitted task acquires it itself, and enableQueue()
+        // must be able to observe the future without contending for the lock the task needs.
         future = executorService.submit(() -> {
             diskLock.lock();
             long start = System.currentTimeMillis();
@@ -186,25 +186,20 @@ public abstract class OffHeapDataBlock<T> implements DataBlock<T> {
                 diskLock.unlock();
             }
         });
-        diskLock.unlock();
     }
 
     // make sure data is in memory queue
     public synchronized void enableQueue() throws ReadFailedException, InterruptedException {
+        // Wait for an in-flight flush before taking diskLock. The flush task acquires diskLock
+        // itself, so holding it while waiting on the future deadlocks the two against each other.
+        while (future != null && !future.isDone()) {
+            this.wait(10);
+        }
+        if (!restore && queue != null) {
+            return;
+        }
+        diskLock.lock();
         try {
-            if (!restore) {
-                while (!diskLock.tryLock()) {
-                    this.wait(10);
-                }
-                while ((future != null && !future.isDone())) {
-                    this.wait(10);
-                }
-                if (queue != null) {
-                    return;
-                }
-            } else {
-                diskLock.lock();
-            }
             toMemory();
             future = null;
             restore = false;

--- a/core/ipc/sink/off-heap/src/main/java/org/opennms/core/ipc/sink/offheap/OffHeapDataBlock.java
+++ b/core/ipc/sink/off-heap/src/main/java/org/opennms/core/ipc/sink/offheap/OffHeapDataBlock.java
@@ -49,16 +49,23 @@ public abstract class OffHeapDataBlock<T> implements DataBlock<T> {
     protected static final Logger LOG = LoggerFactory.getLogger(OffHeapDataBlock.class);
     protected static final ForkJoinPool serdesPool = new ForkJoinPool(
             Math.max(Runtime.getRuntime().availableProcessors() * 2, 4));
+    // flushToDisk() tasks run here. Kept separate from prefetchExecutorService so that
+    // prefetch tasks blocking in enableQueue() waiting on a flush future can never starve
+    // the threads a flush needs to actually run.
     protected static final ExecutorService executorService = Executors.newFixedThreadPool(10);
+    // notifyNextDataBlock() prefetch tasks run here. They call enableQueue(), which can block
+    // waiting on an in-flight flush future; if that wait happened on the same pool as the flush
+    // itself, enough blocked prefetch tasks could wedge every flush behind them forever.
+    protected static final ExecutorService prefetchExecutorService = Executors.newFixedThreadPool(10);
 
     protected int queueSize;
-    protected BlockingQueue<Map.Entry<String, T>> queue;
+    protected volatile BlockingQueue<Map.Entry<String, T>> queue;
 
     private String name;
     private final Function<T, byte[]> serializer;
     private final Function<byte[], T> deserializer;
     private final Lock diskLock = new ReentrantLock(true);
-    private int offHeapQueueSize = -1;
+    private volatile int offHeapQueueSize = -1;
 
     private Future<Integer> future;
 
@@ -131,7 +138,7 @@ public abstract class OffHeapDataBlock<T> implements DataBlock<T> {
             return;
         }
         if (nextDataBlock instanceof OffHeapDataBlock) {
-            executorService.submit(() -> {
+            prefetchExecutorService.submit(() -> {
                         try {
                             ((OffHeapDataBlock<T>) nextDataBlock).enableQueue();
                         } catch (ReadFailedException | InterruptedException e) {

--- a/core/ipc/sink/off-heap/src/test/java/org/opennms/core/ipc/sink/offheap/DataBlocksOffHeapQueueBackpressureDeadlockTest.java
+++ b/core/ipc/sink/off-heap/src/test/java/org/opennms/core/ipc/sink/offheap/DataBlocksOffHeapQueueBackpressureDeadlockTest.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.core.ipc.sink.offheap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicIntegerArray;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.opennms.core.ipc.sink.api.DispatchQueue;
+import org.opennms.core.ipc.sink.api.QueueCreateFailedException;
+
+/**
+ * NMS-20271. Before the fix, enqueue()'s backpressure wait synchronized on the current tailBlock
+ * itself, the same monitor MemoryDataBlock/OffHeapDataBlock use to guard their own synchronized
+ * enqueue()/dequeue()/size() methods, and dequeue() drained a block with the blocking
+ * BlockingQueue.take() rather than poll(). With a small block size, head and tail are the same
+ * block for most of the run, so producers checking isFull() under the tailBlock monitor and the
+ * single consumer draining that same block under headLock+tailLock contend on one shared lock, and
+ * a consumer that wins the race onto an instant-drained block can wait in take() past the point the
+ * block is retired. Like the off-heap transition stalls, this is silent rather than a JVM-visible
+ * deadlock, so the test asserts on forward progress rather than completion.
+ */
+public class DataBlocksOffHeapQueueBackpressureDeadlockTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private static final int PRODUCERS = 8;
+    private static final int CONSUMERS = 8;
+    private static final int PER_PRODUCER = 4000;
+    private static final int TOTAL = PRODUCERS * PER_PRODUCER;
+    private static final long STALL_MILLIS = 10_000L;
+
+    @Test(timeout = 60_000)
+    public void doesNotStallOnSharedTailBlockMonitor() throws Exception {
+        // batchSize 1 with a large in-memory ceiling: every message gets its own block and the
+        // queue never spills off-heap, so head and tail coincide constantly and every enqueue()
+        // backpressure check and dequeue() race for the same tailBlock monitor pre-fix.
+        final DispatchQueue<String> queue = newQueue(1_000_000, 1);
+
+        final AtomicLong enqueued = new AtomicLong();
+        final AtomicLong dequeued = new AtomicLong();
+        final AtomicLong duplicates = new AtomicLong();
+        final AtomicIntegerArray seen = new AtomicIntegerArray(TOTAL);
+        final AtomicBoolean stopped = new AtomicBoolean();
+        final CountDownLatch go = new CountDownLatch(1);
+        final CountDownLatch producersDone = new CountDownLatch(PRODUCERS);
+
+        final List<Thread> threads = new ArrayList<>();
+        for (int p = 0; p < PRODUCERS; p++) {
+            final int id = p;
+            threads.add(daemon("producer-" + p, () -> {
+                try {
+                    go.await();
+                    for (int i = 0; i < PER_PRODUCER && !stopped.get(); i++) {
+                        queue.enqueue(id + "-" + i, id + "-" + i);
+                        enqueued.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    producersDone.countDown();
+                }
+            }));
+        }
+        for (int c = 0; c < CONSUMERS; c++) {
+            threads.add(daemon("consumer-" + c, () -> {
+                try {
+                    go.await();
+                    while (!stopped.get() && dequeued.get() < TOTAL) {
+                        final Map.Entry<String, String> entry = queue.dequeue();
+                        if (entry == null) {
+                            continue;
+                        }
+                        dequeued.incrementAndGet();
+                        final String[] parts = entry.getValue().split("-", 2);
+                        final int index = Integer.parseInt(parts[0]) * PER_PRODUCER + Integer.parseInt(parts[1]);
+                        if (seen.getAndIncrement(index) != 0) {
+                            duplicates.incrementAndGet();
+                        }
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }));
+        }
+
+        threads.forEach(Thread::start);
+        go.countDown();
+
+        long lastEnqueued = -1;
+        long lastDequeued = -1;
+        long lastProgress = System.currentTimeMillis();
+        while (dequeued.get() < TOTAL) {
+            Thread.sleep(100);
+            if (enqueued.get() != lastEnqueued || dequeued.get() != lastDequeued) {
+                lastEnqueued = enqueued.get();
+                lastDequeued = dequeued.get();
+                lastProgress = System.currentTimeMillis();
+            } else if (System.currentTimeMillis() - lastProgress > STALL_MILLIS) {
+                stopped.set(true);
+                threads.forEach(Thread::interrupt);
+                fail(String.format("no progress for %dms: enqueued %d, dequeued %d of %d",
+                        STALL_MILLIS, lastEnqueued, lastDequeued, TOTAL));
+            }
+        }
+        stopped.set(true);
+        producersDone.await(10, TimeUnit.SECONDS);
+
+        assertEquals(TOTAL, dequeued.get());
+        assertEquals(0, duplicates.get());
+        int missing = 0;
+        for (int i = 0; i < TOTAL; i++) {
+            if (seen.get(i) == 0) {
+                missing++;
+            }
+        }
+        assertEquals(0, missing);
+    }
+
+    private DispatchQueue<String> newQueue(int inMemoryQueueSize, int batchSize)
+            throws IOException, QueueCreateFailedException {
+        return new DataBlocksOffHeapQueue<>(
+                String::getBytes, String::new,
+                "backpressure-deadlock", Paths.get(folder.newFolder().toURI()),
+                inMemoryQueueSize, batchSize, 4L * 1024L * 1024L * 1024L);
+    }
+
+    private static Thread daemon(String name, Runnable body) {
+        final Thread t = new Thread(body, name);
+        t.setDaemon(true);
+        return t;
+    }
+}

--- a/core/ipc/sink/off-heap/src/test/java/org/opennms/core/ipc/sink/offheap/DataBlocksOffHeapQueueDeadlockTest.java
+++ b/core/ipc/sink/off-heap/src/test/java/org/opennms/core/ipc/sink/offheap/DataBlocksOffHeapQueueDeadlockTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.core.ipc.sink.offheap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicIntegerArray;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.opennms.core.ipc.sink.api.DispatchQueue;
+import org.opennms.core.ipc.sink.api.QueueCreateFailedException;
+
+/**
+ * NMS-20271. Producers and consumers racing across the memory to off-heap transition used to wedge:
+ * a consumer inside enableQueue() held diskLock while waiting on the flush future whose task needs
+ * that same lock, and readData() never evicted a head block that had drained while it was the tail.
+ * Both stalls are silent, so the test asserts on forward progress rather than on completion alone.
+ */
+public class DataBlocksOffHeapQueueDeadlockTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private static final int PRODUCERS = 8;
+    private static final int CONSUMERS = 8;
+    private static final int PER_PRODUCER = 2000;
+    /** wide enough that serialization and the RocksDB write actually take time */
+    private static final String PADDING = new String(new char[192]).replace('\0', 'x');
+    private static final int TOTAL = PRODUCERS * PER_PRODUCER;
+    private static final long STALL_MILLIS = 20_000L;
+
+    @Test(timeout = 120_000)
+    public void doesNotStallAcrossTheOffHeapTransition() throws Exception {
+        // in-memory capacity of 100 with 10 per block forces off-heap blocks almost immediately
+        final DispatchQueue<String> queue = newQueue(100, 10);
+
+        final AtomicLong enqueued = new AtomicLong();
+        final AtomicLong dequeued = new AtomicLong();
+        final AtomicLong duplicates = new AtomicLong();
+        final AtomicIntegerArray seen = new AtomicIntegerArray(TOTAL);
+        final AtomicBoolean stopped = new AtomicBoolean();
+        final CountDownLatch go = new CountDownLatch(1);
+        final CountDownLatch producersDone = new CountDownLatch(PRODUCERS);
+
+        final List<Thread> threads = new ArrayList<>();
+        for (int p = 0; p < PRODUCERS; p++) {
+            final int id = p;
+            threads.add(daemon("producer-" + p, () -> {
+                try {
+                    go.await();
+                    for (int i = 0; i < PER_PRODUCER && !stopped.get(); i++) {
+                        queue.enqueue(id + "-" + i + "-" + PADDING, id + "-" + i);
+                        enqueued.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    producersDone.countDown();
+                }
+            }));
+        }
+        for (int c = 0; c < CONSUMERS; c++) {
+            threads.add(daemon("consumer-" + c, () -> {
+                try {
+                    go.await();
+                    while (!stopped.get() && dequeued.get() < TOTAL) {
+                        final Map.Entry<String, String> entry = queue.dequeue();
+                        if (entry == null) {
+                            continue;
+                        }
+                        dequeued.incrementAndGet();
+                        final String[] parts = entry.getValue().split("-", 3);
+                        final int index = Integer.parseInt(parts[0]) * PER_PRODUCER + Integer.parseInt(parts[1]);
+                        if (seen.getAndIncrement(index) != 0) {
+                            duplicates.incrementAndGet();
+                        }
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }));
+        }
+
+        threads.forEach(Thread::start);
+        go.countDown();
+
+        long lastEnqueued = -1;
+        long lastDequeued = -1;
+        long lastProgress = System.currentTimeMillis();
+        while (dequeued.get() < TOTAL) {
+            Thread.sleep(100);
+            if (enqueued.get() != lastEnqueued || dequeued.get() != lastDequeued) {
+                lastEnqueued = enqueued.get();
+                lastDequeued = dequeued.get();
+                lastProgress = System.currentTimeMillis();
+            } else if (System.currentTimeMillis() - lastProgress > STALL_MILLIS) {
+                stopped.set(true);
+                threads.forEach(Thread::interrupt);
+                fail(String.format("no progress for %dms: enqueued %d, dequeued %d of %d",
+                        STALL_MILLIS, lastEnqueued, lastDequeued, TOTAL));
+            }
+        }
+        stopped.set(true);
+        producersDone.await(10, TimeUnit.SECONDS);
+
+        assertEquals(TOTAL, dequeued.get());
+        assertEquals(0, duplicates.get());
+        int missing = 0;
+        for (int i = 0; i < TOTAL; i++) {
+            if (seen.get(i) == 0) {
+                missing++;
+            }
+        }
+        assertEquals(0, missing);
+    }
+
+    private DispatchQueue<String> newQueue(int inMemoryQueueSize, int batchSize)
+            throws IOException, QueueCreateFailedException {
+        return new DataBlocksOffHeapQueue<>(
+                s -> s.getBytes(StandardCharsets.UTF_8),
+                b -> new String(b, StandardCharsets.UTF_8),
+                "deadlock", Paths.get(folder.newFolder().toURI()),
+                inMemoryQueueSize, batchSize, 4L * 1024L * 1024L * 1024L);
+    }
+
+    private static Thread daemon(String name, Runnable body) {
+        final Thread t = new Thread(body, name);
+        t.setDaemon(true);
+        return t;
+    }
+}

--- a/core/ipc/sink/off-heap/src/test/java/org/opennms/core/ipc/sink/offheap/DataBlocksOffHeapQueueHeadEvictionRaceTest.java
+++ b/core/ipc/sink/off-heap/src/test/java/org/opennms/core/ipc/sink/offheap/DataBlocksOffHeapQueueHeadEvictionRaceTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.core.ipc.sink.offheap;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicIntegerArray;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.opennms.core.ipc.sink.api.DispatchQueue;
+import org.opennms.core.ipc.sink.api.QueueCreateFailedException;
+
+/**
+ * NMS-20271. readData() calls removeHeadBlockIfNeeded() whenever the head is not also the tail,
+ * including for a head that was already empty on entry - so it can run for a head whose flushToDisk()
+ * is racing on another thread. OffHeapDataBlock.size() reads the queue/offHeapQueueSize fields that
+ * flush writes under diskLock, but size() itself only synchronizes on the block's own monitor, which
+ * the flush task never acquires - so without those fields being volatile there is no happens-before
+ * edge, and a reader can observe the post-flush queue == null alongside the pre-flush
+ * offHeapQueueSize == -1, making size() return -1 and removeHeadBlockIfNeeded() evict a block that is
+ * still being written, dropping a whole batch.
+ *
+ * A single-threaded call sequence can't force this reordering on demand - it's a genuine memory-
+ * visibility race, not a logic bug, so this test leans on volume and concurrency (batchSize 1 so
+ * every message flushes and every head check races a flush) to give it a real chance to surface,
+ * rather than proving it deterministically. It can still pass "by luck" even without the volatile
+ * fix, especially on strongly-ordered hardware; treat a failure here as meaningful, but don't treat a
+ * pass as proof the fields don't need to be volatile.
+ */
+public class DataBlocksOffHeapQueueHeadEvictionRaceTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private static final int PRODUCERS = 8;
+    private static final int CONSUMERS = 8;
+    private static final int PER_PRODUCER = 3000;
+    private static final String PADDING = new String(new char[192]).replace('\0', 'x');
+    private static final int TOTAL = PRODUCERS * PER_PRODUCER;
+
+    @Test(timeout = 120_000)
+    public void doesNotDropAHeadBlockRacingAFlush() throws Exception {
+        // batchSize 1 with a tiny in-memory ceiling: every message is its own block and every block
+        // spills off-heap almost immediately, so head checks are constantly racing a flush in flight.
+        final DispatchQueue<String> queue = newQueue(8, 1);
+
+        final AtomicLong dequeued = new AtomicLong();
+        final AtomicLong duplicates = new AtomicLong();
+        final AtomicIntegerArray seen = new AtomicIntegerArray(TOTAL);
+        final CountDownLatch go = new CountDownLatch(1);
+        final CountDownLatch producersDone = new CountDownLatch(PRODUCERS);
+        final CountDownLatch consumersDone = new CountDownLatch(CONSUMERS);
+
+        final List<Thread> threads = new ArrayList<>();
+        for (int p = 0; p < PRODUCERS; p++) {
+            final int id = p;
+            threads.add(daemon("producer-" + p, () -> {
+                try {
+                    go.await();
+                    for (int i = 0; i < PER_PRODUCER; i++) {
+                        queue.enqueue(id + "-" + i + "-" + PADDING, id + "-" + i);
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    producersDone.countDown();
+                }
+            }));
+        }
+        for (int c = 0; c < CONSUMERS; c++) {
+            threads.add(daemon("consumer-" + c, () -> {
+                try {
+                    go.await();
+                    while (dequeued.get() < TOTAL) {
+                        final Map.Entry<String, String> entry = queue.dequeue();
+                        if (entry == null) {
+                            continue;
+                        }
+                        dequeued.incrementAndGet();
+                        final String[] parts = entry.getValue().split("-", 3);
+                        final int index = Integer.parseInt(parts[0]) * PER_PRODUCER + Integer.parseInt(parts[1]);
+                        if (seen.getAndIncrement(index) != 0) {
+                            duplicates.incrementAndGet();
+                        }
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    consumersDone.countDown();
+                }
+            }));
+        }
+
+        threads.forEach(Thread::start);
+        go.countDown();
+
+        producersDone.await(90, TimeUnit.SECONDS);
+        consumersDone.await(30, TimeUnit.SECONDS);
+
+        assertEquals(TOTAL, dequeued.get());
+        assertEquals(0, duplicates.get());
+        int missing = 0;
+        for (int i = 0; i < TOTAL; i++) {
+            if (seen.get(i) == 0) {
+                missing++;
+            }
+        }
+        assertEquals("a block was evicted while its flush was still racing, dropping its batch",
+                0, missing);
+    }
+
+    private DispatchQueue<String> newQueue(int inMemoryQueueSize, int batchSize)
+            throws IOException, QueueCreateFailedException {
+        return new DataBlocksOffHeapQueue<>(
+                s -> s.getBytes(StandardCharsets.UTF_8),
+                b -> new String(b, StandardCharsets.UTF_8),
+                "head-eviction-race", Paths.get(folder.newFolder().toURI()),
+                inMemoryQueueSize, batchSize, 4L * 1024L * 1024L * 1024L);
+    }
+
+    private static Thread daemon(String name, Runnable body) {
+        final Thread t = new Thread(body, name);
+        t.setDaemon(true);
+        return t;
+    }
+}

--- a/core/ipc/sink/off-heap/src/test/java/org/opennms/core/ipc/sink/offheap/OffHeapDataBlockPrefetchPoolTest.java
+++ b/core/ipc/sink/off-heap/src/test/java/org/opennms/core/ipc/sink/offheap/OffHeapDataBlockPrefetchPoolTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.core.ipc.sink.offheap;
+
+import static org.junit.Assert.assertFalse;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.Test;
+
+/**
+ * NMS-20271. notifyNextDataBlock() submits enableQueue() prefetch tasks that block (poll) until an
+ * in-flight flush's Future completes. Those prefetch tasks and flushToDisk()'s own tasks must run on
+ * separate pools: if they shared one pool, enough concurrently-blocked prefetch tasks could occupy
+ * every thread and starve the flush(es) they are waiting on, which are stuck behind them in the same
+ * queue and can never start - the same class of silent wedge NMS-20271 fixed, just relocated onto the
+ * prefetch path. This saturates OffHeapDataBlock.prefetchExecutorService with blocked enableQueue()
+ * calls and asserts a flush on a different block (which only ever needs executorService) still
+ * completes promptly.
+ */
+public class OffHeapDataBlockPrefetchPoolTest {
+
+    /** matches Executors.newFixedThreadPool(10) in OffHeapDataBlock */
+    private static final int POOL_SIZE = 10;
+
+    @Test(timeout = 20_000)
+    public void flushIsNotStarvedByPrefetchPool() throws Exception {
+        // x's flush never completes for the life of the test (writeData blocks on a latch we never
+        // release until cleanup), so every prefetch task waiting on it stays parked in enableQueue().
+        final CountDownLatch xWriteGate = new CountDownLatch(1);
+        final ControllableBlock<String> x = new ControllableBlock<>(1, xWriteGate, 0L);
+        x.enqueue("k", "v");
+
+        final List<Future<?>> waiters = new ArrayList<>();
+        for (int i = 0; i < POOL_SIZE; i++) {
+            waiters.add(OffHeapDataBlock.prefetchExecutorService.submit(() -> {
+                try {
+                    x.enableQueue();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }));
+        }
+        // let the pool actually dispatch all POOL_SIZE waiters before relying on it being saturated
+        Thread.sleep(500);
+
+        final ExecutorService probe = Executors.newSingleThreadExecutor();
+        try {
+            // b is unrelated to x; its flush only ever needs executorService, which the ten blocked
+            // waiters above never touch once the pools are properly separated.
+            final ControllableBlock<String> b = new ControllableBlock<>(1, null, 100L);
+            final Future<?> flushed = probe.submit(() -> {
+                b.enqueue("k", "v");
+                try {
+                    b.peek();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            boolean timedOut = false;
+            try {
+                flushed.get(5, TimeUnit.SECONDS);
+            } catch (TimeoutException e) {
+                timedOut = true;
+            }
+            assertFalse("flush on a separate block stalled while the prefetch pool was saturated; "
+                    + "flush and prefetch tasks must not share a thread pool", timedOut);
+        } finally {
+            probe.shutdownNow();
+            xWriteGate.countDown();
+            waiters.forEach(f -> f.cancel(true));
+        }
+    }
+
+    /**
+     * Minimal OffHeapDataBlock whose disk I/O is fully controllable: writeData either blocks on a
+     * gate (to simulate a flush that never finishes) or sleeps a fixed delay (to simulate one that
+     * takes a little while), and loadData always returns null so toMemory() completes without
+     * needing a real round trip.
+     */
+    private static final class ControllableBlock<T> extends OffHeapDataBlock<T> {
+        private final CountDownLatch writeGate;
+        private final long writeDelayMillis;
+
+        ControllableBlock(int queueSize, CountDownLatch writeGate, long writeDelayMillis) {
+            super(null, queueSize, o -> new byte[0], b -> null, null);
+            this.writeGate = writeGate;
+            this.writeDelayMillis = writeDelayMillis;
+        }
+
+        @Override
+        void writeData(String key, byte[] data) {
+            try {
+                if (writeGate != null) {
+                    writeGate.await();
+                } else if (writeDelayMillis > 0) {
+                    Thread.sleep(writeDelayMillis);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        @Override
+        byte[] loadData(String key) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Discovered while investigating a flaky test case.

### All Contributors

* [x] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20271

