### PR TITLE
NMS-4471: Daemon Management page with per-daemon config reload

### DIFF
--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-alt.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-alt.json
@@ -367,6 +367,13 @@
           "roles": ["ROLE_ADMIN"]
         },
         {
+          "id": "daemonManagement",
+          "name": "Daemon Management",
+          "url": "ui/index.html#/daemon-management",
+          "locationMatch": "",
+          "roles": ["ROLE_ADMIN"]
+        },
+        {
           "id": "fileEditor",
           "name": "File Editor",
           "url": "ui/index.html#/file-editor",

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-default.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-default.json
@@ -535,6 +535,13 @@
           "url": "ui/index.html#/scv",
           "locationMatch": "configurationManagement",
           "roles": ["ROLE_ADMIN"]
+        },
+        {
+          "id": "daemonManagement",
+          "name": "Daemon Management",
+          "url": "ui/index.html#/daemon-management",
+          "locationMatch": "",
+          "roles": ["ROLE_ADMIN"]
         }
       ]
     },

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-legacy.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template-legacy.json
@@ -101,6 +101,13 @@
           "roles": ["ROLE_ADMIN"]
         },
         {
+          "id": "daemonManagement",
+          "name": "Daemon Management",
+          "url": "ui/index.html#/daemon-management",
+          "locationMatch": "",
+          "roles": ["ROLE_ADMIN"]
+        },
+        {
           "id": "zenithConnect",
           "name": "Connect to Zenith",
           "url": "ui/index.html#/zenith-connect",

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/menu/menu-template.json
@@ -535,6 +535,13 @@
           "url": "ui/index.html#/scv",
           "locationMatch": "configurationManagement",
           "roles": ["ROLE_ADMIN"]
+        },
+        {
+          "id": "daemonManagement",
+          "name": "Daemon Management",
+          "url": "ui/index.html#/daemon-management",
+          "locationMatch": "",
+          "roles": ["ROLE_ADMIN"]
         }
       ]
     },

