### PR TITLE
NMS-20245: Fix SQL injection in Asset Management JasperReports

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/report-templates/AssetManagementMaintExpired.jrxml
+++ b/opennms-base-assembly/src/main/filtered/etc/report-templates/AssetManagementMaintExpired.jrxml
@@ -48,10 +48,10 @@
 	n.nodelabel,
 	a.manufacturer,
 	a.maintcontract,
-	to_date(a.maintcontractexpires,'$P!{DS_DATE_FORMAT}') AS expire,
+	to_date(a.maintcontractexpires,$P{DS_DATE_FORMAT}) AS expire,
 	CASE
 		WHEN
-			to_date(a.maintcontractexpires,'$P!{DS_DATE_FORMAT}') - now() < INTERVAL '0 days'
+			to_date(a.maintcontractexpires,$P{DS_DATE_FORMAT}) - now() < INTERVAL '0 days'
  			THEN 'expired'
 		ELSE
 			'warning'
@@ -71,7 +71,7 @@ WHERE
 	a.maintcontractexpires != 'n.v.' AND
 	a.maintcontract != 'n.v.' AND
 	a.maintcontract != '' AND
-	to_date(a.maintcontractexpires,'$P!{DS_DATE_FORMAT}') - now() < INTERVAL '$P!{DS_WARN_THRESH} days'
+	to_date(a.maintcontractexpires,$P{DS_DATE_FORMAT}) - now() < make_interval(days => $P{DS_WARN_THRESH})
 GROUP BY
 	n.nodelabel,
 	a.manufacturer,
@@ -128,13 +128,13 @@ ORDER BY
 	a.modelnumber,
 	a.operatingsystem,
 	a.serialnumber,
-	to_date(a.dateinstalled,'$P!{DATE_FORMAT}') as dateinstalled,
+	to_date(a.dateinstalled,$P{DATE_FORMAT}) as dateinstalled,
 	a.vendorphone,
-	to_date(a.maintcontractexpires,'$P!{DATE_FORMAT}') AS maintcontractexpires,
-	to_date(a.maintcontractexpires,'$P!{DATE_FORMAT}') - now() AS maintcontractleft,
+	to_date(a.maintcontractexpires,$P{DATE_FORMAT}) AS maintcontractexpires,
+	to_date(a.maintcontractexpires,$P{DATE_FORMAT}) - now() AS maintcontractleft,
 	CASE
 		WHEN
-			to_date(a.maintcontractexpires,'$P!{DATE_FORMAT}') - now() < INTERVAL '$P!{WARNING_THRESHOLD_DAYS} days'
+			to_date(a.maintcontractexpires,$P{DATE_FORMAT}) - now() < make_interval(days => $P{WARNING_THRESHOLD_DAYS})
  			THEN 'expired'
 		ELSE
 			'warning'
@@ -153,7 +153,7 @@ WHERE
 	a.maintcontractexpires != 'n.v.' AND
 	a.maintcontract != 'n.v.' AND
 	a.maintcontract != '' AND
-	to_date(a.maintcontractexpires,'$P!{DATE_FORMAT}') - now() < INTERVAL '$P!{WARNING_THRESHOLD_DAYS} days'
+	to_date(a.maintcontractexpires,$P{DATE_FORMAT}) - now() < make_interval(days => $P{WARNING_THRESHOLD_DAYS})
 ORDER BY
 	a.manufacturer ASC,
 	a.maintcontractexpires DESC]]>

--- a/opennms-base-assembly/src/main/filtered/etc/report-templates/AssetManagementMaintStrategy.jrxml
+++ b/opennms-base-assembly/src/main/filtered/etc/report-templates/AssetManagementMaintStrategy.jrxml
@@ -31,14 +31,14 @@
 	sum(tally)
 FROM
 	(SELECT
-		((EXTRACT(days from (now() - to_date(dateinstalled, '$P!{DS_DATE_FORMAT}'))))/365)::INTEGER AS age,
+		((EXTRACT(days from (now() - to_date(dateinstalled, $P{DS_DATE_FORMAT}))))/365)::INTEGER AS age,
 		CASE
 			WHEN
 				maintcontractexpires = ''
 			THEN
 				NULL
 			ELSE
-				EXTRACT(epoch from (to_date(maintcontractexpires,'$P!{DS_DATE_FORMAT}') - now()))
+				EXTRACT(epoch from (to_date(maintcontractexpires,$P{DS_DATE_FORMAT}) - now()))
 		END AS contractleft,
 		count(*) AS tally
 	FROM
@@ -92,7 +92,7 @@ FROM
 LEFT JOIN
 	assets
 ON
-	(to_char((to_date(assets.maintcontractexpires,'$P!{DS_DATE_FORMAT}')),'YYYY-MM') =
+	(to_char((to_date(assets.maintcontractexpires,$P{DS_DATE_FORMAT})),'YYYY-MM') =
 	to_char(generatedMonth.dates, 'YYYY-MM') AND assets.maintcontractexpires != 'n.v.')
 ORDER BY
 	yearmonth]]>
@@ -119,10 +119,10 @@ ORDER BY
 			THEN
 				'no contract'
 		WHEN
-			EXTRACT(epoch from (to_date(maintcontractexpires,'$P!{DS_DATE_FORMAT}') - now())) > 0
+			EXTRACT(epoch from (to_date(maintcontractexpires,$P{DS_DATE_FORMAT}) - now())) > 0
 			THEN 'in contract'
 		WHEN
-			EXTRACT(epoch from (to_date(maintcontractexpires,'$P!{DS_DATE_FORMAT}') - now())) < 0
+			EXTRACT(epoch from (to_date(maintcontractexpires,$P{DS_DATE_FORMAT}) - now())) < 0
 			THEN 'expired'
 		ELSE
 			'UNKNOWN'


### PR DESCRIPTION
Bind the user-prompted DATE_FORMAT/threshold params ($P{}) instead of literal $P!{} substitution in AssetManagementMaintExpired and AssetManagementMaintStrategy.



### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20245

