### PR TITLE
NMS-20280: Time support for OnmsDatePicker, and TimeControls fixes

### DIFF
--- a/ui/packages/onms-ui/README.md
+++ b/ui/packages/onms-ui/README.md
@@ -269,6 +269,42 @@ tech, and a `tooltip`-only button is named from the tooltip text. Positioning
 modifiers (`v-onms-tooltip.top`) have no prop equivalent — a call site needing
 one keeps using the directive.
 
+## OnmsDatePicker: dates, times, and time-only (NMS-20280)
+
+`OnmsDatePicker` covers all three shapes, so there is no `OnmsTimePicker`:
+
+| prop | type | default | effect |
+| --- | --- | --- | --- |
+| `showTime` | `boolean` | `false` | adds hour/minute spinners below the calendar |
+| `showSeconds` | `boolean` | `false` | adds a second spinner (requires `showTime` or `timeOnly`) |
+| `timeOnly` | `boolean` | `false` | hides the calendar entirely — a pure time picker |
+| `hourFormat` | `OnmsHourFormat` (`'12' \| '24'`) | `'24'` | clock convention |
+| `stepHour` / `stepMinute` / `stepSecond` | `number` | `1` | spinner increments |
+
+`timeOnly` needs no companion `showTime`: PrimeVue gates the time panel on
+`showTime || timeOnly` and the date panel on `!timeOnly`.
+
+`hourFormat` is typed as the owned `OnmsHourFormat` rather than PrimeVue's
+`HintedString<'12' | '24'>`, per rule 4. Every default above matches installed
+primevue@4.5.5's own, so these are not "notable deviations" — declaring them
+changed no existing call site's rendering. `placeholder` / `minDate` / `maxDate`
+are declared for the same reason: passing them by attribute fallthrough happens
+to reach PrimeVue, but rule 2 classes that as unsupported.
+
+Beyond `update:modelValue`, the wrapper emits `show` / `hide` when the overlay
+panel opens and closes. `TimeControls` needs them: PrimeVue dismisses the panel
+from a document-level **mousedown** listener, so a consumer that wants to tell
+"this click dismissed a picker" from "this click chose something else" has to
+sample overlay visibility on mousedown. Without these emits its only route is
+reaching into PrimeVue internals.
+
+`minDate` / `maxDate` accept `Date | null` and collapse `null` to `undefined`
+before reaching PrimeVue, which types them `Date | undefined` and treats any
+non-undefined value as a live bound. That keeps a `?? undefined` out of every
+call site holding its bounds in a nullable ref. `TimeControls` relies on this:
+it cross-wires its two pickers (`:maxDate="endDateRef"` / `:minDate="startDateRef"`)
+so a range cannot invert, and both refs start out null.
+
 ## Runtime exposure for plugins
 
 This package's barrel export (`packages/onms-ui/src/index.ts`) **is** the

--- a/ui/packages/onms-ui/README.md
+++ b/ui/packages/onms-ui/README.md
@@ -291,6 +291,11 @@ changed no existing call site's rendering. `placeholder` / `minDate` / `maxDate`
 are declared for the same reason: passing them by attribute fallthrough happens
 to reach PrimeVue, but rule 2 classes that as unsupported.
 
+`inputId` lands on the rendered `<input>` rather than the wrapper element, so a
+`FormField` label's `for` can reach the real control — the same reason
+`OnmsSelect`, `OnmsInputNumber` and the other input wrappers declare one. A
+plain `id` would fall through to PrimeVue's wrapper, out of a label's reach.
+
 Beyond `update:modelValue`, the wrapper emits `show` / `hide` when the overlay
 panel opens and closes. `TimeControls` needs them: PrimeVue dismisses the panel
 from a document-level **mousedown** listener, so a consumer that wants to tell

--- a/ui/packages/onms-ui/src/components/OnmsDatePicker.vue
+++ b/ui/packages/onms-ui/src/components/OnmsDatePicker.vue
@@ -1,24 +1,80 @@
 <template>
   <DatePicker
     :modelValue="modelValue"
+    :showTime="showTime"
+    :timeOnly="timeOnly"
+    :hourFormat="hourFormat"
+    :showSeconds="showSeconds"
+    :stepHour="stepHour"
+    :stepMinute="stepMinute"
+    :stepSecond="stepSecond"
+    :placeholder="placeholder"
+    :minDate="minDate ?? undefined"
+    :maxDate="maxDate ?? undefined"
     :pt="unsafePt as never"
     @update:modelValue="emit('update:modelValue', $event as Date | null)"
+    @show="emit('show')"
+    @hide="emit('hide')"
   />
 </template>
 
 <script setup lang="ts">
 import DatePicker from 'primevue/datepicker'
+import type { OnmsHourFormat } from '../types'
 
 // Seam wrapper (NMS-20081) around PrimeVue DatePicker.
+//
+// Time support (NMS-20280): showTime / timeOnly / hourFormat / showSeconds are
+// generic enough to survive a framework swap, so they are declared rather than
+// left to attribute fallthrough. `timeOnly` covers the time-only case on its
+// own -- PrimeVue gates the time panel on `showTime || timeOnly` and the date
+// panel on `!timeOnly` -- so there is no separate OnmsTimePicker.
+//
+// hourFormat is typed as the owned OnmsHourFormat rather than PrimeVue's
+// `HintedString<'12' | '24'>` (seam rule 4: no PrimeVue types in a public
+// signature). All defaults below match installed primevue@4.5.5's own, so
+// declaring these props changes no existing consumer's rendering.
+//
+// PrimeVue-reality: minDate/maxDate are typed `Date | undefined` there, and any
+// non-undefined value is treated as a live bound. Consumers hold bounds in
+// nullable refs (TimeControls' startDateRef/endDateRef), so this wrapper
+// accepts null and collapses it to undefined instead of pushing that `?? undefined`
+// onto every call site.
 withDefaults(defineProps<{
   modelValue?: Date | null
+  showTime?: boolean
+  timeOnly?: boolean
+  hourFormat?: OnmsHourFormat
+  showSeconds?: boolean
+  stepHour?: number
+  stepMinute?: number
+  stepSecond?: number
+  placeholder?: string
+  minDate?: Date | null
+  maxDate?: Date | null
   unsafePt?: unknown
 }>(), {
   modelValue: null,
+  showTime: false,
+  timeOnly: false,
+  hourFormat: '24',
+  showSeconds: false,
+  stepHour: 1,
+  stepMinute: 1,
+  stepSecond: 1,
+  placeholder: undefined,
+  minDate: undefined,
+  maxDate: undefined,
   unsafePt: undefined
 })
 
+// show/hide report overlay visibility in framework-neutral terms. TimeControls
+// needs them so a click elsewhere in its popover can dismiss an open picker
+// instead of being treated as a range selection; without them a consumer's only
+// route is reaching into PrimeVue internals.
 const emit = defineEmits<{
   'update:modelValue': [value: Date | null]
+  show: []
+  hide: []
 }>()
 </script>

--- a/ui/packages/onms-ui/src/components/OnmsDatePicker.vue
+++ b/ui/packages/onms-ui/src/components/OnmsDatePicker.vue
@@ -9,6 +9,7 @@
     :stepMinute="stepMinute"
     :stepSecond="stepSecond"
     :placeholder="placeholder"
+    :inputId="inputId"
     :minDate="minDate ?? undefined"
     :maxDate="maxDate ?? undefined"
     :pt="unsafePt as never"
