### PR TITLE
NMS-20273: Open side menu submenus on hover, in both rail states

### DIFF
--- a/ui/src/components/Menu/SideMenu.vue
+++ b/ui/src/components/Menu/SideMenu.vue
@@ -116,6 +116,45 @@ const topPanels = computed<OnmsMenuItem[]>(() => {
 
 const tieredMenuRef = ref<any>(null)
 
+// Close any open flyout and drop out of hover mode, so the next hover has to
+// dwell again.
+//
+// With nothing open, clearing `dirty` is the whole job (hide() would have done
+// it as a side effect): TieredMenu leaves it set after hovering an entry that
+// has no submenu, so skipping this would keep the rail in hover mode with no
+// flyout to show for it, and the next hover would open instantly with no dwell.
+//
+// hide() also resets focusedItemInfo to index -1. That is right for a flyout
+// the pointer merely hovered open — hover never focuses the menubar, so there
+// is no position to lose — but not for one the user clicked or tabbed into,
+// where it would discard their place in the menu. So when the menu actually
+// holds focus, put the focused index back on the root entry that was open,
+// which is where TieredMenu itself lands after closing a submenu (see its
+// onItemClick). A deeper position is not restored as-is: it points into a
+// submenu that is now closed, and TieredMenu would resolve the stale index
+// against the root list.
+const closeFlyouts = () => {
+  const menu = tieredMenuRef.value
+
+  if (!menu) {
+    return
+  }
+
+  if (!menu.activeItemPath?.length) {
+    menu.dirty = false
+    return
+  }
+
+  const rootItem = menu.activeItemPath.find((item: { parentKey: string }) => item.parentKey === '')
+  const keepFocus = menu.focused && rootItem
+
+  menu.hide?.()
+
+  if (keepFocus) {
+    menu.focusedItemInfo = { index: rootItem.index, level: 0, parentKey: '' }
+  }
+}
+
 const togglePinned = () => {
   isPinned.value = !isPinned.value
   menuStore.setSideMenuExpanded(isPinned.value)
@@ -126,17 +165,12 @@ const togglePinned = () => {
   clearHoverTimers()
   hoveredItem = null
 
-  // Close any open flyout. Clicking the toggle button already does this via
-  // TieredMenu's outside-click listener; this makes the keyboard shortcut
-  // behave the same — otherwise the flyout would be repositioned mid-way
-  // through the rail's 0.1s width transition and end up with a stale left
-  // offset once the transition finishes. Guarded on an actually-open flyout
-  // (activeItemPath non-empty) because hide() also resets TieredMenu's
-  // focusedItemInfo — calling it unconditionally would throw away a keyboard
-  // user's arrow-navigation position even when there was nothing to close.
-  if (tieredMenuRef.value?.activeItemPath?.length) {
-    tieredMenuRef.value.hide?.()
-  }
+  // Clicking the toggle button already closes the flyout via TieredMenu's
+  // outside-click listener; this makes the keyboard shortcut behave the same —
+  // otherwise the flyout would be repositioned mid-way through the rail's 0.1s
+  // width transition and end up with a stale left offset once the transition
+  // finishes.
+  closeFlyouts()
 }
 
 // --- Hover-to-open flyouts (NMS-20273) -----------------------------------
@@ -185,12 +219,23 @@ const onRailMouseOver = (event: MouseEvent) => {
   const target = event.target as HTMLElement | null
   const item = target?.closest<HTMLElement>('.p-tieredmenu-root-list > .p-tieredmenu-item') ?? null
 
-  if (!item || item === hoveredItem) {
+  if (item === hoveredItem) {
     return
   }
 
-  hoveredItem = item
+  // Also covers the pointer landing on the rail's own chrome — the toggle
+  // button, the gap below the last entry — where item is null. The dwell has
+  // to be cancelled there too: its only guard is `hoveredItem !== item`, so
+  // leaving hoveredItem set would let it fire for an entry the pointer has
+  // already left, opening a flyout under it (reaching for the toggle is the
+  // common case). Clearing hoveredItem also re-arms the dwell if the pointer
+  // comes back to that same entry.
   window.clearTimeout(hoverOpenTimer)
+  hoveredItem = item
+
+  if (!item) {
+    return
+  }
 
   // Already in hover mode: TieredMenu's own mouseenter handler switches
   // flyouts, so no dwell and nothing for us to do.
@@ -222,22 +267,7 @@ const onRailMouseLeave = () => {
   clearHoverTimers()
   hoveredItem = null
 
-  hoverCloseTimer = window.setTimeout(() => {
-    const menu = tieredMenuRef.value
-
-    if (!menu) {
-      return
-    }
-
-    // Same guard as togglePinned: hide() also resets focusedItemInfo, so only
-    // call it when there is actually a flyout to close. Otherwise just drop
-    // out of hover mode, so re-entering the rail needs a fresh dwell.
-    if (menu.activeItemPath?.length) {
-      menu.hide()
-    } else {
-      menu.dirty = false
-    }
-  }, HOVER_CLOSE_DELAY_MS)
+  hoverCloseTimer = window.setTimeout(closeFlyouts, HOVER_CLOSE_DELAY_MS)
 }
 
 // Global shortcut: Ctrl+\ toggles the rail expand/collapse, so the menu can be

--- a/ui/src/components/Menu/SideMenu.vue
+++ b/ui/src/components/Menu/SideMenu.vue
@@ -4,6 +4,8 @@
     id="opennms-sidemenu-vue-container"
     class="onms-side-menu"
     :class="{ 'onms-side-menu--open': isPinned }"
+    @mouseover="onRailMouseOver"
+    @mouseleave="onRailMouseLeave"
   >
     <button
       type="button"
@@ -27,7 +29,7 @@
         <a
           class="onms-side-menu__link"
           v-bind="props.action"
-          v-onms-tooltip="{ value: item.label, disabled: isPinned || !item.topLevel, showDelay: 300 }"
+          v-onms-tooltip="{ value: item.label, disabled: isPinned || !item.topLevel || hasSubmenu, showDelay: HOVER_OPEN_DELAY_MS }"
           :href="item.url || undefined"
           :target="item.target || undefined"
         >
@@ -46,8 +48,9 @@
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
 // We are using PrimeVue TieredMenu directly here, rather than wrapping it in an OnmsUI component.
-// We are reaching into TieredMenu internals (DOM queries in positionFlyouts, hide() in togglePinned),
-// and also not using this anywhere else in the app, so we don't want to add a new OnmsUI component for it.
+// We are reaching into TieredMenu internals (DOM queries in positionFlyouts, hide() in togglePinned,
+// the `dirty` hover flag in the collapsed-rail hover handlers below), and also not using this
+// anywhere else in the app, so we don't want to add a new OnmsUI component for it.
 // If we ever need to use TieredMenu elsewhere, we can wrap it in an OnmsUI component at that time.
 // eslint-disable-next-line no-restricted-imports
 import TieredMenu from 'primevue/tieredmenu'
@@ -86,10 +89,10 @@ const { getIcon } = useMenuIcons()
 const mainMenu = computed<MainMenu>(() => menuStore.mainMenu)
 const plugins = computed<Plugin[]>(() => pluginStore.plugins)
 
-// isPinned is the persisted expanded/collapsed state (toggle button). The rail
-// no longer expands on hover (NMS-20167): submenus follow PrimeVue TieredMenu's
-// default interaction — click to open, hover-to-switch only after that first
-// click — and TieredMenu's own outside-click listener closes any open flyout.
+// isPinned is the persisted expanded/collapsed state (toggle button), and the
+// only thing that sets the rail's width. The rail itself never resizes on
+// hover (NMS-20167) — hover only opens the flyouts, in either state; see the
+// hover handlers below.
 const isPinned = ref<boolean>(menuStore.sideMenuExpanded() ?? false)
 
 const onPerformLogout = async () => {
@@ -117,6 +120,12 @@ const togglePinned = () => {
   isPinned.value = !isPinned.value
   menuStore.setSideMenuExpanded(isPinned.value)
 
+  // The rail is mid-resize and any open flyout is about to be closed below, so
+  // a pending dwell or close timer has nothing left to act on. Dropping
+  // hoveredItem also means the next mouseover re-arms the dwell from scratch.
+  clearHoverTimers()
+  hoveredItem = null
+
   // Close any open flyout. Clicking the toggle button already does this via
   // TieredMenu's outside-click listener; this makes the keyboard shortcut
   // behave the same — otherwise the flyout would be repositioned mid-way
@@ -128,6 +137,107 @@ const togglePinned = () => {
   if (tieredMenuRef.value?.activeItemPath?.length) {
     tieredMenuRef.value.hide?.()
   }
+}
+
+// --- Hover-to-open flyouts (NMS-20273) -----------------------------------
+//
+// Hovering a top-level entry flies its submenu out, in either rail state. What
+// the rail never does on hover is change its own width: an earlier iteration
+// expanded it from under the pointer, and that — rather than the flyouts — was
+// the jarring part. While collapsed, entries that are direct links (Topology,
+// the maps) have no submenu, so they get a label tooltip on the same beat
+// instead; see the v-onms-tooltip binding in the template, which shares this
+// delay. Expanded, their labels are already visible and it stays suppressed.
+//
+// TieredMenu already opens submenus on hover, but only once its internal
+// `dirty` flag is set — normally by a first click. Setting `dirty` the moment
+// the pointer touches the rail makes flyouts fire at every entry the pointer
+// merely passes over on its way elsewhere. So the FIRST entry has to be
+// dwelled on: a delegated mouseover starts the timer, and when it elapses we
+// set `dirty` and re-dispatch mouseenter on the item so PrimeVue's own
+// onItemMouseEnter handler does the opening. After that the rail is in hover
+// mode and TieredMenu switches between entries on its own, with no further
+// dwell, until the pointer leaves the rail.
+const HOVER_OPEN_DELAY_MS = 150
+// Grace period on the way out: a flyout can be clamped away from its item's
+// row (see positionFlyouts), so reaching it may take the pointer briefly
+// outside the rail. Closing instantly would cut that travel off.
+const HOVER_CLOSE_DELAY_MS = 200
+
+let hoverOpenTimer = 0
+let hoverCloseTimer = 0
+let hoveredItem: HTMLElement | null = null
+
+const clearHoverTimers = () => {
+  window.clearTimeout(hoverOpenTimer)
+  window.clearTimeout(hoverCloseTimer)
+  hoverOpenTimer = 0
+  hoverCloseTimer = 0
+}
+
+// mouseover bubbles (mouseenter does not), so one listener on the nav covers
+// every item. An item's open flyout is a DOM descendant of that item, so
+// hovering into the flyout resolves back to the same root item and is a no-op.
+const onRailMouseOver = (event: MouseEvent) => {
+  // Back inside the rail: cancel any pending close.
+  window.clearTimeout(hoverCloseTimer)
+
+  const target = event.target as HTMLElement | null
+  const item = target?.closest<HTMLElement>('.p-tieredmenu-root-list > .p-tieredmenu-item') ?? null
+
+  if (!item || item === hoveredItem) {
+    return
+  }
+
+  hoveredItem = item
+  window.clearTimeout(hoverOpenTimer)
+
+  // Already in hover mode: TieredMenu's own mouseenter handler switches
+  // flyouts, so no dwell and nothing for us to do.
+  if (tieredMenuRef.value?.dirty) {
+    return
+  }
+
+  hoverOpenTimer = window.setTimeout(() => {
+    // The pointer may have moved on, or left the rail, while the timer was
+    // pending.
+    if (!tieredMenuRef.value || hoveredItem !== item) {
+      return
+    }
+
+    // TieredMenu binds @mouseenter on the item's content wrapper, not on the
+    // <li>, and mouseenter does not bubble — so dispatch it there.
+    const content = item.querySelector<HTMLElement>(':scope > .p-tieredmenu-item-content')
+
+    if (!content) {
+      return
+    }
+
+    tieredMenuRef.value.dirty = true
+    content.dispatchEvent(new MouseEvent('mouseenter'))
+  }, HOVER_OPEN_DELAY_MS)
+}
+
+const onRailMouseLeave = () => {
+  clearHoverTimers()
+  hoveredItem = null
+
+  hoverCloseTimer = window.setTimeout(() => {
+    const menu = tieredMenuRef.value
+
+    if (!menu) {
+      return
+    }
+
+    // Same guard as togglePinned: hide() also resets focusedItemInfo, so only
+    // call it when there is actually a flyout to close. Otherwise just drop
+    // out of hover mode, so re-entering the rail needs a fresh dwell.
+    if (menu.activeItemPath?.length) {
+      menu.hide()
+    } else {
+      menu.dirty = false
+    }
+  }, HOVER_CLOSE_DELAY_MS)
 }
 
 // Global shortcut: Ctrl+\ toggles the rail expand/collapse, so the menu can be
@@ -306,6 +416,7 @@ onBeforeUnmount(() => {
   }
 
   window.clearTimeout(vaadinResizeTimer)
+  clearHoverTimers()
   document.documentElement.style.removeProperty('--onms-side-menu-offset')
 
   flyoutObserver?.disconnect()

--- a/ui/tests/components/Menu/SideMenu.test.ts
+++ b/ui/tests/components/Menu/SideMenu.test.ts
@@ -22,6 +22,7 @@
 
 import SideMenu from '@/components/Menu/SideMenu.vue'
 import { useMenuStore } from '@/stores/menuStore'
+import { MainMenu } from '@/types/mainMenu'
 import { createTestingPinia } from '@pinia/testing'
 import { mount, VueWrapper } from '@vue/test-utils'
 import PrimeVue from 'primevue/config'
@@ -50,6 +51,42 @@ const ctrlBackslash = (init: KeyboardEventInit = {}) => new KeyboardEvent('keydo
   ...init
 })
 
+// The rail's own hover timings (SideMenu.vue). Kept as literals here so a
+// change to either constant has to be a deliberate change to these tests too.
+const HOVER_OPEN_DELAY_MS = 150
+const HOVER_CLOSE_DELAY_MS = 200
+
+const recordTooltip = (el: HTMLElement, binding: { value?: Record<string, unknown> }) => {
+  el.setAttribute('data-test-tooltip', JSON.stringify(binding.value ?? {}))
+}
+
+// Two top-level entries covering both collapsed-hover cases: 'Info' has a
+// submenu (flyout, no tooltip), 'Topology' is a direct link (tooltip, no flyout).
+const testMainMenu = {
+  username: 'admin',
+  baseHref: '/opennms/',
+  menus: [
+    {
+      id: 'info',
+      name: 'Info',
+      url: null,
+      locationMatch: null,
+      roles: null,
+      items: [
+        { id: 'nodes', name: 'Nodes', url: 'nodelist.htm', locationMatch: null, roles: null }
+      ]
+    },
+    {
+      id: 'topology',
+      name: 'Topology',
+      action: 'link',
+      url: 'topology.jsp',
+      locationMatch: null,
+      roles: null
+    }
+  ]
+} as unknown as MainMenu
+
 describe('SideMenu.vue', () => {
   let wrapper: VueWrapper<any>
   let store: ReturnType<typeof useMenuStore>
@@ -63,8 +100,15 @@ describe('SideMenu.vue', () => {
       },
       global: {
         plugins: [createTestingPinia({ createSpy: vi.fn, stubActions: false }), PrimeVue],
-        // The real directive renders tooltips into <body>; irrelevant here.
-        directives: { 'onms-tooltip': {}}
+        // The real directive renders tooltips into <body>. Record the binding
+        // on the element instead, so the tooltip rules can be asserted.
+        directives: { 'onms-tooltip': { mounted: recordTooltip, updated: recordTooltip }},
+        // TieredMenu wraps its root list in a <transition>, and the list's own
+        // class/role land on that component. Stubbing it (the VTU default)
+        // would leave them on the stub instead of the <ul>, so the rail's
+        // '.p-tieredmenu-root-list > .p-tieredmenu-item' selector — the same
+        // one positionFlyouts uses in production — would match nothing.
+        stubs: { transition: false }
       },
       attachTo: document.body
     })
@@ -209,6 +253,126 @@ describe('SideMenu.vue', () => {
       window.dispatchEvent(ctrlBackslash())
       await nextTick()
       expect(hideSpy).toHaveBeenCalled()
+    })
+  })
+
+  // NMS-20273: hovering a top-level entry flies its submenu out, in either rail
+  // state — what the rail never does on hover is change its own width. While
+  // collapsed, entries that are direct links (no submenu) get a label tooltip
+  // on the same beat instead; expanded, their labels are already visible.
+  describe('hover flyouts', () => {
+    const menu = () => wrapper.findComponent({ name: 'TieredMenu' }).vm as any
+    const rootItems = () => wrapper.findAll('.p-tieredmenu-root-list > .p-tieredmenu-item')
+    const activePath = () => menu().activeItemPath
+
+    const dwellOn = async (index: number) => {
+      await rootItems()[index].trigger('mouseover')
+      vi.advanceTimersByTime(HOVER_OPEN_DELAY_MS)
+      await nextTick()
+    }
+
+    beforeEach(async () => {
+      store.mainMenu = testMainMenu
+      await nextTick()
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('renders both top-level entries', () => {
+      expect(rootItems()).toHaveLength(2)
+    })
+
+    it('opens the flyout only after the dwell elapses, without widening the rail', async () => {
+      await rootItems()[0].trigger('mouseover')
+      vi.advanceTimersByTime(HOVER_OPEN_DELAY_MS - 1)
+      await nextTick()
+      expect(activePath()).toHaveLength(0)
+
+      vi.advanceTimersByTime(1)
+      await nextTick()
+      expect(activePath()).toHaveLength(1)
+      expect(isOpen()).toBe(false)
+    })
+
+    it('does not open a flyout when the pointer leaves before the dwell elapses', async () => {
+      await rootItems()[0].trigger('mouseover')
+      await wrapper.get('nav').trigger('mouseleave')
+      vi.advanceTimersByTime(HOVER_OPEN_DELAY_MS)
+      await nextTick()
+
+      expect(activePath()).toHaveLength(0)
+    })
+
+    it('switches between icons without a second dwell, and a direct link closes the flyout', async () => {
+      await dwellOn(0)
+      expect(activePath()).toHaveLength(1)
+
+      // Real pointer movement fires both; once TieredMenu is dirty its own
+      // mouseenter handler — bound on the item's content wrapper — does the
+      // switching, with no further dwell.
+      await rootItems()[1].trigger('mouseover')
+      await rootItems()[1].get('.p-tieredmenu-item-content').trigger('mouseenter')
+      await nextTick()
+
+      expect(activePath()).toHaveLength(0)
+    })
+
+    it('behaves the same way while the rail is pinned open', async () => {
+      await wrapper.get('.onms-side-menu__toggle').trigger('click')
+      expect(isOpen()).toBe(true)
+
+      await dwellOn(0)
+      expect(activePath()).toHaveLength(1)
+
+      await wrapper.get('nav').trigger('mouseleave')
+      vi.advanceTimersByTime(HOVER_CLOSE_DELAY_MS)
+      await nextTick()
+      expect(activePath()).toHaveLength(0)
+    })
+
+    it('closes the flyout and leaves hover mode once the pointer leaves the rail', async () => {
+      await dwellOn(0)
+      expect(menu().dirty).toBe(true)
+
+      await wrapper.get('nav').trigger('mouseleave')
+      vi.advanceTimersByTime(HOVER_CLOSE_DELAY_MS)
+      await nextTick()
+
+      expect(activePath()).toHaveLength(0)
+      expect(menu().dirty).toBe(false)
+    })
+
+    it('keeps the flyout open when the pointer returns within the close grace period', async () => {
+      await dwellOn(0)
+
+      await wrapper.get('nav').trigger('mouseleave')
+      vi.advanceTimersByTime(HOVER_CLOSE_DELAY_MS - 50)
+      await rootItems()[0].trigger('mouseover')
+      vi.advanceTimersByTime(HOVER_CLOSE_DELAY_MS)
+      await nextTick()
+
+      expect(activePath()).toHaveLength(1)
+    })
+
+    it('tooltips only the collapsed top-level icons that have no submenu', async () => {
+      const tooltip = (index: number) => JSON.parse(
+        rootItems()[index].get('.onms-side-menu__link').attributes('data-test-tooltip') as string
+      )
+
+      // 'Info' has a submenu: the flyout is the affordance, so no tooltip.
+      expect(tooltip(0).disabled).toBe(true)
+
+      // 'Topology' is a direct link: tooltip, on the same beat as the flyout.
+      expect(tooltip(1).disabled).toBe(false)
+      expect(tooltip(1).value).toBe('Topology')
+      expect(tooltip(1).showDelay).toBe(HOVER_OPEN_DELAY_MS)
+
+      // Pinned open, every label is already visible.
+      await wrapper.get('.onms-side-menu__toggle').trigger('click')
+      expect(tooltip(1).disabled).toBe(true)
     })
   })
 })

--- a/ui/tests/components/Menu/SideMenu.test.ts
+++ b/ui/tests/components/Menu/SideMenu.test.ts
@@ -320,6 +320,71 @@ describe('SideMenu.vue', () => {
       expect(activePath()).toHaveLength(0)
     })
 
+    it('cancels a pending dwell when the pointer moves onto the rail chrome', async () => {
+      await rootItems()[0].trigger('mouseover')
+
+      // The common 'hover an entry, then reach for the toggle' motion. The
+      // toggle is inside the nav, so no mouseleave fires to stop the dwell.
+      await wrapper.get('.onms-side-menu__toggle').trigger('mouseover')
+      vi.advanceTimersByTime(HOVER_OPEN_DELAY_MS)
+      await nextTick()
+
+      expect(activePath()).toHaveLength(0)
+      expect(menu().dirty).toBe(false)
+
+      // Coming back to the same entry has to re-arm the dwell, not sit inert.
+      await dwellOn(0)
+      expect(activePath()).toHaveLength(1)
+    })
+
+    it('leaves hover mode when the rail is toggled with no flyout open', async () => {
+      // dirty with an empty activeItemPath is reachable: hovering a direct link
+      // once in hover mode routes through TieredMenu's own onItemChange, which
+      // empties activeItemPath but never clears dirty.
+      await dwellOn(0)
+      await rootItems()[1].trigger('mouseover')
+      await rootItems()[1].get('.p-tieredmenu-item-content').trigger('mouseenter')
+      await nextTick()
+      expect(activePath()).toHaveLength(0)
+      expect(menu().dirty).toBe(true)
+
+      window.dispatchEvent(ctrlBackslash())
+      await nextTick()
+
+      // Otherwise every hover after the toggle opens instantly, with no dwell.
+      expect(menu().dirty).toBe(false)
+    })
+
+    it('keeps the focused entry when the pointer leaves a menu that holds focus', async () => {
+      await dwellOn(0)
+
+      // Stands in for a user who clicked or tabbed in and then arrowed into the
+      // submenu: TieredMenu focuses its menubar, and hide() resets
+      // focusedItemInfo along with everything else.
+      menu().focused = true
+      menu().focusedItemInfo = { index: 1, level: 1, parentKey: '0' }
+
+      await wrapper.get('nav').trigger('mouseleave')
+      vi.advanceTimersByTime(HOVER_CLOSE_DELAY_MS)
+      await nextTick()
+
+      expect(activePath()).toHaveLength(0)
+      // Back on the root entry whose flyout was open, rather than discarded —
+      // the same place TieredMenu itself lands after closing a submenu.
+      expect(menu().focusedItemInfo).toEqual({ index: 0, level: 0, parentKey: '' })
+    })
+
+    it('discards nothing after a pure hover, which never focuses the menu', async () => {
+      await dwellOn(0)
+      expect(menu().focused).toBe(false)
+
+      await wrapper.get('nav').trigger('mouseleave')
+      vi.advanceTimersByTime(HOVER_CLOSE_DELAY_MS)
+      await nextTick()
+
+      expect(menu().focusedItemInfo).toEqual({ index: -1, level: 0, parentKey: '' })
+    })
+
     it('behaves the same way while the rail is pinned open', async () => {
       await wrapper.get('.onms-side-menu__toggle').trigger('click')
       expect(isOpen()).toBe(true)


### PR DESCRIPTION
# NMS-20273: Open side menu submenus on hover, in both rail states

Hovering a top-level entry in the side menu now flies its submenu out, instead of requiring a
click. This applies whether the rail is collapsed or pinned open.

---

## Background

The rail used to expand on hover *and* open its flyouts (NMS-18287). NMS-20167 removed both,
because the combination was jarring, leaving click-to-open. That turned out to be dialed back too
far: the jarring part was the rail resizing from under the pointer — reflowing the page and moving
every icon the user was aiming at — not the flyouts themselves.

So the flyouts come back, and the rail's width does not move. `isPinned` is now the only thing that
sets it, and only the toggle button and `Ctrl+\` change `isPinned`.

## Behavior

- Hovering a top-level entry opens its submenu after a **150ms dwell**. The rail keeps its width.
- Once the first flyout is open the rail is in hover mode: moving between entries switches flyouts
  **instantly**, with no further delay — the macOS menu-bar feel.
- Leaving the rail closes any open flyout after a **200ms grace**, and leaves hover mode, so
  re-entering needs a fresh dwell.
- Identical in both rail states. Click-to-open still works and is unchanged; so is keyboard
  navigation.

The dwell is the point of the design. Opening on bare `mouseenter` fires a flyout at every entry
the pointer merely crosses on its way somewhere else, which is the same class of noise the old
hover mode had. 150ms is long enough to ignore a pass-through and short enough to read as instant
on a deliberate hover.

The close grace matters because a flyout is not always beside its own entry: `positionFlyouts`
clamps tall flyouts to the rail's vertical band, so reaching one can take the pointer briefly
outside the rail. Closing on the first `mouseleave` would cut that travel off.

## Tooltips

While collapsed, top-level entries had a label tooltip, since their labels are hidden. Now:

- Entries **with** a submenu no longer show one.
- Entries **without** a submenu (Topology Map, Geographical Map — direct links, nothing to fly out)
  keep theirs, and its `showDelay` drops from 300ms to the same 150ms as the flyout, so every
  top-level entry responds on the same beat regardless of which kind it is.
- Expanded, labels are visible and tooltips stay suppressed, as before.

## Notes for reviewers

- **This reaches into TieredMenu internals** — the `dirty` flag, and a synthetic event aimed at a
  PrimeVue-owned element. A PrimeVue upgrade could change either. It is contained to this one
  component, which already carries a comment explaining why TieredMenu is used unwrapped rather
  than behind an `onms-ui` seam component, now extended to cover this. The alternative — calling
  `onItemChange()` with a processed item pulled off the instance — couples to more internals, not
  fewer, and skips PrimeVue's own handler.
- **An expanded-rail flyout now closes when the pointer leaves the rail**, where before it stayed
  until an outside click. Deliberate: the interaction should not differ between the two states.
- **Touch is unaffected.** There is no hover to dwell on, and click-to-open is untouched.
- The two timing constants are the only tuning knobs; both are named and commented at their
  definitions.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20273