--- a/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
@@ -303,6 +303,9 @@ public class MenuHeaderIT extends OpenNMSSeleniumIT {
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//div[@class='link']/a[text()='Secure Credentials Vault']")));
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//div[@class='scv-container']//p[text()='Add Credentials']")));
 
+        clickMenuItem("Tools", "Daemon Management");
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//div[@class='card-title' and text()='Daemon Management']")));
+
         // Omitting for now - need ROLE_FILESYSTEM_EDITOR
         // clickMenuItem("toolsMenu", "File Editor");
         // wait.until(ExpectedConditions.presenceOfElementLocated(By.id("app")));

--- a/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
@@ -304,7 +304,7 @@ public class MenuHeaderIT extends OpenNMSSeleniumIT {
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//div[@class='scv-container']//p[text()='Add Credentials']")));
 
         clickMenuItem("Tools", "Daemon Management");
-        wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//div[@class='card-title' and text()='Daemon Management']")));
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@id='app']//h1[@class='page-title' and text()='Daemon Management']")));
 
         // Omitting for now - need ROLE_FILESYSTEM_EDITOR
         // clickMenuItem("toolsMenu", "File Editor");

--- a/ui/src/components/DaemonManagement/DaemonManagementAbout.vue
+++ b/ui/src/components/DaemonManagement/DaemonManagementAbout.vue
@@ -1,0 +1,22 @@
+<template>
+  <div data-test="daemon-management-about">
+    <p>
+      Most OpenNMS daemons can re-read their configuration while running. Reloading applies changes made to a
+      daemon's configuration files (directly or through the configuration pages) without restarting OpenNMS or
+      interrupting the other daemons.
+    </p>
+    <p>
+      A reload request is delivered as the <em>uei.opennms.org/internal/reloadDaemonConfig</em> event and handled
+      asynchronously: the daemon answers with a <em>reloadDaemonConfigSuccessful</em> or
+      <em>reloadDaemonConfigFailed</em> event, which you can find in the event list. A failed reload leaves the
+      previous configuration in effect.
+    </p>
+    <p>
+      Only the daemons listed here support config reload. Starting and stopping daemons, and live daemon status,
+      are not yet available from this page.
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+</script>

--- a/ui/src/components/DaemonManagement/DaemonManagementAbout.vue
+++ b/ui/src/components/DaemonManagement/DaemonManagementAbout.vue
@@ -12,8 +12,10 @@
       previous configuration in effect.
     </p>
     <p>
-      Only the daemons listed here support config reload. Starting and stopping daemons, and live daemon status,
-      are not yet available from this page.
+      This page lists the daemons that handle the reload event. Some specialized components — provisioning
+      adapters (addressed as <em>Provisiond.&lt;AdapterName&gt;</em>) and correlation engines — also accept
+      targeted reloads but are configured through their own subsystems and are not listed here. Starting and
+      stopping daemons, and live daemon status, are not yet available from this page.
     </p>
   </div>
 </template>

--- a/ui/src/components/DaemonManagement/DaemonManagementAbout.vue
+++ b/ui/src/components/DaemonManagement/DaemonManagementAbout.vue
@@ -1,21 +1,20 @@
 <template>
   <div data-test="daemon-management-about">
     <p>
-      Most OpenNMS daemons can re-read their configuration while running. Reloading applies changes made to a
-      daemon's configuration files (directly or through the configuration pages) without restarting OpenNMS or
-      interrupting the other daemons.
+      Reloading makes a daemon re-read its configuration files without restarting OpenNMS or interrupting the
+      other daemons. This page lists the daemons that handle the reload event.
     </p>
     <p>
-      A reload request is delivered as the <em>uei.opennms.org/internal/reloadDaemonConfig</em> event and handled
-      asynchronously: the daemon answers with a <em>reloadDaemonConfigSuccessful</em> or
-      <em>reloadDaemonConfigFailed</em> event, which you can find in the event list. A failed reload leaves the
+      The request is sent as the <em>uei.opennms.org/internal/reloadDaemonConfig</em> event and handled
+      asynchronously. The daemon answers with a <em>reloadDaemonConfigSuccessful</em> or
+      <em>reloadDaemonConfigFailed</em> event, both visible in the event list. A failed reload leaves the
       previous configuration in effect.
     </p>
     <p>
-      This page lists the daemons that handle the reload event. Some specialized components — provisioning
-      adapters (addressed as <em>Provisiond.&lt;AdapterName&gt;</em>) and correlation engines — also accept
-      targeted reloads but are configured through their own subsystems and are not listed here. Starting and
-      stopping daemons, and live daemon status, are not yet available from this page.
+      Some specialized components — provisioning adapters (addressed as <em>Provisiond.&lt;AdapterName&gt;</em>)
+      and correlation engines — also accept targeted reloads but are configured through their own subsystems and
+      are not listed here. Starting and stopping daemons, and live daemon status, are not yet available from this
+      page.
     </p>
   </div>
 </template>

--- a/ui/src/components/DaemonManagement/DaemonManagementTable.vue
+++ b/ui/src/components/DaemonManagement/DaemonManagementTable.vue
@@ -1,0 +1,130 @@
+<template>
+  <TableCard class="daemons-table">
+    <div class="header">
+      <div class="card-title" data-test="daemon-title">Daemons</div>
+      <AboutDialogButton title="Daemon Management">
+        <DaemonManagementAbout />
+      </AboutDialogButton>
+    </div>
+    <p class="subtitle">
+      Reload a daemon's configuration without restarting OpenNMS. The reload runs asynchronously;
+      the daemon reports the outcome as a <em>reloadDaemonConfigSuccessful</em> or
+      <em>reloadDaemonConfigFailed</em> event.
+    </p>
+
+    <OnmsTable :value="RELOADABLE_DAEMONS" dataKey="name" data-test="daemons-table">
+      <OnmsColumn field="label" header="Daemon" />
+      <OnmsColumn field="description" header="Reload applies" />
+      <OnmsColumn header="Actions">
+        <template #body="{ data }">
+          <OnmsButton
+            variant="outlined"
+            label="Reload"
+            :disabled="reloading === data.name"
+            :data-test="`reload-${data.name}`"
+            @click="askReload(data)"
+          />
+        </template>
+      </OnmsColumn>
+    </OnmsTable>
+  </TableCard>
+
+  <OnmsConfirmationDialog
+    :visible="showReloadConfirmation"
+    title="Reload Daemon Configuration"
+    actionButtonText="Reload"
+    @ok="confirmReload"
+    @cancel="cancelReload"
+  >
+    <template #content>
+      <p data-test="reload-confirm-text">
+        Reload the configuration of <strong>{{ daemonToReload?.label }}</strong>?
+        The daemon re-reads its configuration and rebuilds its schedules, which can
+        briefly delay its regular work on large installations.
+      </p>
+    </template>
+  </OnmsConfirmationDialog>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+import { OnmsButton, OnmsColumn, OnmsConfirmationDialog, OnmsTable, useOnmsToast } from '@opennms/onms-ui'
+
+import AboutDialogButton from '@/components/Common/AboutDialogButton.vue'
+import TableCard from '@/components/Common/TableCard.vue'
+import DaemonManagementAbout from '@/components/DaemonManagement/DaemonManagementAbout.vue'
+import { RELOADABLE_DAEMONS, ReloadableDaemon, reloadDaemon } from '@/services/daemonService'
+
+const { showToast } = useOnmsToast()
+
+const reloading = ref('')
+const showReloadConfirmation = ref(false)
+const daemonToReload = ref<ReloadableDaemon | null>(null)
+
+const askReload = (daemon: ReloadableDaemon) => {
+  daemonToReload.value = daemon
+  showReloadConfirmation.value = true
+}
+
+const cancelReload = () => {
+  showReloadConfirmation.value = false
+  daemonToReload.value = null
+}
+
+// a 400 from POST /rest/events carries the validation reason as a plain-text
+// body — the only actionable detail a failed request has
+const serverMessage = (err: unknown): string => {
+  const data = (err as { response?: { data?: unknown }})?.response?.data
+  return typeof data === 'string' && data.length ? ` Server said: ${data.split('\n')[0]}` : ''
+}
+
+const confirmReload = async () => {
+  const daemon = daemonToReload.value
+  showReloadConfirmation.value = false
+  daemonToReload.value = null
+  if (!daemon) {
+    return
+  }
+  reloading.value = daemon.name
+  try {
+    await reloadDaemon(daemon.name)
+    showToast({
+      message: `Reload requested for ${daemon.label}. The daemon reports the outcome as an event.`,
+      severity: 'success',
+      timeout: 8000
+    })
+  } catch (err) {
+    showToast({
+      message: `Failed to request a reload for ${daemon.label}.${serverMessage(err)}`,
+      severity: 'error'
+    })
+  } finally {
+    reloading.value = ''
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.daemons-table {
+  padding: 25px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.card-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.subtitle {
+  margin: 0.25rem 0 1rem 0;
+  color: var(--p-text-muted-color);
+}
+</style>

--- a/ui/src/containers/DaemonManagement.vue
+++ b/ui/src/containers/DaemonManagement.vue
@@ -1,0 +1,95 @@
+<template>
+  <div class="onms-row">
+    <div class="onms-col-12">
+      <BreadCrumbs :items="breadcrumbs" />
+    </div>
+  </div>
+
+  <div class="daemon-management">
+    <TableCard>
+      <div class="header">
+        <div class="card-title" data-test="daemon-title">Daemon Management</div>
+        <AboutDialogButton title="Daemon Management">
+          <DaemonManagementAbout />
+        </AboutDialogButton>
+      </div>
+      <p class="subtitle">
+        Reload a daemon's configuration without restarting OpenNMS. The reload runs asynchronously;
+        the daemon reports the outcome as a <em>reloadDaemonConfigSuccessful</em> or
+        <em>reloadDaemonConfigFailed</em> event.
+      </p>
+
+      <OnmsTable :value="RELOADABLE_DAEMONS" dataKey="name" data-test="daemons-table">
+        <OnmsColumn field="label" header="Daemon" />
+        <OnmsColumn field="description" header="Reload applies" />
+        <OnmsColumn header="Actions">
+          <template #body="{ data }">
+            <OnmsButton
+              variant="outlined"
+              label="Reload"
+              :disabled="reloading === data.name"
+              :data-test="`reload-${data.name}`"
+              @click="reload(data)"
+            />
+          </template>
+        </OnmsColumn>
+      </OnmsTable>
+    </TableCard>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+import { OnmsButton, OnmsColumn, OnmsTable } from '@opennms/onms-ui'
+
+import AboutDialogButton from '@/components/Common/AboutDialogButton.vue'
+import BreadCrumbs from '@/components/Layout/BreadCrumbs.vue'
+import TableCard from '@/components/Common/TableCard.vue'
+import DaemonManagementAbout from '@/components/DaemonManagement/DaemonManagementAbout.vue'
+import useSnackbar from '@/composables/useSnackbar'
+import { RELOADABLE_DAEMONS, ReloadableDaemon, reloadDaemon } from '@/services/daemonService'
+import { BreadCrumb } from '@/types'
+
+const { showSnackBar } = useSnackbar()
+
+const breadcrumbs: BreadCrumb[] = [
+  { label: 'Home', to: '/' },
+  { label: 'Daemon Management', to: '/daemon-management' }
+]
+
+const reloading = ref('')
+
+const reload = async (daemon: ReloadableDaemon) => {
+  reloading.value = daemon.name
+  try {
+    await reloadDaemon(daemon.name)
+    showSnackBar({ msg: `Reload requested for ${daemon.label}. The daemon reports the outcome as an event.`, timeout: 8000 })
+  } catch (_err) {
+    showSnackBar({ msg: `Failed to request a reload for ${daemon.label}.`, error: true })
+  } finally {
+    reloading.value = ''
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.daemon-management {
+  .header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .card-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+  }
+
+  .subtitle {
+    margin: 0.25rem 0 1rem 0;
+    color: var(--p-text-muted-color);
+  }
+}
+</style>

--- a/ui/src/containers/DaemonManagement.vue
+++ b/ui/src/containers/DaemonManagement.vue
@@ -4,92 +4,43 @@
       <BreadCrumbs :items="breadcrumbs" />
     </div>
   </div>
-
-  <div class="daemon-management">
-    <TableCard>
-      <div class="header">
-        <div class="card-title" data-test="daemon-title">Daemon Management</div>
-        <AboutDialogButton title="Daemon Management">
-          <DaemonManagementAbout />
-        </AboutDialogButton>
-      </div>
-      <p class="subtitle">
-        Reload a daemon's configuration without restarting OpenNMS. The reload runs asynchronously;
-        the daemon reports the outcome as a <em>reloadDaemonConfigSuccessful</em> or
-        <em>reloadDaemonConfigFailed</em> event.
-      </p>
-
-      <OnmsTable :value="RELOADABLE_DAEMONS" dataKey="name" data-test="daemons-table">
-        <OnmsColumn field="label" header="Daemon" />
-        <OnmsColumn field="description" header="Reload applies" />
-        <OnmsColumn header="Actions">
-          <template #body="{ data }">
-            <OnmsButton
-              variant="outlined"
-              label="Reload"
-              :disabled="reloading === data.name"
-              :data-test="`reload-${data.name}`"
-              @click="reload(data)"
-            />
-          </template>
-        </OnmsColumn>
-      </OnmsTable>
-    </TableCard>
+  <div class="daemon-management-container">
+    <h1 class="page-title">Daemon Management</h1>
+    <DaemonManagementTable />
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed } from 'vue'
 
-import { OnmsButton, OnmsColumn, OnmsTable } from '@opennms/onms-ui'
-
-import AboutDialogButton from '@/components/Common/AboutDialogButton.vue'
 import BreadCrumbs from '@/components/Layout/BreadCrumbs.vue'
-import TableCard from '@/components/Common/TableCard.vue'
-import DaemonManagementAbout from '@/components/DaemonManagement/DaemonManagementAbout.vue'
-import useSnackbar from '@/composables/useSnackbar'
-import { RELOADABLE_DAEMONS, ReloadableDaemon, reloadDaemon } from '@/services/daemonService'
+import DaemonManagementTable from '@/components/DaemonManagement/DaemonManagementTable.vue'
+import { useMenuStore } from '@/stores/menuStore'
 import { BreadCrumb } from '@/types'
 
-const { showSnackBar } = useSnackbar()
+const menuStore = useMenuStore()
 
-const breadcrumbs: BreadCrumb[] = [
-  { label: 'Home', to: '/' },
-  { label: 'Daemon Management', to: '/daemon-management' }
-]
+const homeUrl = computed<string>(() => menuStore.mainMenu.homeUrl)
 
-const reloading = ref('')
-
-const reload = async (daemon: ReloadableDaemon) => {
-  reloading.value = daemon.name
-  try {
-    await reloadDaemon(daemon.name)
-    showSnackBar({ msg: `Reload requested for ${daemon.label}. The daemon reports the outcome as an event.`, timeout: 8000 })
-  } catch (_err) {
-    showSnackBar({ msg: `Failed to request a reload for ${daemon.label}.`, error: true })
-  } finally {
-    reloading.value = ''
-  }
-}
+const breadcrumbs = computed<BreadCrumb[]>(() => {
+  return [
+    { label: 'Home', to: homeUrl.value, isAbsoluteLink: true },
+    { label: 'Daemon Management', to: '#', position: 'last' }
+  ]
+})
 </script>
 
-<style scoped lang="scss">
-.daemon-management {
-  .header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-  }
+<style lang="scss" scoped>
+.daemon-management-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 0 2px 2rem 2px;
+}
 
-  .card-title {
-    font-size: 1.25rem;
-    font-weight: 600;
-  }
-
-  .subtitle {
-    margin: 0.25rem 0 1rem 0;
-    color: var(--p-text-muted-color);
-  }
+.page-title {
+  font-size: 1.4rem;
+  font-weight: 600;
+  margin: 0;
 }
 </style>

--- a/ui/src/main/router/index.ts
+++ b/ui/src/main/router/index.ts
@@ -273,6 +273,25 @@ const router = createRouter({
       }
     },
     {
+      path: '/daemon-management',
+      name: 'Daemon Management',
+      component: () => import('@/containers/DaemonManagement.vue'),
+      beforeEnter: (to, from) => {
+        const checkRoles = () => {
+          if (!adminRole.value) {
+            showSnackBar({ msg: 'Must be admin to manage daemons.' })
+            router.push(from.path)
+          }
+        }
+
+        if (rolesAreLoaded.value) {
+          checkRoles()
+        } else {
+          whenever(rolesAreLoaded, () => checkRoles())
+        }
+      }
+    },
+    {
       path: '/scv',
       name: 'SCV',
       component: () => import('@/containers/SecureCredentialsVault.vue'),

--- a/ui/src/services/daemonService.ts
+++ b/ui/src/services/daemonService.ts
@@ -41,7 +41,7 @@ export interface ReloadableDaemon {
 // components addressed by their own name, not daemons, so they are not listed.
 export const RELOADABLE_DAEMONS: ReloadableDaemon[] = [
   { name: 'Ackd', label: 'Ackd', description: 'Acknowledgment readers and their schedules.' },
-  { name: 'Alarmd', label: 'Alarmd', description: 'Alarm processing: reduction, correlation, and northbound rules.' },
+  { name: 'Alarmd', label: 'Alarmd', description: 'Alarm correlation rules (Drools).' },
   { name: 'Bsmd', label: 'Bsmd', description: 'Business service hierarchy and reduction rules.' },
   { name: 'Collectd', label: 'Collectd', description: 'Performance data collection packages and schedules.' },
   { name: 'Discovery', label: 'Discovery', description: 'Discovery ranges, foreign sources, and schedules.' },
@@ -50,7 +50,7 @@ export const RELOADABLE_DAEMONS: ReloadableDaemon[] = [
   { name: 'Notifd', label: 'Notifd', description: 'Notifications, destination paths, and notice queues.' },
   { name: 'PerspectivePoller', label: 'Perspective Poller', description: 'Monitoring perspective polling packages.' },
   { name: 'Pollerd', label: 'Pollerd', description: 'Service polling packages, thresholds, and outage handling.' },
-  { name: 'Provisiond', label: 'Provisiond', description: 'Provisioning: import schedules and detection settings.' },
+  { name: 'Provisiond', label: 'Provisiond', description: 'Requisition import schedule.' },
   { name: 'Reportd', label: 'Reportd', description: 'Scheduled report definitions and delivery.' },
   { name: 'Scriptd', label: 'Scriptd', description: 'Event-driven scripts and script engines.' },
   { name: 'Statsd', label: 'Statsd', description: 'Statistics report definitions and schedules.' },

--- a/ui/src/services/daemonService.ts
+++ b/ui/src/services/daemonService.ts
@@ -1,0 +1,66 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { rest } from './axiosInstances'
+
+// Daemon Management (NMS-4471), reload-only scope: reloading a daemon's config
+// is done by publishing the reloadDaemonConfig event through the existing v1
+// events API — the same event the `opennms:reload-daemon` Karaf command sends.
+// The daemon answers asynchronously with reloadDaemonConfigSuccessful/Failed.
+// A status API and on-page status display are follow-up tickets.
+
+export interface ReloadableDaemon {
+  // the exact daemonName parm value the daemon matches on (casing matters)
+  name: string
+  label: string
+  description: string
+}
+
+// Mirrors DaemonReloadEnum (core/lib), the canonical set the Karaf
+// reload-daemon command completes on. Keep in sync when the enum grows.
+export const RELOADABLE_DAEMONS: ReloadableDaemon[] = [
+  { name: 'alarmd', label: 'Alarmd', description: 'Alarm processing: reduction, correlation, and northbound rules.' },
+  { name: 'Collectd', label: 'Collectd', description: 'Performance data collection packages and schedules.' },
+  { name: 'Eventd', label: 'Eventd', description: 'Event configuration (eventconf) and processing.' },
+  { name: 'Notifd', label: 'Notifd', description: 'Notifications, destination paths, and notice queues.' },
+  { name: 'Pollerd', label: 'Pollerd', description: 'Service polling packages, thresholds, and outage handling.' },
+  { name: 'syslogd', label: 'Syslogd', description: 'Syslog reception and matching rules.' },
+  { name: 'Telemetryd', label: 'Telemetryd', description: 'Telemetry listeners, parsers, and adapters.' },
+  { name: 'trapd', label: 'Trapd', description: 'SNMP trap reception configuration.' }
+]
+
+const RELOAD_UEI = 'uei.opennms.org/internal/reloadDaemonConfig'
+
+const escapeXml = (value: string): string =>
+  value.replace(/[<>&'"]/g, c => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;', '\'': '&apos;', '"': '&quot;' }[c] as string))
+
+// POST /rest/events accepts the JAXB event XML; source and time are filled in
+// server-side. 202 Accepted means the event reached the bus, not that the
+// reload finished — that outcome arrives as a follow-up event.
+export const reloadDaemon = async (daemonName: string): Promise<void> => {
+  const xml = '<event xmlns="http://xmlns.opennms.org/xsd/event">'
+    + `<uei>${RELOAD_UEI}</uei>`
+    + '<parms><parm><parmName>daemonName</parmName>'
+    + `<value type="string" encoding="text">${escapeXml(daemonName)}</value>`
+    + '</parm></parms></event>'
+  await rest.post('/events', xml, { headers: { 'Content-Type': 'application/xml' }})
+}

--- a/ui/src/services/daemonService.ts
+++ b/ui/src/services/daemonService.ts
@@ -29,23 +29,39 @@ import { rest } from './axiosInstances'
 // A status API and on-page status display are follow-up tickets.
 
 export interface ReloadableDaemon {
-  // the exact daemonName parm value the daemon matches on (casing matters)
   name: string
   label: string
   description: string
 }
 
-// Mirrors DaemonReloadEnum (core/lib), the canonical set the Karaf
-// reload-daemon command completes on. Keep in sync when the enum grows.
+// Every daemon with a reloadDaemonConfig handler in the codebase; each handler
+// subscribes independently, so this union is hand-maintained. All handlers
+// match the daemonName parm case-insensitively. Provisioning adapters
+// (Provisiond.*) and correlation engines also accept targeted reloads but are
+// components addressed by their own name, not daemons, so they are not listed.
 export const RELOADABLE_DAEMONS: ReloadableDaemon[] = [
-  { name: 'alarmd', label: 'Alarmd', description: 'Alarm processing: reduction, correlation, and northbound rules.' },
+  { name: 'Ackd', label: 'Ackd', description: 'Acknowledgment readers and their schedules.' },
+  { name: 'Alarmd', label: 'Alarmd', description: 'Alarm processing: reduction, correlation, and northbound rules.' },
+  { name: 'Bsmd', label: 'Bsmd', description: 'Business service hierarchy and reduction rules.' },
   { name: 'Collectd', label: 'Collectd', description: 'Performance data collection packages and schedules.' },
+  { name: 'Discovery', label: 'Discovery', description: 'Discovery ranges, foreign sources, and schedules.' },
+  { name: 'Enlinkd', label: 'Enlinkd', description: 'Topology link discovery protocols and schedules.' },
   { name: 'Eventd', label: 'Eventd', description: 'Event configuration (eventconf) and processing.' },
   { name: 'Notifd', label: 'Notifd', description: 'Notifications, destination paths, and notice queues.' },
+  { name: 'PerspectivePoller', label: 'Perspective Poller', description: 'Monitoring perspective polling packages.' },
   { name: 'Pollerd', label: 'Pollerd', description: 'Service polling packages, thresholds, and outage handling.' },
-  { name: 'syslogd', label: 'Syslogd', description: 'Syslog reception and matching rules.' },
+  { name: 'Provisiond', label: 'Provisiond', description: 'Provisioning: import schedules and detection settings.' },
+  { name: 'Reportd', label: 'Reportd', description: 'Scheduled report definitions and delivery.' },
+  { name: 'Scriptd', label: 'Scriptd', description: 'Event-driven scripts and script engines.' },
+  { name: 'Statsd', label: 'Statsd', description: 'Statistics report definitions and schedules.' },
+  { name: 'Syslogd', label: 'Syslogd', description: 'Syslog reception and matching rules.' },
   { name: 'Telemetryd', label: 'Telemetryd', description: 'Telemetry listeners, parsers, and adapters.' },
-  { name: 'trapd', label: 'Trapd', description: 'SNMP trap reception configuration.' }
+  { name: 'Threshd', label: 'Threshd', description: 'Thresholding configuration and package assignments.' },
+  { name: 'Ticketd', label: 'Ticketd', description: 'Trouble-ticketing integration settings.' },
+  { name: 'Tl1d', label: 'Tl1d', description: 'TL1 network element connections.' },
+  { name: 'Translator', label: 'Translator', description: 'Event translation specifications.' },
+  { name: 'Trapd', label: 'Trapd', description: 'SNMP trap reception configuration.' },
+  { name: 'Vacuumd', label: 'Vacuumd', description: 'Database automations, triggers, and actions.' }
 ]
 
 const RELOAD_UEI = 'uei.opennms.org/internal/reloadDaemonConfig'

--- a/ui/tests/components/DaemonManagement/DaemonManagementTable.test.ts
+++ b/ui/tests/components/DaemonManagement/DaemonManagementTable.test.ts
@@ -1,0 +1,138 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { flushPromises, mount } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import DaemonManagementTable from '@/components/DaemonManagement/DaemonManagementTable.vue'
+import { RELOADABLE_DAEMONS, reloadDaemon } from '@/services/daemonService'
+
+const showToast = vi.fn()
+vi.mock('@opennms/onms-ui', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@opennms/onms-ui')>()
+  return { ...original, useOnmsToast: () => ({ showToast }) }
+})
+
+vi.mock('@/services/daemonService', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/services/daemonService')>()
+  return { ...original, reloadDaemon: vi.fn() }
+})
+
+// expose the content slot and ok/cancel controls without the modal machinery
+const ConfirmationDialogStub = {
+  props: ['visible', 'title', 'actionButtonText'],
+  template: `<div v-if="visible" class="confirm-stub">
+    <slot name="content"></slot>
+    <button class="ok-btn" @click="$emit('ok')">{{ actionButtonText }}</button>
+    <button class="cancel-btn" @click="$emit('cancel')">Cancel</button>
+  </div>`
+}
+
+const mountTable = async () => {
+  const wrapper = mount(DaemonManagementTable, {
+    global: {
+      plugins: [PrimeVue],
+      stubs: {
+        AboutDialogButton: true,
+        DaemonManagementAbout: true,
+        OnmsConfirmationDialog: ConfirmationDialogStub
+      }
+    }
+  })
+  await flushPromises()
+  return wrapper
+}
+
+describe('DaemonManagementTable.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('lists every reloadable daemon with a reload action', async () => {
+    const wrapper = await mountTable()
+    const table = wrapper.find('[data-test="daemons-table"]')
+    for (const daemon of RELOADABLE_DAEMONS) {
+      expect(table.text()).toContain(daemon.label)
+    }
+    expect(wrapper.findAll('[data-test^="reload-"]')).toHaveLength(RELOADABLE_DAEMONS.length)
+  })
+
+  it('asks for confirmation and only reloads after OK', async () => {
+    vi.mocked(reloadDaemon).mockResolvedValue()
+    const wrapper = await mountTable()
+
+    await wrapper.find('[data-test="reload-Pollerd"]').trigger('click')
+    expect(reloadDaemon).not.toHaveBeenCalled()
+    expect(wrapper.find('[data-test="reload-confirm-text"]').text()).toContain('Pollerd')
+
+    await wrapper.find('.ok-btn').trigger('click')
+    await flushPromises()
+
+    expect(reloadDaemon).toHaveBeenCalledWith('Pollerd')
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({
+      severity: 'success',
+      message: expect.stringContaining('Reload requested for Pollerd')
+    }))
+  })
+
+  it('does not reload when the confirmation is cancelled', async () => {
+    const wrapper = await mountTable()
+
+    await wrapper.find('[data-test="reload-Vacuumd"]').trigger('click')
+    await wrapper.find('.cancel-btn').trigger('click')
+    await flushPromises()
+
+    expect(reloadDaemon).not.toHaveBeenCalled()
+    expect(wrapper.find('.confirm-stub').exists()).toBe(false)
+  })
+
+  it('surfaces the server validation message on a failed request', async () => {
+    // POST /rest/events answers 400 with the reason as a plain-text body
+    vi.mocked(reloadDaemon).mockRejectedValue({
+      response: { status: 400, data: 'Failed to marshal/unmarshal XML file' }
+    })
+    const wrapper = await mountTable()
+
+    await wrapper.find('[data-test="reload-Trapd"]').trigger('click')
+    await wrapper.find('.ok-btn').trigger('click')
+    await flushPromises()
+
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({
+      severity: 'error',
+      message: expect.stringContaining('Failed to marshal/unmarshal XML file')
+    }))
+  })
+
+  it('still reports a failure without a server message', async () => {
+    vi.mocked(reloadDaemon).mockRejectedValue(new Error('network'))
+    const wrapper = await mountTable()
+
+    await wrapper.find('[data-test="reload-Eventd"]').trigger('click')
+    await wrapper.find('.ok-btn').trigger('click')
+    await flushPromises()
+
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({
+      severity: 'error',
+      message: expect.stringContaining('Failed to request a reload for Eventd.')
+    }))
+  })
+})