@@ -35,6 +36,11 @@ import type { OnmsHourFormat } from '../types'
 // signature). All defaults below match installed primevue@4.5.5's own, so
 // declaring these props changes no existing consumer's rendering.
 //
+// inputId lands on the rendered <input>, not the wrapper element. A plain `id`
+// falling through would settle on PrimeVue's wrapper, out of reach of a
+// FormField label's `for`, so the association needs this dedicated prop --
+// the same reason OnmsSelect, OnmsInputNumber and friends declare one.
+//
 // PrimeVue-reality: minDate/maxDate are typed `Date | undefined` there, and any
 // non-undefined value is treated as a live bound. Consumers hold bounds in
 // nullable refs (TimeControls' startDateRef/endDateRef), so this wrapper
@@ -50,6 +56,7 @@ withDefaults(defineProps<{
   stepMinute?: number
   stepSecond?: number
   placeholder?: string
+  inputId?: string
   minDate?: Date | null
   maxDate?: Date | null
   unsafePt?: unknown
@@ -63,6 +70,7 @@ withDefaults(defineProps<{
   stepMinute: 1,
   stepSecond: 1,
   placeholder: undefined,
+  inputId: undefined,
   minDate: undefined,
   maxDate: undefined,
   unsafePt: undefined

--- a/ui/packages/onms-ui/src/index.ts
+++ b/ui/packages/onms-ui/src/index.ts
@@ -64,6 +64,6 @@ export { releaseActiveToast, useOnmsToast, ONMS_TOAST_GROUP_CENTER, ONMS_TOAST_G
 // Directives — register app-level; core does this in src/theme/primevue-setup.ts
 export { default as OnmsTooltip } from './directives/OnmsTooltip'
 
-export type { OnmsMenuItem, OnmsTablePageEvent, OnmsTableRowEditSaveEvent, OnmsTableSortEvent, OnmsTagSeverity } from './types'
+export type { OnmsHourFormat, OnmsMenuItem, OnmsTablePageEvent, OnmsTableRowEditSaveEvent, OnmsTableSortEvent, OnmsTagSeverity } from './types'
 export type { OnmsColumnProps, OnmsColumnSlots } from './components/OnmsColumn'
 export type { OnmsToastOptions, OnmsToastSeverity } from './composables/useOnmsToast'

--- a/ui/packages/onms-ui/src/types.ts
+++ b/ui/packages/onms-ui/src/types.ts
@@ -20,6 +20,9 @@
 /// License.
 ///
 
+/** Clock convention for OnmsDatePicker's time panel. */
+export type OnmsHourFormat = '12' | '24'
+
 export type OnmsTagSeverity = 'secondary' | 'success' | 'info' | 'warn' | 'danger'
 
 // Menu model item in OpenNMS vocabulary (structurally compatible with

--- a/ui/src/components/AdhocGraphs/AdhocChartToolbar.vue
+++ b/ui/src/components/AdhocGraphs/AdhocChartToolbar.vue
@@ -2,19 +2,16 @@
   <div class="chart-toolbar">
     <div class="toolbar-row">
       <!--
-        A visible label: the range button shows only the current selection ("Last
-        day"), so without this there is nothing saying what it selects. Not wired up
-        with aria-labelledby, because TimeControls' fallthrough target is a plain
-        div and the attribute would be inert there — associating it properly means
-        changing the shared component, which Resource Graphs needs too.
+        The label is TimeControls' own `label` prop, not a span here: the range
+        button shows only the current selection ("Last day"), so something has to
+        say what it selects, and only the component itself can put aria-labelledby
+        on the button rather than on its plain root div.
       -->
-      <div class="time-range">
-        <span class="time-range-label">Time Range:</span>
-        <TimeControls
-          data-test="toolbar-time-range"
-          @updateTime="(value: StartEndTime) => emit('updateTime', value)"
-        />
-      </div>
+      <TimeControls
+        label="Time Range:"
+        data-test="toolbar-time-range"
+        @updateTime="(value: StartEndTime) => emit('updateTime', value)"
+      />
 
       <div class="toolbar-actions">
         <OnmsIconButton
@@ -165,7 +162,7 @@ import FullscreenExitIcon from '@opennms/onms-ui/icons/navigation/FullscreenExit
 import LinkIcon from '@opennms/onms-ui/icons/action/Link.vue'
 import PdfIcon from '@opennms/onms-ui/icons/file/Pdf.vue'
 import FormField from '@/components/Common/FormField.vue'
-import TimeControls from '@/components/Resources/TimeControls.vue'
+import TimeControls from '@/components/Common/TimeControls.vue'
 import { StartEndTime } from '@/types'
 import { AdhocGraphConfig } from '@/types/adhocGraph'
 import { DEFAULT_RESOLUTION, MAX_RESOLUTION } from './utils/adhocQuery'
@@ -216,19 +213,6 @@ const emit = defineEmits<{
   display: flex;
   align-items: flex-start;
   gap: 0.5rem;
-}
-
-// Every control on this row is now the same height, so the label sits beside the
-// range button rather than above it.
-.time-range {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-
-  .time-range-label {
-    font-weight: 700;
-    white-space: nowrap;
-  }
 }
 
 .toolbar-fields {

--- a/ui/src/components/AdhocGraphs/AdhocGraphBuilder.vue
+++ b/ui/src/components/AdhocGraphs/AdhocGraphBuilder.vue
@@ -222,7 +222,7 @@ import { useAppStore } from '@/stores/appStore'
 import { useAdhocGraphStore } from '@/stores/adhocGraphStore'
 import { useMenuStore } from '@/stores/menuStore'
 import { BreadCrumb, StartEndTime } from '@/types'
-import { DEFAULT_RANGE, resolveRelativeRange } from '@/components/Resources/utils/timeRangeOptions'
+import { DEFAULT_RANGE, resolveRelativeRange } from '@/components/Common/utils/timeRangeOptions'
 import {
   AdhocDatasourceOption,
   AdhocExpression,

--- a/ui/src/components/AdhocGraphs/utils/adhocUrlState.ts
+++ b/ui/src/components/AdhocGraphs/utils/adhocUrlState.ts
@@ -23,7 +23,7 @@
 import { AdhocExpression, AdhocGraphConfig, AdhocSeries, AdhocSeriesStyle } from '@/types/adhocGraph'
 import { ConsolidationFunctionType } from '@/types/timeSeries'
 import { RelativeTimeRange, StartEndTime } from '@/types'
-import { RANGE_UNITS } from '@/components/Resources/utils/timeRangeOptions'
+import { RANGE_UNITS } from '@/components/Common/utils/timeRangeOptions'
 import { DEFAULT_RESOLUTION } from './adhocQuery'
 
 /** Field separator inside one entry. */

--- a/ui/src/components/Common/TimeControls.vue
+++ b/ui/src/components/Common/TimeControls.vue
@@ -55,8 +55,8 @@
                 hourFormat="12"
                 placeholder="Start date and time"
                 :maxDate="endDateRef"
-                @show="openPickerCount++"
-                @hide="openPickerCount--"
+                @show="onPickerShow"
+                @hide="onPickerHide"
               />
             </FormField>
             <FormField
@@ -72,8 +72,8 @@
                 hourFormat="12"
                 placeholder="End date and time"
                 :minDate="startDateRef"
-                @show="openPickerCount++"
-                @hide="openPickerCount--"
+                @show="onPickerShow"
+                @hide="onPickerHide"
               />
             </FormField>
             <OnmsButton
@@ -130,6 +130,20 @@ const selectedTime = ref('Last day')
 // How many picker overlays are on screen (there are two, and both can be open in
 // sequence). Fed by OnmsDatePicker's show/hide.
 const openPickerCount = ref(0)
+
+const onPickerShow = () => {
+  openPickerCount.value++
+}
+
+// Clamped, not a bare decrement: a hide with no matching show (unmount
+// ordering, or a third picker added later) would otherwise drive the count
+// negative, and a subsequent show would only bring it back to 0 -- the latch
+// below reads `> 0`, so it would see "no picker open" while one is on screen and
+// take the next preset click as a selection. Only `> 0` is ever read, so that
+// failure is silent; the clamp makes the latch immune to it.
+const onPickerHide = () => {
+  openPickerCount.value = Math.max(0, openPickerCount.value - 1)
+}
 
 /**
  * Latched on mousedown over the preset list, NOT read at click time.

--- a/ui/src/components/Common/TimeControls.vue
+++ b/ui/src/components/Common/TimeControls.vue
@@ -7,11 +7,18 @@
         class="time-range-label"
       >{{ label }}</span>
 
+      <!--
+        aria-labelledby REPLACES the button's content as its accessible name, so
+        pointing it at the label alone would drop the selected range -- the only
+        changing information the button carries. Listing the button's own id
+        after the label's concatenates the two ("Time Range: Last day").
+      -->
       <OnmsButton
+        :id="triggerId"
         variant="text"
         class="graph-controls"
         aria-haspopup="true"
-        :aria-labelledby="label ? labelId : undefined"
+        :aria-labelledby="label ? `${labelId} ${triggerId}` : undefined"
         @click="toggleMenu"
       >
         {{ selectedTime }} &nbsp;
@@ -36,9 +43,14 @@
           </ul>
 
           <div class="custom-col">
-            <FormField label="Start" class="date-input">
+            <FormField
+              label="Start"
+              class="date-input"
+              :for="startInputId"
+            >
               <OnmsDatePicker
                 v-model="startDateRef"
+                :inputId="startInputId"
                 showTime
                 hourFormat="12"
                 placeholder="Start date and time"
@@ -47,9 +59,15 @@
                 @hide="openPickerCount--"
               />
             </FormField>
-            <FormField label="End" class="date-input">
+            <FormField
+              label="End"
+              class="date-input"
+              :for="endInputId"
+              :error="rangeError"
+            >
               <OnmsDatePicker
                 v-model="endDateRef"
+                :inputId="endInputId"
                 showTime
                 hourFormat="12"
                 placeholder="End date and time"
@@ -95,6 +113,9 @@ defineProps<{
 const emit = defineEmits(['updateTime'])
 
 const labelId = useId()
+const triggerId = useId()
+const startInputId = useId()
+const endInputId = useId()
 
 const menu = ref()
 
@@ -118,6 +139,16 @@ const openPickerCount = ref(0)
  * gone and openPickerCount is back to 0. Sampling here -- the <ul> sees mousedown
  * before it bubbles to document -- is what makes "a click that merely dismissed a
  * picker" distinguishable from "a click that chose a preset".
+ *
+ * Known window: PrimeVue emits `show` from the overlay's onEnter hook but binds
+ * that document dismisser in onAfterEnter, so during the enter transition a
+ * picker reports itself open while nothing will dismiss it. A press landing in
+ * that window makes the preset click a no-op -- the picker stays up and nothing
+ * is selected -- and the next click behaves normally. Left as-is deliberately:
+ * suppressing only when the picker actually closed would, in the same window,
+ * restore the original bug (preset selected and popover closed) which is a wrong
+ * action rather than a dropped one, and PrimeVue exposes no way to dismiss the
+ * overlay ourselves (onBlur does not close it; overlayVisible is internal).
  */
 const dismissedPickerOnPress = ref(false)
 
@@ -125,7 +156,24 @@ const latchPickerDismissal = () => {
   dismissedPickerOnPress.value = openPickerCount.value > 0
 }
 
-const disableCustomTimeBtn = computed(() => !startDateRef.value || !endDateRef.value)
+/**
+ * The :minDate/:maxDate cross-wiring below is a UI affordance, NOT the
+ * correctness guarantee -- PrimeVue does not enforce it strictly enough to be
+ * one. Its isSelectable() compares year/month/day only, and the typed-input
+ * path (isValidSelection, with manualInput defaulting to true) goes through
+ * that, so typing a later time on the boundary day into Start is accepted
+ * unclamped and inverts the range. A calendar click does clamp at full
+ * granularity, but clamping Start to maxDate lands it exactly on End, which is
+ * a zero-width window. Both slip past a null-check, and an inverted range then
+ * reads as a negative difference below, mislabelling the window as "minutes".
+ */
+const rangeError = computed(() =>
+  startDateRef.value && endDateRef.value && endDateRef.value <= startDateRef.value
+    ? 'End must be after start'
+    : undefined)
+
+const disableCustomTimeBtn = computed(() =>
+  !startDateRef.value || !endDateRef.value || Boolean(rangeError.value))
 
 const toggleMenu = (event: Event) => menu.value.toggle(event)
 
@@ -165,14 +213,18 @@ const selectOption = (option: TimeOption) => {
 }
 
 const applyCustomTime = () => {
-  // The button is disabled until both are set; this narrows the refs without a cast.
-  if (!startDateRef.value || !endDateRef.value) {
+  const start = startDateRef.value
+  const end = endDateRef.value
+
+  // Mirrors disableCustomTimeBtn rather than trusting it: the button being
+  // disabled is a UI state, and this also narrows the refs without a cast.
+  if (!start || !end || end <= start) {
     return
   }
 
   let format = 'hours'
-  const startTime = getUnixTime(startDateRef.value)
-  const endTime = getUnixTime(endDateRef.value)
+  const startTime = getUnixTime(start)
+  const endTime = getUnixTime(end)
 
   // end - start, as Dates. This previously passed unix SECONDS in the wrong order,
   // so the difference was always negative and every custom range was labeled as

--- a/ui/src/components/Common/TimeControls.vue
+++ b/ui/src/components/Common/TimeControls.vue
@@ -1,10 +1,17 @@
 <template>
   <div class="onms-row">
     <div class="onms-col-12 wrapper">
+      <span
+        v-if="label"
+        :id="labelId"
+        class="time-range-label"
+      >{{ label }}</span>
+
       <OnmsButton
         variant="text"
         class="graph-controls"
         aria-haspopup="true"
+        :aria-labelledby="label ? labelId : undefined"
         @click="toggleMenu"
       >
         {{ selectedTime }} &nbsp;
@@ -16,7 +23,10 @@
         class="graph-controls-panel"
       >
         <div class="menu-content">
-          <ul class="onms-list options-col">
+          <ul
+            class="onms-list options-col"
+            @mousedown="latchPickerDismissal"
+          >
             <li
               class="list-item"
               v-for="option in TIME_RANGE_OPTIONS"
@@ -26,29 +36,31 @@
           </ul>
 
           <div class="custom-col">
-            <FormField label="Start Date" class="date-input">
-              <OnmsDatePicker v-model="startDateRef" />
-            </FormField>
-            <FormField label="Start Time">
-              <OnmsSelect
-                :options="HOUR_OPTIONS"
-                v-model="startTimeRef"
-                optionLabel="label"
+            <FormField label="Start" class="date-input">
+              <OnmsDatePicker
+                v-model="startDateRef"
+                showTime
+                hourFormat="12"
+                placeholder="Start date and time"
+                :maxDate="endDateRef"
+                @show="openPickerCount++"
+                @hide="openPickerCount--"
               />
             </FormField>
-            <FormField label="End Date" class="date-input">
-              <OnmsDatePicker v-model="endDateRef" />
-            </FormField>
-            <FormField label="End Time">
-              <OnmsSelect
-                :options="HOUR_OPTIONS"
-                v-model="endTimeRef"
-                optionLabel="label"
+            <FormField label="End" class="date-input">
+              <OnmsDatePicker
+                v-model="endDateRef"
+                showTime
+                hourFormat="12"
+                placeholder="End date and time"
+                :minDate="startDateRef"
+                @show="openPickerCount++"
+                @hide="openPickerCount--"
               />
             </FormField>
             <OnmsButton
               :disabled="disableCustomTimeBtn"
-              variant="text"
+              variant="ghost"
               @click="applyCustomTime"
             >Apply custom time</OnmsButton>
           </div>
@@ -59,31 +71,61 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, useId } from 'vue'
 
-import { OnmsButton, OnmsDatePicker, OnmsIcon, OnmsPopover, OnmsSelect } from '@opennms/onms-ui'
+import { OnmsButton, OnmsDatePicker, OnmsIcon, OnmsPopover } from '@opennms/onms-ui'
 import FormField from '@/components/Common/FormField.vue'
-import { add, sub, getUnixTime, differenceInHours, fromUnixTime } from 'date-fns'
+import { sub, getUnixTime, differenceInHours, fromUnixTime } from 'date-fns'
 import ArrowDropDown from '@opennms/onms-ui/icons/navigation/ArrowDropDown.vue'
 import {
-  HOUR_OPTIONS,
   relativeRangeOf,
   resolveRelativeRange,
   TIME_RANGE_OPTIONS,
   TimeOption
 } from './utils/timeRangeOptions'
 
+// The label lives here rather than in each consumer because aria-labelledby
+// applied from outside would fall through to this component's plain root div,
+// where it is inert; inside, it can name the actual trigger button. Optional so
+// a consumer that supplies its own heading can omit it.
+defineProps<{
+  label?: string
+}>()
+
 const emit = defineEmits(['updateTime'])
 
+const labelId = useId()
+
 const menu = ref()
-const startDateRef = ref()
-const startTimeRef = ref<TimeOption>({ label: '1 PM', time: { hours: 13 }})
-const endDateRef = ref()
-const endTimeRef = ref<TimeOption>({ label: '1 PM', time: { hours: 13 }})
+
+// One instant per range end (NMS-20280). These used to be a date ref plus a
+// whole-hour OnmsSelect whose value was added to the date; OnmsDatePicker's
+// showTime carries the time of day directly, to the minute.
+const startDateRef = ref<Date | null>(null)
+const endDateRef = ref<Date | null>(null)
 
 const selectedTime = ref('Last day')
 
-const disableCustomTimeBtn = computed(() => Boolean(!startDateRef.value || !startTimeRef.value || !endDateRef.value || !endTimeRef.value))
+// How many picker overlays are on screen (there are two, and both can be open in
+// sequence). Fed by OnmsDatePicker's show/hide.
+const openPickerCount = ref(0)
+
+/**
+ * Latched on mousedown over the preset list, NOT read at click time.
+ *
+ * PrimeVue's DatePicker dismisses its overlay from a document-level *mousedown*
+ * listener, so by the time the preset's click handler runs the panel is already
+ * gone and openPickerCount is back to 0. Sampling here -- the <ul> sees mousedown
+ * before it bubbles to document -- is what makes "a click that merely dismissed a
+ * picker" distinguishable from "a click that chose a preset".
+ */
+const dismissedPickerOnPress = ref(false)
+
+const latchPickerDismissal = () => {
+  dismissedPickerOnPress.value = openPickerCount.value > 0
+}
+
+const disableCustomTimeBtn = computed(() => !startDateRef.value || !endDateRef.value)
 
 const toggleMenu = (event: Event) => menu.value.toggle(event)
 
@@ -93,6 +135,13 @@ const toggleMenu = (event: Event) => menu.value.toggle(event)
  * produces a genuinely absolute window, matching the legacy graph pages.
  */
 const selectOption = (option: TimeOption) => {
+  // The press that opened this click dismissed a picker overlay instead; accept
+  // whatever that picker had selected and leave the popover open.
+  if (dismissedPickerOnPress.value) {
+    dismissedPickerOnPress.value = false
+    return
+  }
+
   selectedTime.value = option.label
 
   const range = relativeRangeOf(option)
@@ -116,9 +165,14 @@ const selectOption = (option: TimeOption) => {
 }
 
 const applyCustomTime = () => {
+  // The button is disabled until both are set; this narrows the refs without a cast.
+  if (!startDateRef.value || !endDateRef.value) {
+    return
+  }
+
   let format = 'hours'
-  const startTime = getUnixTime(add(startDateRef.value, startTimeRef.value.time))
-  const endTime = getUnixTime(add(endDateRef.value, endTimeRef.value.time))
+  const startTime = getUnixTime(startDateRef.value)
+  const endTime = getUnixTime(endDateRef.value)
 
   // end - start, as Dates. This previously passed unix SECONDS in the wrong order,
   // so the difference was always negative and every custom range was labeled as
@@ -150,8 +204,19 @@ const applyCustomTime = () => {
 
 <style lang="scss" scoped>
 @import '@/styles/onms-typography';
+// No fixed height: the row is as tall as its tallest child, so the label text and
+// the button text share a baseline. A 70px box around a 35px button made that
+// impossible.
 .wrapper {
-  height: 70px;
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+
+  .time-range-label {
+    font-weight: 700;
+    white-space: nowrap;
+  }
+
   .graph-controls {
     padding: 8px;
     max-height: 35px;
@@ -188,6 +253,11 @@ const applyCustomTime = () => {
 
   .custom-col {
     flex: 1;
+
+    // 1em between the Start, End and Apply blocks.
+    > * + * {
+      margin-top: 1em;
+    }
 
     .date-input {
       @include onms-body-small;

--- a/ui/src/components/Common/utils/timeRangeOptions.ts
+++ b/ui/src/components/Common/utils/timeRangeOptions.ts
@@ -53,34 +53,6 @@ export const TIME_RANGE_OPTIONS: TimeOption[] = [
   { label: 'Last year', time: { years: 1 }}
 ]
 
-/** Hour-of-day choices for the custom range. */
-export const HOUR_OPTIONS: TimeOption[] = [
-  { label: '12 AM', time: { hours: 0 }},
-  { label: '1 AM', time: { hours: 1 }},
-  { label: '2 AM', time: { hours: 2 }},
-  { label: '3 AM', time: { hours: 3 }},
-  { label: '4 AM', time: { hours: 4 }},
-  { label: '5 AM', time: { hours: 5 }},
-  { label: '6 AM', time: { hours: 6 }},
-  { label: '7 AM', time: { hours: 7 }},
-  { label: '8 AM', time: { hours: 8 }},
-  { label: '9 AM', time: { hours: 9 }},
-  { label: '10 AM', time: { hours: 10 }},
-  { label: '11 AM', time: { hours: 11 }},
-  { label: '12 PM', time: { hours: 12 }},
-  { label: '1 PM', time: { hours: 13 }},
-  { label: '2 PM', time: { hours: 14 }},
-  { label: '3 PM', time: { hours: 15 }},
-  { label: '4 PM', time: { hours: 16 }},
-  { label: '5 PM', time: { hours: 17 }},
-  { label: '6 PM', time: { hours: 18 }},
-  { label: '7 PM', time: { hours: 19 }},
-  { label: '8 PM', time: { hours: 20 }},
-  { label: '9 PM', time: { hours: 21 }},
-  { label: '10 PM', time: { hours: 22 }},
-  { label: '11 PM', time: { hours: 23 }}
-]
-
 /** Units a relative range may use; anything else is rejected when decoding a link. */
 export const RANGE_UNITS: RelativeTimeRange['unit'][] =
   ['minutes', 'hours', 'days', 'weeks', 'months', 'years']

--- a/ui/src/components/Resources/Graphs.vue
+++ b/ui/src/components/Resources/Graphs.vue
@@ -7,7 +7,10 @@
   <div class="onms-row">
     <div class="onms-col-11">
       <div class="controls">
-        <TimeControls @updateTime="updateTime" />
+        <TimeControls
+          label="Time Range:"
+          @updateTime="updateTime"
+        />
         <FormField
           v-if="!singleGraphDefinition"
           class="search-input"
@@ -40,7 +43,7 @@ import { useDebounceFn, useScroll } from '@vueuse/core'
 import { useRouter } from 'vue-router'
 
 import GraphContainer from './GraphContainer.vue'
-import TimeControls from './TimeControls.vue'
+import TimeControls from '@/components/Common/TimeControls.vue'
 import { sub, getUnixTime } from 'date-fns'
 import { StartEndTime } from '@/types'
 import FormField from '@/components/Common/FormField.vue'

--- a/ui/tests/components/Common/TimeControls.test.ts
+++ b/ui/tests/components/Common/TimeControls.test.ts
@@ -1,0 +1,272 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { OnmsButton, OnmsDatePicker } from '@opennms/onms-ui'
+import { mount } from '@vue/test-utils'
+import { getUnixTime } from 'date-fns'
+import PrimeVue from 'primevue/config'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import TimeControls from '@/components/Common/TimeControls.vue'
+
+// OnmsPopover renders its slot only while the overlay is open, and appends the
+// panel to <body>. Stubbing it keeps this test on TimeControls' own custom-range
+// arithmetic instead of PrimeVue's overlay lifecycle; toggle/hide are stubbed
+// because the component calls them through the template ref.
+const popoverHideCalls = { count: 0 }
+
+const OnmsPopoverStub = {
+  template: '<div><slot /></div>',
+  methods: {
+    toggle: () => undefined,
+    hide: () => {
+      popoverHideCalls.count++
+    }
+  }
+}
+
+const mountControls = (props: Record<string, unknown> = {}) => mount(TimeControls, {
+  props,
+  global: {
+    plugins: [PrimeVue],
+    stubs: { OnmsPopover: OnmsPopoverStub }
+  }
+})
+
+/** Drive the two custom-range pickers the way a user's selections would. */
+const pick = async (wrapper: ReturnType<typeof mountControls>, start: Date | null, end: Date | null) => {
+  const pickers = wrapper.findAllComponents(OnmsDatePicker)
+  expect(pickers).toHaveLength(2)
+
+  await pickers[0].vm.$emit('update:modelValue', start)
+  await pickers[1].vm.$emit('update:modelValue', end)
+}
+
+const applyButton = (wrapper: ReturnType<typeof mountControls>) =>
+  wrapper.findAll('button').find(button => button.text().includes('Apply custom time'))!
+
+describe('TimeControls custom range', () => {
+  let wrapper: ReturnType<typeof mountControls>
+
+  beforeEach(() => {
+    popoverHideCalls.count = 0
+    wrapper = mountControls()
+  })
+
+  it('offers one date-and-time picker per range end', () => {
+    const pickers = wrapper.findAllComponents(OnmsDatePicker)
+
+    expect(pickers).toHaveLength(2)
+    for (const picker of pickers) {
+      expect(picker.props('showTime')).toBe(true)
+      expect(picker.props('hourFormat')).toBe('12')
+    }
+  })
+
+  it('emits the picked instants, time of day included', async () => {
+    const start = new Date(2026, 8, 1, 13, 30)
+    const end = new Date(2026, 8, 2, 9, 45)
+
+    await pick(wrapper, start, end)
+    await applyButton(wrapper).trigger('click')
+
+    expect(wrapper.emitted('updateTime')).toEqual([[{
+      startTime: getUnixTime(start),
+      endTime: getUnixTime(end),
+      format: 'hours'
+    }]])
+  })
+
+  it('labels a sub-hour window as minutes', async () => {
+    const start = new Date(2026, 8, 1, 13, 0)
+
+    await pick(wrapper, start, new Date(2026, 8, 1, 13, 30))
+    await applyButton(wrapper).trigger('click')
+
+    expect(wrapper.emitted('updateTime')![0][0]).toMatchObject({ format: 'minutes' })
+  })
+
+  it('labels a multi-day window as days', async () => {
+    await pick(wrapper, new Date(2026, 8, 1, 13, 0), new Date(2026, 8, 5, 13, 0))
+    await applyButton(wrapper).trigger('click')
+
+    expect(wrapper.emitted('updateTime')![0][0]).toMatchObject({ format: 'days' })
+  })
+
+  // An absolute window must never carry `range`, or the consumer would slide it
+  // forward on every refresh.
+  it('emits no relative range for an absolute window', async () => {
+    await pick(wrapper, new Date(2026, 8, 1, 13, 0), new Date(2026, 8, 2, 13, 0))
+    await applyButton(wrapper).trigger('click')
+
+    expect(wrapper.emitted('updateTime')![0][0]).not.toHaveProperty('range')
+  })
+
+  it('disables apply until both instants are picked', async () => {
+    expect(applyButton(wrapper).attributes('disabled')).toBeDefined()
+
+    await pick(wrapper, new Date(2026, 8, 1, 13, 0), null)
+    expect(applyButton(wrapper).attributes('disabled')).toBeDefined()
+
+    await pick(wrapper, new Date(2026, 8, 1, 13, 0), new Date(2026, 8, 2, 13, 0))
+    expect(applyButton(wrapper).attributes('disabled')).toBeUndefined()
+  })
+
+  it('bounds each picker by the other, so a range cannot invert', async () => {
+    const start = new Date(2026, 8, 1, 13, 0)
+    const end = new Date(2026, 8, 2, 9, 0)
+
+    await pick(wrapper, start, end)
+    const [startPicker, endPicker] = wrapper.findAllComponents(OnmsDatePicker)
+
+    expect(startPicker.props('maxDate')).toEqual(end)
+    expect(endPicker.props('minDate')).toEqual(start)
+  })
+
+  it('renders apply as a ghost button', () => {
+    const apply = wrapper.findAllComponents(OnmsButton)
+      .find(button => button.text().includes('Apply custom time'))!
+
+    expect(apply.props('variant')).toBe('ghost')
+  })
+})
+
+describe('TimeControls preset options', () => {
+  beforeEach(() => {
+    popoverHideCalls.count = 0
+  })
+
+  const firstOption = (wrapper: ReturnType<typeof mountControls>) =>
+    wrapper.findAll('.options-col .list-item')[0]
+
+  it('selects a preset and closes the popover', async () => {
+    const wrapper = mountControls()
+    const option = firstOption(wrapper)
+
+    await option.trigger('mousedown')
+    await option.trigger('click')
+
+    expect(wrapper.emitted('updateTime')).toHaveLength(1)
+    expect(popoverHideCalls.count).toBe(1)
+  })
+
+  // PrimeVue's DatePicker unbinds its overlay on document MOUSEDOWN, so by the
+  // time this click fires the panel is already gone and `datePickerOpen` reads
+  // false. The suppression therefore has to latch on mousedown, which reaches
+  // the <li> target before the document-level listener bubbles. A test that
+  // only triggered 'click' would pass against a naive click-time check.
+  it('ignores a preset click that only dismissed an open picker', async () => {
+    const wrapper = mountControls()
+    await wrapper.findAllComponents(OnmsDatePicker)[0].vm.$emit('show')
+
+    const option = firstOption(wrapper)
+    await option.trigger('mousedown')
+    await wrapper.findAllComponents(OnmsDatePicker)[0].vm.$emit('hide')
+    await option.trigger('click')
+
+    expect(wrapper.emitted('updateTime')).toBeUndefined()
+    expect(popoverHideCalls.count).toBe(0)
+  })
+
+  it('selects a preset on the next click after the picker is dismissed', async () => {
+    const wrapper = mountControls()
+    const pickers = wrapper.findAllComponents(OnmsDatePicker)
+    const option = firstOption(wrapper)
+
+    await pickers[0].vm.$emit('show')
+    await option.trigger('mousedown')
+    await pickers[0].vm.$emit('hide')
+    await option.trigger('click')
+
+    await option.trigger('mousedown')
+    await option.trigger('click')
+
+    expect(wrapper.emitted('updateTime')).toHaveLength(1)
+    expect(popoverHideCalls.count).toBe(1)
+  })
+
+  // Two pickers share one flag; the second closing must not be masked by the
+  // first, nor the flag left latched while one is still open.
+  it('stays suppressed while the second picker is still open', async () => {
+    const wrapper = mountControls()
+    const pickers = wrapper.findAllComponents(OnmsDatePicker)
+
+    await pickers[0].vm.$emit('show')
+    await pickers[1].vm.$emit('show')
+    await pickers[0].vm.$emit('hide')
+
+    const option = firstOption(wrapper)
+    await option.trigger('mousedown')
+    await option.trigger('click')
+
+    expect(wrapper.emitted('updateTime')).toBeUndefined()
+  })
+})
+
+describe('TimeControls label', () => {
+  it('renders no label by default', () => {
+    const wrapper = mountControls()
+
+    expect(wrapper.find('.time-range-label').exists()).toBe(false)
+  })
+
+  // The label has to live here rather than in each consumer: aria-labelledby on
+  // the component from outside would land on TimeControls' plain root div, where
+  // it is inert. Inside, it can be put on the actual trigger button.
+  it('renders the label and names the trigger button with it', () => {
+    const wrapper = mountControls({ label: 'Time Range:' })
+    const label = wrapper.find('.time-range-label')
+
+    expect(label.text()).toBe('Time Range:')
+    expect(label.attributes('id')).toBeTruthy()
+    expect(wrapper.get('button[aria-haspopup="true"]').attributes('aria-labelledby'))
+      .toBe(label.attributes('id'))
+  })
+
+  it('leaves the trigger button unnamed when there is no label', () => {
+    const wrapper = mountControls()
+
+    expect(wrapper.get('button[aria-haspopup="true"]').attributes('aria-labelledby'))
+      .toBeUndefined()
+  })
+
+  // Two instances must be mounted in ONE app: Vue's useId counter is per app
+  // instance, so two separate mount() calls would both yield 'v-0' and the
+  // assertion would be vacuous.
+  it('gives each instance on a page its own label id', () => {
+    const Host = {
+      components: { TimeControls },
+      template: '<div><TimeControls label="From:" /><TimeControls label="To:" /></div>'
+    }
+    const wrapper = mount(Host, {
+      global: {
+        plugins: [PrimeVue],
+        stubs: { OnmsPopover: OnmsPopoverStub }
+      }
+    })
+
+    const [first, second] = wrapper.findAll('.time-range-label')
+
+    expect(first.attributes('id')).toBeTruthy()
+    expect(first.attributes('id')).not.toBe(second.attributes('id'))
+  })
+})

--- a/ui/tests/components/Common/TimeControls.test.ts
+++ b/ui/tests/components/Common/TimeControls.test.ts
@@ -238,8 +238,10 @@ describe('TimeControls label', () => {
 
     expect(label.text()).toBe('Time Range:')
     expect(label.attributes('id')).toBeTruthy()
+    // The label leads the accessible name; the exact composition (label id then
+    // the button's own id) is asserted in the accessible-name test below.
     expect(wrapper.get('button[aria-haspopup="true"]').attributes('aria-labelledby'))
-      .toBe(label.attributes('id'))
+      .toMatch(new RegExp(`^${label.attributes('id')}\\b`))
   })
 
   it('leaves the trigger button unnamed when there is no label', () => {
@@ -252,6 +254,22 @@ describe('TimeControls label', () => {
   // Two instances must be mounted in ONE app: Vue's useId counter is per app
   // instance, so two separate mount() calls would both yield 'v-0' and the
   // assertion would be vacuous.
+  // aria-labelledby REPLACES the element's content as its accessible name, so
+  // pointing it at the label span alone renamed the button from "Last day" to
+  // "Time Range:" -- the selected range, the only changing information on the
+  // button, stopped being announced. Referencing the button's own id after the
+  // label's concatenates the two.
+  it('names the trigger button with the label AND the selected range', () => {
+    const wrapper = mountControls({ label: 'Time Range:' })
+    const button = wrapper.get('button[aria-haspopup="true"]')
+    const labelId = wrapper.get('.time-range-label').attributes('id')
+
+    expect(button.attributes('id')).toBeTruthy()
+    expect(button.attributes('aria-labelledby'))
+      .toBe(`${labelId} ${button.attributes('id')}`)
+    expect(button.text()).toContain('Last day')
+  })
+
   it('gives each instance on a page its own label id', () => {
     const Host = {
       components: { TimeControls },
@@ -268,5 +286,79 @@ describe('TimeControls label', () => {
 
     expect(first.attributes('id')).toBeTruthy()
     expect(first.attributes('id')).not.toBe(second.attributes('id'))
+  })
+})
+
+describe('TimeControls range validity', () => {
+  const applyButton = (wrapper: ReturnType<typeof mountControls>) =>
+    wrapper.findAll('button').find(button => button.text().includes('Apply custom time'))!
+
+  const pickRange = async (wrapper: ReturnType<typeof mountControls>, start: Date, end: Date) => {
+    const pickers = wrapper.findAllComponents(OnmsDatePicker)
+    await pickers[0].vm.$emit('update:modelValue', start)
+    await pickers[1].vm.$emit('update:modelValue', end)
+  }
+
+  // minDate/maxDate cross-wiring is NOT sufficient. PrimeVue's isSelectable
+  // compares only year/month/day, and isValidSelection (the typed-input path,
+  // with manualInput defaulting to true) goes through it -- so typing a later
+  // time on the boundary DAY into the start field is accepted unclamped.
+  it('rejects an inverted range', async () => {
+    const wrapper = mountControls()
+
+    await pickRange(wrapper, new Date(2026, 8, 2, 23, 30), new Date(2026, 8, 2, 9, 0))
+
+    expect(applyButton(wrapper).attributes('disabled')).toBeDefined()
+  })
+
+  // A calendar click DOES clamp at full granularity (selectDate assigns
+  // date = maxDate), so clicking a too-late day in the start field lands
+  // exactly on the end instant. That zero-width window is the likely outcome,
+  // not the inverted one.
+  it('rejects a zero-width range', async () => {
+    const wrapper = mountControls()
+    const instant = new Date(2026, 8, 2, 9, 0)
+
+    await pickRange(wrapper, instant, new Date(instant))
+
+    expect(applyButton(wrapper).attributes('disabled')).toBeDefined()
+  })
+
+  it('emits nothing for an invalid range', async () => {
+    const wrapper = mountControls()
+
+    await pickRange(wrapper, new Date(2026, 8, 2, 23, 30), new Date(2026, 8, 2, 9, 0))
+    await applyButton(wrapper).trigger('click')
+
+    expect(wrapper.emitted('updateTime')).toBeUndefined()
+  })
+
+  it('explains why an invalid range is rejected', async () => {
+    const wrapper = mountControls()
+
+    await pickRange(wrapper, new Date(2026, 8, 2, 23, 30), new Date(2026, 8, 2, 9, 0))
+
+    expect(wrapper.text()).toContain('End must be after start')
+  })
+
+  it('accepts a well-ordered range', async () => {
+    const wrapper = mountControls()
+
+    await pickRange(wrapper, new Date(2026, 8, 1, 13, 0), new Date(2026, 8, 2, 9, 0))
+
+    expect(applyButton(wrapper).attributes('disabled')).toBeUndefined()
+    expect(wrapper.text()).not.toContain('End must be after start')
+  })
+
+  it('labels each range field for its own picker input', () => {
+    const wrapper = mountControls()
+    const labels = wrapper.findAll('.custom-col label[for]')
+    const inputIds = wrapper.findAll('.custom-col input').map(input => input.attributes('id'))
+
+    expect(labels).toHaveLength(2)
+    for (const label of labels) {
+      expect(inputIds).toContain(label.attributes('for'))
+    }
+    expect(labels[0].attributes('for')).not.toBe(labels[1].attributes('for'))
   })
 })

--- a/ui/tests/components/Common/TimeControls.test.ts
+++ b/ui/tests/components/Common/TimeControls.test.ts
@@ -204,6 +204,25 @@ describe('TimeControls preset options', () => {
     expect(popoverHideCalls.count).toBe(1)
   })
 
+  // An unmatched hide must not drive the count below zero: a later show would
+  // then only bring it back to 0, the latch would read "no picker open" while
+  // one is on screen, and the preset click would be taken as a selection. Only
+  // `> 0` is read, so an unclamped decrement fails silently rather than loudly.
+  it('survives a hide with no matching show', async () => {
+    const wrapper = mountControls()
+    const picker = wrapper.findAllComponents(OnmsDatePicker)[0]
+
+    await picker.vm.$emit('hide')
+    await picker.vm.$emit('show')
+
+    const option = firstOption(wrapper)
+    await option.trigger('mousedown')
+    await option.trigger('click')
+
+    expect(wrapper.emitted('updateTime')).toBeUndefined()
+    expect(popoverHideCalls.count).toBe(0)
+  })
+
   // Two pickers share one flag; the second closing must not be masked by the
   // first, nor the flag left latched while one is still open.
   it('stays suppressed while the second picker is still open', async () => {

--- a/ui/tests/components/Common/timeRangeOptions.test.ts
+++ b/ui/tests/components/Common/timeRangeOptions.test.ts
@@ -3,11 +3,10 @@ import { describe, expect, it } from 'vitest'
 
 import {
   DEFAULT_RANGE,
-  HOUR_OPTIONS,
   relativeRangeOf,
   resolveRelativeRange,
   TIME_RANGE_OPTIONS
-} from '@/components/Resources/utils/timeRangeOptions'
+} from '@/components/Common/utils/timeRangeOptions'
 
 // A date well away from a DST boundary or month end, so the arithmetic below is
 // unambiguous.
@@ -80,26 +79,6 @@ describe('TIME_RANGE_OPTIONS', () => {
   it('carries exactly one duration field per option', () => {
     for (const option of TIME_RANGE_OPTIONS) {
       expect(Object.keys(option.time), option.label).toHaveLength(1)
-    }
-  })
-})
-
-describe('HOUR_OPTIONS', () => {
-  it('covers all 24 hours of the day in order', () => {
-    expect(HOUR_OPTIONS).toHaveLength(24)
-    expect(HOUR_OPTIONS.map(option => option.time.hours)).toEqual(
-      Array.from({ length: 24 }, (_unused, hour) => hour)
-    )
-  })
-
-  it('labels midnight and noon as 12 AM and 12 PM', () => {
-    expect(HOUR_OPTIONS[0].label).toBe('12 AM')
-    expect(HOUR_OPTIONS[12].label).toBe('12 PM')
-  })
-
-  it('uses numeric hours, so add() cannot concatenate them', () => {
-    for (const option of HOUR_OPTIONS) {
-      expect(typeof option.time.hours, option.label).toBe('number')
     }
   })
 })

--- a/ui/tests/onms-ui/OnmsDatePicker.test.ts
+++ b/ui/tests/onms-ui/OnmsDatePicker.test.ts
@@ -133,4 +133,17 @@ describe('OnmsDatePicker', () => {
     expect(wrapper.emitted('show')).toHaveLength(1)
     expect(wrapper.emitted('hide')).toHaveLength(1)
   })
+
+  // Needed so a FormField label can be associated with the real <input>:
+  // PrimeVue renders the input inside a wrapper, so an `id` falling through to
+  // the root lands on the wrapper, where a label's `for` cannot reach it.
+  it('declares and forwards inputId onto the rendered input', () => {
+    const wrapper = mount(OnmsDatePicker, {
+      props: { inputId: 'range-start' },
+      global: globalPlugins
+    })
+
+    expect(wrapper.props('inputId')).toBe('range-start')
+    expect(wrapper.get('input').attributes('id')).toBe('range-start')
+  })
 })

--- a/ui/tests/onms-ui/OnmsDatePicker.test.ts
+++ b/ui/tests/onms-ui/OnmsDatePicker.test.ts
@@ -28,4 +28,109 @@ describe('OnmsDatePicker', () => {
     const wrapper = mount(OnmsDatePicker, { global: globalPlugins })
     expect(wrapper.findComponent({ name: 'DatePicker' }).props('modelValue')).toBe(null)
   })
+
+  // Seam rule 2: the public API is the DECLARED props only. Asserting via
+  // wrapper.props() (which lists declared props, not $attrs) is deliberate --
+  // an undeclared attr still reaches the inner DatePicker by fallthrough, so
+  // asserting only on the inner component would pass without a real contract.
+  it('declares the time props with PrimeVue-matching defaults', () => {
+    const wrapper = mount(OnmsDatePicker, { global: globalPlugins })
+    const inner = wrapper.findComponent({ name: 'DatePicker' })
+
+    expect(wrapper.props()).toMatchObject({
+      showTime: false,
+      timeOnly: false,
+      hourFormat: '24',
+      showSeconds: false,
+      stepHour: 1,
+      stepMinute: 1,
+      stepSecond: 1
+    })
+    expect(inner.props('showTime')).toBe(false)
+    expect(inner.props('hourFormat')).toBe('24')
+  })
+
+  it('declares and forwards the time props', () => {
+    const wrapper = mount(OnmsDatePicker, {
+      props: {
+        showTime: true,
+        hourFormat: '12',
+        showSeconds: true,
+        stepHour: 2,
+        stepMinute: 15,
+        stepSecond: 30
+      },
+      global: globalPlugins
+    })
+    const inner = wrapper.findComponent({ name: 'DatePicker' })
+
+    expect(wrapper.props()).toMatchObject({
+      showTime: true,
+      hourFormat: '12',
+      showSeconds: true,
+      stepHour: 2,
+      stepMinute: 15,
+      stepSecond: 30
+    })
+    expect(inner.props('showTime')).toBe(true)
+    expect(inner.props('hourFormat')).toBe('12')
+    expect(inner.props('showSeconds')).toBe(true)
+    expect(inner.props('stepHour')).toBe(2)
+    expect(inner.props('stepMinute')).toBe(15)
+    expect(inner.props('stepSecond')).toBe(30)
+  })
+
+  // timeOnly needs no companion showTime: PrimeVue gates the time panel on
+  // `showTime || timeOnly` and the date panel on `!timeOnly`.
+  it('declares and forwards timeOnly on its own', () => {
+    const wrapper = mount(OnmsDatePicker, {
+      props: { timeOnly: true, showSeconds: true },
+      global: globalPlugins
+    })
+
+    expect(wrapper.props('timeOnly')).toBe(true)
+    expect(wrapper.findComponent({ name: 'DatePicker' }).props('timeOnly')).toBe(true)
+  })
+
+  it('declares and forwards placeholder and the date bounds', () => {
+    const min = new Date(2026, 0, 1)
+    const max = new Date(2026, 11, 31)
+    const wrapper = mount(OnmsDatePicker, {
+      props: { placeholder: 'From', minDate: min, maxDate: max },
+      global: globalPlugins
+    })
+    const inner = wrapper.findComponent({ name: 'DatePicker' })
+
+    expect(wrapper.props()).toMatchObject({ placeholder: 'From', minDate: min, maxDate: max })
+    expect(inner.props('placeholder')).toBe('From')
+    expect(inner.props('minDate')).toEqual(min)
+    expect(inner.props('maxDate')).toEqual(max)
+  })
+
+  // Consumers hold their bounds in nullable refs (TimeControls' startDateRef /
+  // endDateRef). PrimeVue types minDate/maxDate as `Date | undefined` and treats
+  // any non-undefined value as a real bound, so a null must not reach it.
+  it('normalizes null date bounds to undefined', () => {
+    const inner = mount(OnmsDatePicker, {
+      props: { minDate: null, maxDate: null },
+      global: globalPlugins
+    }).findComponent({ name: 'DatePicker' })
+
+    expect(inner.props('minDate')).toBeUndefined()
+    expect(inner.props('maxDate')).toBeUndefined()
+  })
+
+  // Overlay-visibility events, in framework-neutral vocabulary. TimeControls
+  // needs them to know whether a picker panel is on screen; without them a
+  // consumer's only route is reaching into PrimeVue internals.
+  it('forwards the overlay show and hide events', async () => {
+    const wrapper = mount(OnmsDatePicker, { global: globalPlugins })
+    const inner = wrapper.findComponent({ name: 'DatePicker' })
+
+    await inner.vm.$emit('show')
+    await inner.vm.$emit('hide')
+
+    expect(wrapper.emitted('show')).toHaveLength(1)
+    expect(wrapper.emitted('hide')).toHaveLength(1)
+  })
 })


### PR DESCRIPTION
# NMS-20280: Time support for `OnmsDatePicker`, and `TimeControls` fixes

Adds time-of-day support to the `OnmsDatePicker` seam wrapper, then uses it to
replace the fake time picker in `TimeControls` — which turned out to have a
silent 13-hour bug — and cleans up several long-standing annoyances in that
component.

## `OnmsDatePicker` (`onms-ui` component seam layer)

You can use `timeOnly` to show only time controls; `showTime` to include time controls under the date picker; or just display the date picker.

Now declares the following props.

| prop | type | default |
| --- | --- | --- |
| `showTime` | `boolean` | `false` |
| `timeOnly` | `boolean` | `false` |
| `showSeconds` | `boolean` | `false` |
| `hourFormat` | `OnmsHourFormat` (`'12' \| '24'`) | `'24'` |
| `stepHour` / `stepMinute` / `stepSecond` | `number` | `1` |
| `placeholder` | `string` | — |
| `minDate` / `maxDate` | `Date \| null` | — |
| `inputId` | `string` | — |

Plus new `show` / `hide` emits reporting overlay visibility.

Notes for reviewers:

- **No `OnmsTimePicker` is needed.** `timeOnly` works on its own — PrimeVue
  gates the time panel on `showTime || timeOnly` and the date panel on
  `!timeOnly`.
- **Every default matches PrimeVue's own**, so this changes no existing call
  site's rendering. These are not "notable deviations" in the README sense.
- `hourFormat` is typed as a new owned `OnmsHourFormat` in
  `packages/onms-ui/src/types.ts`, not PrimeVue's `HintedString<'12' | '24'>` —
  seam rule 4 (no PrimeVue types in a public signature).
- `minDate` / `maxDate` accept `Date | null` and collapse `null` to `undefined`
  before reaching PrimeVue, which types them `Date | undefined` and treats any
  non-`undefined` value as a live bound. This keeps a `?? undefined` out of
  every call site that holds its bounds in a nullable ref.
- `inputId` lands on the rendered `<input>`, not the wrapper, so a `FormField`
  label's `for` can reach the real control — matching what `OnmsSelect`,
  `OnmsInputNumber` and the other input wrappers already declare.
- These props were previously reachable only by Vue attribute fallthrough,
  which seam rule 2 classes as unsupported. Declaring them makes the API real.

## `TimeControls`

**Moved to `components/Common`**, along with `utils/timeRangeOptions.ts` —
`AdhocGraphBuilder.vue` and `adhocUrlState.ts` were already importing that out
of `components/Resources/`. Both moves are recorded as git renames.

### Bug fix: custom ranges were silently shifted 13 hours

The old UI was a date picker plus a separate whole-hour `OnmsSelect`, and
`applyCustomTime` **added** the select's value to the picked date. The select
defaulted to `1 PM`, so unless the user touched both selects, every custom range
came out 13 hours off. The test that caught it:

```
expected startTime 1788330600, got 1788283800   // Δ = 46800s = 13h
```

One `showTime` picker per range end replaces the pair. Ranges are now
minute-precise instead of whole-hour. `HOUR_OPTIONS` becomes dead and is
removed with its test.

### Clicking the preset list while date picker open no longer closes the popover

Previously, clicking the preset list ("Last hour", …) while a date picker
overlay was open selected a preset *and* closed the popover. Now that click only
dismisses the picker, keeping its selection, and leaves the popover open.

### Range validity

An explicit ordering check, **not** the `:minDate` / `:maxDate` cross-wiring. PrimeVue does not enforce those strictly enough to be a correctness guarantee. The Apply button is disabled unless
`end > start`, the End field explains why, and `applyCustomTime` re-checks rather than trusting the button's disabled state.

### Labels and accessibility

- **New optional `label` prop** renders a bold label beside the trigger button.
  The **Resource Graphs page gains the "Time Range:" label it was missing**, and
  `AdhocChartToolbar` drops its local `<span>` + CSS in favor of the prop.
- The trigger button is named by `"<label id> <own id>"`, so its accessible name
  is "Time Range: **Last day**" — label *and* current selection.
- The Start and End `FormField`s pass a `for` matching each picker's `inputId`,
  so those labels are associated with their inputs for the first time.

### Layout

- Dropped `.wrapper`'s fixed `height: 70px` (a 70px box around a 35px button) so
  the label and button text align on a baseline.
- "Apply custom time" is now `variant="ghost"`, with `1em` between the Start,
  End and Apply blocks.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20280