### PR TITLE
NMS-20283: Count notifications, not deliveries, in the notification s…

### DIFF
--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NotificationRestService.java
@@ -120,9 +120,12 @@ public class NotificationRestService extends OnmsRestService {
         // All unack notifications
         info.setTotalUnacknowledgedCount(m_notifDao.countMatching(new CriteriaBuilder(OnmsNotification.class).isNull("answeredBy").toCriteria()));
 
-        // All unacknowledged notifications for current user
+        // All unacknowledged notifications for current user. A notification holds one
+        // usersNotified row per notification method, so the join must be counted over
+        // distinct notifications rather than over rows.
         info.setUserUnacknowledgedCount(m_notifDao.countMatching(new CriteriaBuilder(OnmsNotification.class).isNull("answeredBy")
                 .alias("usersNotified", "usersNotified").eq("usersNotified.userId", user)
+                .distinct()
                 .toCriteria()));
 
         // Determine number of notices not acknowledged and not "assigned to" current user
@@ -130,12 +133,14 @@ public class NotificationRestService extends OnmsRestService {
                 .isNull("answeredBy")
                 .alias("usersNotified", "usersNotified", JoinType.LEFT_JOIN)
                 .or(Restrictions.ne("usersNotified.userId", user), Restrictions.isNull("usersNotified.userId"))
+                .distinct()
                 .toCriteria()));
 
         // Load newest unacknowledged notifications for user, but only N
         if (info.getUserUnacknowledgedCount() != 0) {
             final List<OnmsNotification> newestNotifications = m_notifDao.findMatching(new CriteriaBuilder(OnmsNotification.class).isNull("answeredBy")
                     .alias("usersNotified", "usersNotified").eq("usersNotified.userId", user)
+                    .distinct()
                     .orderBy("pageTime", false)
                     .limit(10)
                     .toCriteria());

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NotificationRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NotificationRestServiceIT.java
@@ -38,6 +38,10 @@ import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
 import org.opennms.core.test.rest.AbstractSpringJerseyRestTestCase;
 import org.opennms.netmgt.dao.DatabasePopulator;
+import org.opennms.netmgt.dao.api.NotificationDao;
+import org.opennms.netmgt.dao.api.UserNotificationDao;
+import org.opennms.netmgt.model.OnmsNotification;
+import org.opennms.netmgt.model.OnmsUserNotification;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -72,6 +76,12 @@ public class NotificationRestServiceIT extends AbstractSpringJerseyRestTestCase 
 
     @Autowired
     private ServletContext m_servletContext;
+
+    @Autowired
+    private NotificationDao m_notificationDao;
+
+    @Autowired
+    private UserNotificationDao m_userNotificationDao;
 
     @Override
     protected void afterServletStart() {
@@ -109,5 +119,37 @@ public class NotificationRestServiceIT extends AbstractSpringJerseyRestTestCase 
         JSONObject restObject = new JSONObject(json);
         JSONObject expectedObject = new JSONObject(IOUtils.toString(new FileInputStream("src/test/resources/v1/notifications.json")));
         JSONAssert.assertEquals(expectedObject, restObject, true);
+    }
+
+    /**
+     * A notification carries one usersNotified row per notification method, so the
+     * same user can appear on it more than once. The summary must count notifications,
+     * not join rows.
+     */
+    @Test
+    @JUnitTemporaryDatabase
+    public void testSummaryCountsNotificationsNotUsersNotifiedRows() throws Exception {
+        final OnmsNotification notification = m_notificationDao.findAll().get(0);
+
+        // the same notification delivered to the same user twice (e.g. email and pager)
+        for (final String media : new String[] { "email", "pager" }) {
+            final OnmsUserNotification delivery = new OnmsUserNotification();
+            delivery.setUserId("admin");
+            delivery.setNotification(notification);
+            delivery.setMedia(media);
+            m_userNotificationDao.saveOrUpdate(delivery);
+        }
+        m_userNotificationDao.flush();
+
+        final MockHttpServletRequest request = createRequest(m_servletContext, GET, "/notifications/summary");
+        request.addHeader("Accept", MediaType.APPLICATION_JSON);
+        final JSONObject summary = new JSONObject(sendRequest(request, 200));
+
+        // fixture guard: exactly one unacknowledged notification exists
+        assertEquals(1, summary.getInt("totalUnacknowledgedCount"));
+        // two deliveries, one notification
+        assertEquals(1, summary.getInt("userUnacknowledgedCount"));
+        assertEquals(1, summary.getJSONObject("userUnacknowledgedNotifications")
+                .getJSONArray("notification").length());
     }
 }


### PR DESCRIPTION
/notifications/summary derived userUnacknowledgedCount, teamUnacknowledgedCount and the newest-notifications list from a criteria join to usersNotified, and countMatching counts join rows. A notification carries one usersNotified row per notification method, so a user notified by both email and pager was counted twice and appeared twice in the list. On a real install the personal count came back larger than the total unacknowledged count, and the header badge disagreed with the notification list it links to.

This fixes that.

Assisted by Anthropic Claude Opus 5.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20283