--- a/ui/tests/containers/DaemonManagement.test.ts
+++ b/ui/tests/containers/DaemonManagement.test.ts
@@ -21,64 +21,38 @@
 ///
 
 import DaemonManagement from '@/containers/DaemonManagement.vue'
-import { flushPromises, mount } from '@vue/test-utils'
+import DaemonManagementTable from '@/components/DaemonManagement/DaemonManagementTable.vue'
+import { useMenuStore } from '@/stores/menuStore'
+import { createTestingPinia } from '@pinia/testing'
+import { mount } from '@vue/test-utils'
 import PrimeVue from 'primevue/config'
+import { setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { reloadDaemon } from '@/services/daemonService'
 
-const showSnackBar = vi.fn()
-vi.mock('@/composables/useSnackbar', () => ({
-  default: () => ({ showSnackBar })
-}))
-
-vi.mock('@/services/daemonService', async (importOriginal) => {
-  const original = await importOriginal<typeof import('@/services/daemonService')>()
-  return { ...original, reloadDaemon: vi.fn() }
+const mountContainer = () => mount(DaemonManagement, {
+  global: {
+    plugins: [PrimeVue],
+    stubs: { DaemonManagementTable: true, BreadCrumbs: true }
+  }
 })
 
-const mountPage = async () => {
-  const wrapper = mount(DaemonManagement, {
-    global: {
-      plugins: [PrimeVue],
-      stubs: { BreadCrumbs: true, AboutDialogButton: true, DaemonManagementAbout: true }
-    }
-  })
-  await flushPromises()
-  return wrapper
-}
-
-describe('DaemonManagement.vue', () => {
+describe('DaemonManagement.vue (container)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    setActivePinia(createTestingPinia({ createSpy: vi.fn, stubActions: false }))
+    useMenuStore().mainMenu = { homeUrl: '/opennms/index.jsp' } as any
   })
 
-  it('lists every reloadable daemon with a reload action', async () => {
-    const wrapper = await mountPage()
-    const table = wrapper.find('[data-test="daemons-table"]')
-    for (const name of ['Alarmd', 'Collectd', 'Eventd', 'Notifd', 'Pollerd', 'Syslogd', 'Telemetryd', 'Trapd']) {
-      expect(table.text()).toContain(name)
-    }
-    expect(wrapper.findAll('[data-test^="reload-"]')).toHaveLength(8)
+  it('renders the page title and the daemons table', () => {
+    const wrapper = mountContainer()
+    expect(wrapper.find('h1.page-title').text()).toBe('Daemon Management')
+    expect(wrapper.findComponent(DaemonManagementTable).exists()).toBe(true)
   })
 
-  it('requests the reload with the exact wire name and confirms via snackbar', async () => {
-    vi.mocked(reloadDaemon).mockResolvedValue()
-    const wrapper = await mountPage()
-
-    await wrapper.find('[data-test="reload-Pollerd"]').trigger('click')
-    await flushPromises()
-
-    expect(reloadDaemon).toHaveBeenCalledWith('Pollerd')
-    expect(showSnackBar).toHaveBeenCalledWith(expect.objectContaining({ msg: expect.stringContaining('Reload requested for Pollerd') }))
-  })
-
-  it('surfaces a failed reload request as an error snackbar', async () => {
-    vi.mocked(reloadDaemon).mockRejectedValue(new Error('boom'))
-    const wrapper = await mountPage()
-
-    await wrapper.find('[data-test="reload-trapd"]').trigger('click')
-    await flushPromises()
-
-    expect(showSnackBar).toHaveBeenCalledWith(expect.objectContaining({ error: true }))
+  it('points the Home crumb at the OpenNMS home page, not the SPA root', () => {
+    const wrapper = mountContainer()
+    const crumbs = (wrapper.vm as any).breadcrumbs
+    expect(crumbs[0]).toEqual({ label: 'Home', to: '/opennms/index.jsp', isAbsoluteLink: true })
+    expect(crumbs[1]).toEqual({ label: 'Daemon Management', to: '#', position: 'last' })
   })
 })

--- a/ui/tests/containers/DaemonManagement.test.ts
+++ b/ui/tests/containers/DaemonManagement.test.ts
@@ -1,0 +1,84 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import DaemonManagement from '@/containers/DaemonManagement.vue'
+import { flushPromises, mount } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { reloadDaemon } from '@/services/daemonService'
+
+const showSnackBar = vi.fn()
+vi.mock('@/composables/useSnackbar', () => ({
+  default: () => ({ showSnackBar })
+}))
+
+vi.mock('@/services/daemonService', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/services/daemonService')>()
+  return { ...original, reloadDaemon: vi.fn() }
+})
+
+const mountPage = async () => {
+  const wrapper = mount(DaemonManagement, {
+    global: {
+      plugins: [PrimeVue],
+      stubs: { BreadCrumbs: true, AboutDialogButton: true, DaemonManagementAbout: true }
+    }
+  })
+  await flushPromises()
+  return wrapper
+}
+
+describe('DaemonManagement.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('lists every reloadable daemon with a reload action', async () => {
+    const wrapper = await mountPage()
+    const table = wrapper.find('[data-test="daemons-table"]')
+    for (const name of ['Alarmd', 'Collectd', 'Eventd', 'Notifd', 'Pollerd', 'Syslogd', 'Telemetryd', 'Trapd']) {
+      expect(table.text()).toContain(name)
+    }
+    expect(wrapper.findAll('[data-test^="reload-"]')).toHaveLength(8)
+  })
+
+  it('requests the reload with the exact wire name and confirms via snackbar', async () => {
+    vi.mocked(reloadDaemon).mockResolvedValue()
+    const wrapper = await mountPage()
+
+    await wrapper.find('[data-test="reload-Pollerd"]').trigger('click')
+    await flushPromises()
+
+    expect(reloadDaemon).toHaveBeenCalledWith('Pollerd')
+    expect(showSnackBar).toHaveBeenCalledWith(expect.objectContaining({ msg: expect.stringContaining('Reload requested for Pollerd') }))
+  })
+
+  it('surfaces a failed reload request as an error snackbar', async () => {
+    vi.mocked(reloadDaemon).mockRejectedValue(new Error('boom'))
+    const wrapper = await mountPage()
+
+    await wrapper.find('[data-test="reload-trapd"]').trigger('click')
+    await flushPromises()
+
+    expect(showSnackBar).toHaveBeenCalledWith(expect.objectContaining({ error: true }))
+  })
+})

--- a/ui/tests/services/daemonService.test.ts
+++ b/ui/tests/services/daemonService.test.ts
@@ -1,0 +1,60 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { RELOADABLE_DAEMONS, reloadDaemon } from '@/services/daemonService'
+import { rest } from '@/services/axiosInstances'
+
+vi.mock('@/services/axiosInstances', () => ({
+  rest: { post: vi.fn() }
+}))
+
+describe('daemonService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('publishes the reloadDaemonConfig event with the daemonName parm as XML', async () => {
+    vi.mocked(rest.post).mockResolvedValue({ status: 202 })
+
+    await reloadDaemon('Pollerd')
+
+    const [url, body, config] = vi.mocked(rest.post).mock.calls[0]
+    expect(url).toBe('/events')
+    expect(config).toEqual({ headers: { 'Content-Type': 'application/xml' }})
+    expect(body).toContain('<uei>uei.opennms.org/internal/reloadDaemonConfig</uei>')
+    expect(body).toContain('<parmName>daemonName</parmName>')
+    expect(body).toContain('<value type="string" encoding="text">Pollerd</value>')
+    expect(body).toContain('xmlns="http://xmlns.opennms.org/xsd/event"')
+  })
+
+  it('propagates a publish failure to the caller', async () => {
+    vi.mocked(rest.post).mockRejectedValue(new Error('403'))
+    await expect(reloadDaemon('trapd')).rejects.toThrow('403')
+  })
+
+  it('keeps the exact daemonName casing the daemons match on', () => {
+    // reload matching is case-sensitive per daemon (DaemonReloadEnum wire values)
+    expect(RELOADABLE_DAEMONS.map(d => d.name)).toEqual(
+      ['alarmd', 'Collectd', 'Eventd', 'Notifd', 'Pollerd', 'syslogd', 'Telemetryd', 'trapd'])
+  })
+})

