### PR TITLE
perf(collectd): build metadata scopes lazily during collection

### DIFF
--- a/features/collection/client-rpc/src/main/java/org/opennms/netmgt/collection/client/rpc/CollectorRequestBuilderImpl.java
+++ b/features/collection/client-rpc/src/main/java/org/opennms/netmgt/collection/client/rpc/CollectorRequestBuilderImpl.java
@@ -31,6 +31,7 @@ import java.util.concurrent.CompletionException;
 
 import org.opennms.core.mate.api.FallbackScope;
 import org.opennms.core.mate.api.Interpolator;
+import org.opennms.core.mate.api.LazyScope;
 import org.opennms.core.mate.api.MetadataConstants;
 import org.opennms.core.mate.api.Scope;
 import org.opennms.core.rpc.api.RpcRequest;
@@ -132,9 +133,13 @@ public class CollectorRequestBuilderImpl implements CollectorRequestBuilder {
             throw new IllegalArgumentException("Agent is required.");
         }
 
+        // Each entity scope costs a read-only transaction and several selects, so build
+        // them on demand: no metadata expression means no lookup at all, and an expression
+        // resolved from the node scope never touches the interface scope because
+        // FallbackScope stops at the first match.
         final Scope scope = new FallbackScope(
-                this.client.getEntityScopeProvider().getScopeForNode(agent.getNodeId()),
-                this.client.getEntityScopeProvider().getScopeForInterface(agent.getNodeId(), InetAddressUtils.toIpAddrString(agent.getAddress()))
+                new LazyScope(() -> this.client.getEntityScopeProvider().getScopeForNode(agent.getNodeId())),
+                new LazyScope(() -> this.client.getEntityScopeProvider().getScopeForInterface(agent.getNodeId(), InetAddressUtils.toIpAddrString(agent.getAddress())))
         );
 
         final Map<String, Object> interpolatedAttributes = Interpolator.interpolateObjects(attributes, scope);

--- a/features/collection/core/src/main/java/org/opennms/netmgt/collection/core/CollectionSpecification.java
+++ b/features/collection/core/src/main/java/org/opennms/netmgt/collection/core/CollectionSpecification.java
@@ -34,6 +34,7 @@ import org.opennms.core.mate.api.EmptyScope;
 import org.opennms.core.mate.api.EmptyScopeProvider;
 import org.opennms.core.mate.api.EntityScopeProvider;
 import org.opennms.core.mate.api.Interpolator;
+import org.opennms.core.mate.api.LazyScope;
 import org.opennms.core.mate.api.Scope;
 import org.opennms.core.mate.api.ScopeProvider;
 import org.opennms.core.rpc.api.RpcExceptionHandler;
@@ -187,7 +188,11 @@ public class CollectionSpecification {
      * @return A read only Map instance
      */
     public ServiceParameters getServiceParameters() {
-        return new ServiceParameters(Collections.unmodifiableMap(Interpolator.interpolateObjects(m_parameters, scopeProvider.getScope())));
+        // The returned map is a lazy transformValues view, so interpolation runs per read.
+        // Wrap the scope so the entity lookups behind it are only paid if a parameter
+        // actually contains a metadata expression, and then only once (LazyScope memoizes).
+        final Scope scope = new LazyScope(scopeProvider::getScope);
+        return new ServiceParameters(Collections.unmodifiableMap(Interpolator.interpolateObjects(m_parameters, scope)));
     }
 
     private boolean isTrue(String stg) {


### PR DESCRIPTION
## Problem

Collectd builds the Mate entity scopes eagerly, twice per interface per collection cycle, regardless of whether any service parameter contains a metadata expression.

- `CollectionSpecification.getServiceParameters()` resolves its `ScopeProvider` before handing the scope to the `Interpolator`. `Interpolator.interpolateObjects` returns a lazy Guava `transformValues` view, so the substitution is deferred, but the scope construction has already happened.
- `CollectorRequestBuilderImpl.execute()` constructs a `FallbackScope` over the node and interface scopes up front, then uses it for both the attribute pass and the runtime-attribute pass.

Each scope build opens a read-only transaction and issues several selects:

- `getScopeForNode()` loads the node, forces the lazily mapped `node_metadata` element collection, and pulls the asset record (a `@OneToOne(mappedBy=…)` that Hibernate cannot proxy).
- `getScopeForInterface()` loads the `ipinterface` row and forces `ipinterface_metadata`.

That is roughly ten selects and four read-only transactions per interface per collection cycle, paid by every deployment even with no metadata expressions configured anywhere. On 10k collected interfaces at a 300s interval that is on the order of 300 selects/s of pure scope construction.

## Change

Wrap both call sites in `LazyScope`, which defers construction to the first lookup and memoizes the result. The `Interpolator` only consults a scope when the input actually contains an expression, so the cost becomes demand-driven.

In `CollectorRequestBuilderImpl` the two scopes are wrapped individually rather than the combined `FallbackScope`, so an expression that resolves from node metadata never triggers the interface lookup: `FallbackScope` stops at the first match.

This applies to the collection dispatch path the same treatment the thresholding path already received in NMS-16966 and NMS-20007. `LazyScope` exists today and is used only by thresholding.

Expected selects per interface per cycle:

| Service configuration | before | after |
| --- | --- | --- |
| No `${...}` in any parameter | ~10 | 0 |
| `${requisition:collection\|detector:collection\|default}` resolving from node metadata | ~10 | ~6 |
| Expression resolving only from interface metadata | ~10 | ~10 |

No functional change is intended: the resolved values and their precedence are unchanged, only the point in time at which the lookups happen.

## Why draft

Open questions I have not settled, and the reason this is not ready to merge:

- **No Jira issue yet.** Needs an NMS ticket and the commit/PR title adjusted to match the project convention if that is wanted here.
- **Not measured.** The query counts above are read off the Hibernate mappings by inspection, not observed. Wants a `pg_stat_statements` or `log_statement=all` before/after on a node with a few hundred interfaces.
- **Transaction timing moves.** The read-only transaction now runs at first `scope.get()` rather than at method entry. Same thread and same call in the common path, but `CollectableService`'s constructor hands its `ServiceParameters` to `thresholdingService.createSession` and holds it for the service lifetime, so a first placeholder read could open a transaction on a thresholding thread instead of during scheduling. Staleness is unchanged: that scope was already cached for the service lifetime.
- **Pre-existing lazy-init risk, unchanged but worth a test.** `${node:location}` and `${node:area}` dereference a LAZY `@ManyToOne` proxy after the transaction has closed (`EntityScopeProviderImpl` lines 127-128). This patch neither introduces nor fixes that, but deferring the build could change whether a session happens to be bound. Wants a test with `node:location` in a collectd parameter.
- **Not done here:** collapsing the remaining two scope builds per cycle into one shared instance. That needs the scope plumbed from `CollectableService.doCollection()` through `CollectionSpecification.collect()` into the builder, i.e. a `withScope(Scope)` on the `CollectorRequestBuilder` interface, and `features/collection/api` has no dependency on `core/mate/api` today. Better as its own change.
- **Possible wider fix:** `FallBackScopeProvider.getScope()` maps over all children eagerly. Making that lazy centrally would fix every consumer at once, with a correspondingly wider blast radius. Deliberately left out of this PR.

## Verification

`mvn -pl features/collection/core,features/collection/client-rpc -DskipTests compile` passes (exit 0). No tests have been run yet.