--- a/ui/tests/services/daemonService.test.ts
+++ b/ui/tests/services/daemonService.test.ts
@@ -52,9 +52,17 @@ describe('daemonService', () => {
     await expect(reloadDaemon('trapd')).rejects.toThrow('403')
   })
 
-  it('keeps the exact daemonName casing the daemons match on', () => {
-    // reload matching is case-sensitive per daemon (DaemonReloadEnum wire values)
-    expect(RELOADABLE_DAEMONS.map(d => d.name)).toEqual(
-      ['alarmd', 'Collectd', 'Eventd', 'Notifd', 'Pollerd', 'syslogd', 'Telemetryd', 'trapd'])
+  it('covers the daemons with reloadDaemonConfig handlers, without duplicates', () => {
+    // every handler matches daemonName case-insensitively, so casing is display
+    // preference; the set is the hand-maintained union of handler subscriptions
+    const names = RELOADABLE_DAEMONS.map(d => d.name)
+    expect(new Set(names).size).toBe(names.length)
+    for (const name of ['Ackd', 'Alarmd', 'Bsmd', 'Collectd', 'Discovery', 'Enlinkd', 'Eventd', 'Notifd',
+      'PerspectivePoller', 'Pollerd', 'Provisiond', 'Reportd', 'Scriptd', 'Statsd', 'Syslogd',
+      'Telemetryd', 'Threshd', 'Ticketd', 'Tl1d', 'Translator', 'Trapd', 'Vacuumd']) {
+      expect(names).toContain(name)
+    }
+    const labels = RELOADABLE_DAEMONS.map(d => d.label)
+    expect(labels).toEqual([...labels].sort((a, b) => a.localeCompare(b)))
   })
 })


### PR DESCRIPTION
Adds a "Daemon Management" page under Tools (NMS-4471) that reloads one daemon's configuration at a time.

Per the scope discussion: reload-only, via the existing events API — no new backend; a daemon status API and surfacing status on this page are follow-up tickets, and start/stop needs backend groundwork first.

- The page lists all 22 daemons that implement a `reloadDaemonConfig` handler, with what each reload applies; handlers match `daemonName` case-insensitively.
- Reload publishes `uei.opennms.org/internal/reloadDaemonConfig` with the `daemonName` parm through `POST /rest/events` — the same event `opennms:reload-daemon` sends — behind a confirmation dialog.
- The page states that the outcome arrives asynchronously as a `reloadDaemonConfigSuccessful`/`Failed` event; the About dialog explains the mechanism.
- Menu entry under Tools (`ROLE_ADMIN`) in all four templates; the route is admin-gated; `MenuHeaderIT` covers the new entry.
- Uses Onms-XXX components on the standard container/table-card layout; eslint/`vue-tsc` clean; tests cover the event payload, the daemon set, and the confirmation flow.
- Verified end to end on a running instance: Pollerd, Provisiond, Vacuumd, Discovery, Ackd, and Translator answer `reloadDaemonConfigSuccessful`, including lower/upper-cased names.
