### PR TITLE
NMS-19840: Kafka producer json metric payloads

### DIFF
--- a/container/features/pom.xml
+++ b/container/features/pom.xml
@@ -530,6 +530,7 @@
                           <feature>opennms-timeseries-api</feature>
                           <feature>opennms-timeseries-api</feature>
                           <feature>opennms-grpc-exporter</feature>
+                          <feature>opennms-kafka-producer</feature>
                           <feature>vaadin</feature>
 
                           <!-- minion features -->

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -1031,6 +1031,9 @@
         <feature>opennms-collection-api</feature>
         <feature>opennms-situation-feedback-api</feature>
         <bundle>wrap:mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
+        <!-- gson is a mandatory Import-Package of the wrapped protobuf-java-util bundle -->
+        <bundle dependency="true">mvn:com.google.code.gson/gson/${gsonVersion}</bundle>
+        <bundle dependency="true">wrap:mvn:com.google.protobuf/protobuf-java-util/${protobufVersion}$overwrite=merge&amp;Import-Package=javax.annotation;version=!,*</bundle>
         <bundle>mvn:at.yawk.lz4/lz4-java/${lz4JavaVersion}</bundle>
         <bundle>mvn:org.opennms.core.ipc.common/org.opennms.core.ipc.common.kafka/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.kafka/org.opennms.features.kafka.producer/${project.version}</bundle>

--- a/docs/modules/operation/pages/deep-dive/kafka-producer/configure-kafka.adoc
+++ b/docs/modules/operation/pages/deep-dive/kafka-producer/configure-kafka.adoc
@@ -204,6 +204,10 @@ The JSON representation follows the canonical protobuf JSON mapping of the same 
 Note that JSON messages are larger than their protobuf equivalents; the message splitting described above accounts for the encoded size, so large collection sets may split into more messages when JSON is enabled.
 This setting only affects metrics; events, alarms, nodes, and topology messages are always forwarded as protobuf.
 
+IMPORTANT: JSON has no representation for non-finite numbers, so the protobuf JSON mapping encodes them as the strings `"NaN"`, `"Infinity"`, and `"-Infinity"`.
+A numeric attribute with a missing sample (for example, an uninitialized counter) is therefore forwarded with a string where consumers otherwise see a JSON number.
+Strongly typed consumers must either tolerate this mixed type or parse the payload with a protobuf JSON parser, which accepts these strings for numeric fields.
+
 === Enable exclusive metric forwarding
 
 Once metric forwarding is enabled, you can use this as the exclusive persistence strategy by setting the following system property:

--- a/docs/modules/operation/pages/deep-dive/kafka-producer/configure-kafka.adoc
+++ b/docs/modules/operation/pages/deep-dive/kafka-producer/configure-kafka.adoc
@@ -62,6 +62,10 @@ Set this to an empty string to disable filtering, and forward all metrics.
 | Set this value to `true` to enable forwarding of metrics.
 | false
 
+| metrics.useJson
+| Set this value to `true` to forward metrics encoded as JSON instead of protobuf (see below).
+| false
+
 | nodeRefreshTimeoutMs
 | Number of milliseconds to wait before looking up a node in the database again.
 Decrease this value to improve accuracy at the cost of additional database lookups.
@@ -173,6 +177,32 @@ Or add following line at `$OPENNMS_HOME/etc/org.opennms.features.kafka.producer.
 ```
 disable.metrics.splitting = true
 ```
+
+=== Forward metrics as JSON
+
+By default, metrics are forwarded as protobuf messages (see `collectionset.proto` in your distribution for the model definitions).
+To forward metrics encoded as JSON instead, set the value of the `metrics.useJson` property to `true`.
+
+[source, console]
+----
+$ ssh -p 8101 admin@localhost
+...
+admin@opennms()> config:edit org.opennms.features.kafka.producer
+admin@opennms()> config:property-set metrics.useJson true
+admin@opennms()> config:update
+----
+
+Or add following line at `$OPENNMS_HOME/etc/org.opennms.features.kafka.producer.cfg`
+```
+metrics.useJson = true
+```
+
+NOTE: The metric forwarder reads `metrics.useJson` (like `forward.metrics` and `disable.metrics.splitting`) only when the `opennms-kafka-producer` feature starts.
+After changing it, restart {page-component-title} (or restart the feature) for the change to take effect.
+
+The JSON representation follows the canonical protobuf JSON mapping of the same CollectionSet model.
+Note that JSON messages are larger than their protobuf equivalents; the message splitting described above accounts for the encoded size, so large collection sets may split into more messages when JSON is enabled.
+This setting only affects metrics; events, alarms, nodes, and topology messages are always forwarded as protobuf.
 
 === Enable exclusive metric forwarding
 

--- a/features/kafka/producer/pom.xml
+++ b/features/kafka/producer/pom.xml
@@ -146,6 +146,18 @@
       <artifactId>protobuf-java</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+      <version>${protobufVersion}</version>
+      <exclusions>
+        <!-- not necessary at runtime -->
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.opennms</groupId>
       <artifactId>opennms-alarm-api</artifactId>
       <version>${project.version}</version>

--- a/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/collection/KafkaPersister.java
+++ b/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/collection/KafkaPersister.java
@@ -54,8 +54,13 @@ public class KafkaPersister implements Persister {
 
     private static final ExpressionParser SPEL_PARSER = new SpelExpressionParser();
 
+    // NumericAttribute.type must always print: GAUGE is the zero enum value, which the
+    // printer would otherwise omit, leaving gauges without a type key while counters keep theirs
     private static final JsonFormat.Printer JSON_PRINTER = JsonFormat.printer()
-            .omittingInsignificantWhitespace();
+            .omittingInsignificantWhitespace()
+            .includingDefaultValueFields(Collections.singleton(
+                    CollectionSetProtos.NumericAttribute.getDescriptor()
+                            .findFieldByNumber(CollectionSetProtos.NumericAttribute.TYPE_FIELD_NUMBER)));
 
     private CollectionSetMapper collectionSetMapper;
 

--- a/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/collection/KafkaPersister.java
+++ b/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/collection/KafkaPersister.java
@@ -23,6 +23,8 @@ package org.opennms.features.kafka.producer.collection;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.opennms.features.kafka.producer.model.CollectionSetProtos;
@@ -39,6 +41,7 @@ import org.springframework.expression.Expression;
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -51,6 +54,9 @@ public class KafkaPersister implements Persister {
 
     private static final ExpressionParser SPEL_PARSER = new SpelExpressionParser();
 
+    private static final JsonFormat.Printer JSON_PRINTER = JsonFormat.printer()
+            .omittingInsignificantWhitespace();
+
     private CollectionSetMapper collectionSetMapper;
 
     private final ServiceParameters m_params;
@@ -60,6 +66,8 @@ public class KafkaPersister implements Persister {
     private String topicName = "metrics";
 
     private Boolean disableMetricsSplitting = false;
+
+    private boolean useJson = false;
 
     private Expression metricFilterExpression;
 
@@ -86,7 +94,11 @@ public class KafkaPersister implements Persister {
     }
 
     void bisectAndSendMessageToKafka(CollectionSetProtos.CollectionSet collectionSetProto) {
-        if (!getDisableMetricsSplitting() && checkForMaxSize(collectionSetProto.toByteArray().length)) {
+        final byte[] payload = serializeCollectionSet(collectionSetProto);
+        if (payload == null) {
+            return;
+        }
+        if (!getDisableMetricsSplitting() && checkForMaxSize(payload.length)) {
             if(collectionSetProto.getResourceCount() == 1) {
                 /// Handle the case where resource is only one with too many attributes that can cross max buffer size.
                 CollectionSetProtos.CollectionSetResource collectionSetResource = collectionSetProto.getResource(0);
@@ -120,19 +132,28 @@ public class KafkaPersister implements Persister {
                 bisectAndSendMessageToKafka(secondPartCollectionSet);
             }
         } else {
-            sendMessageToKafka(collectionSetProto);
+            sendMessageToKafka(collectionSetProto, payload);
         }
     }
 
     private void bisectNumericAttributes(CollectionSetProtos.CollectionSet collectionSetProto) {
         // Divide numeric attributes into two in recursive way
-        if (checkForMaxSize(collectionSetProto.toByteArray().length)) {
+        final byte[] payload = serializeCollectionSet(collectionSetProto);
+        if (payload == null) {
+            return;
+        }
+        final boolean oversized = checkForMaxSize(payload.length);
+        if (oversized && collectionSetProto.getResource(0).getNumericCount() > 1) {
             Iterator<List<CollectionSetProtos.NumericAttribute>> subList = Iterables.partition(collectionSetProto.getResource(0).getNumericList(),
                     (collectionSetProto.getResource(0).getNumericCount() + 1) / 2).iterator();
             bisectNumericAttributes(buildCollectionSetWithNumericAttributes(collectionSetProto, subList.next()));
             bisectNumericAttributes(buildCollectionSetWithNumericAttributes(collectionSetProto, subList.next()));
         } else {
-            sendMessageToKafka(collectionSetProto);
+            if (oversized) {
+                LOG.warn("A single attribute encodes to {} bytes, exceeding the maximum of {} bytes; it cannot be split further and will be sent as-is",
+                        payload.length, MAX_BUFFER_SIZE_CONFIGURED);
+            }
+            sendMessageToKafka(collectionSetProto, payload);
         }
     }
 
@@ -149,13 +170,22 @@ public class KafkaPersister implements Persister {
 
     private void bisectStringAttributes(CollectionSetProtos.CollectionSet collectionSetProto) {
         // Divide string attributes into two in recursive way
-        if (checkForMaxSize(collectionSetProto.toByteArray().length)) {
+        final byte[] payload = serializeCollectionSet(collectionSetProto);
+        if (payload == null) {
+            return;
+        }
+        final boolean oversized = checkForMaxSize(payload.length);
+        if (oversized && collectionSetProto.getResource(0).getStringCount() > 1) {
             Iterator<List<CollectionSetProtos.StringAttribute>> subList = Iterables.partition(collectionSetProto.getResource(0).getStringList(),
                     (collectionSetProto.getResource(0).getStringCount() + 1) / 2).iterator();
             bisectStringAttributes(buildCollectionSetWithStringAttributes(collectionSetProto, subList.next()));
             bisectStringAttributes(buildCollectionSetWithStringAttributes(collectionSetProto, subList.next()));
         } else {
-            sendMessageToKafka(collectionSetProto);
+            if (oversized) {
+                LOG.warn("A single attribute encodes to {} bytes, exceeding the maximum of {} bytes; it cannot be split further and will be sent as-is",
+                        payload.length, MAX_BUFFER_SIZE_CONFIGURED);
+            }
+            sendMessageToKafka(collectionSetProto, payload);
         }
     }
 
@@ -173,16 +203,33 @@ public class KafkaPersister implements Persister {
     boolean checkForMaxSize(int length) {
         return length > MAX_BUFFER_SIZE_CONFIGURED;
     }
-    
-    private void sendMessageToKafka( CollectionSetProtos.CollectionSet collectionSetProto) {
+
+    /**
+     * Serialize the CollectionSet with the configured output format:
+     * JSON when useJson is enabled, protobuf otherwise.
+     * Returns null if the CollectionSet could not be serialized.
+     */
+    byte[] serializeCollectionSet(CollectionSetProtos.CollectionSet collectionSetProto) {
+        if (useJson) {
+            try {
+                return JSON_PRINTER.print(collectionSetProto).getBytes(StandardCharsets.UTF_8);
+            } catch (InvalidProtocolBufferException e) {
+                LOG.error("Failed to serialize collection set with {} resources (key {}) to JSON, it will not be forwarded",
+                        collectionSetProto.getResourceCount(), deriveKeyFromCollectionSet(collectionSetProto), e);
+                return null;
+            }
+        }
+        return collectionSetProto.toByteArray();
+    }
+
+    private void sendMessageToKafka(CollectionSetProtos.CollectionSet collectionSetProto, byte[] payload) {
         // If no resources should be persisted, do not send an empty CollectionSet
         if (collectionSetProto.getResourceCount() == 0) {
             return;
         }
         // Derive key, it will be nodeId for all resources except for response time, it would be IpAddress
         final String key = deriveKeyFromCollectionSet(collectionSetProto);
-        final ProducerRecord<String, byte[]> record = new ProducerRecord<>(topicName, key,
-                collectionSetProto.toByteArray());
+        final ProducerRecord<String, byte[]> record = new ProducerRecord<>(topicName, key, payload);
         producer.send(record, (recordMetadata, e) -> {
             if (e != null) {
                 LOG.warn("Failed to send record to producer: {}.", record, e);
@@ -276,6 +323,10 @@ public class KafkaPersister implements Persister {
 
     public Boolean getDisableMetricsSplitting() {
         return disableMetricsSplitting;
+    }
+
+    public void setUseJson(boolean useJson) {
+        this.useJson = useJson;
     }
 
     public void setMetricFilter(final String metricFilter) {

--- a/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/collection/KafkaPersisterActivator.java
+++ b/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/collection/KafkaPersisterActivator.java
@@ -43,6 +43,7 @@ public class KafkaPersisterActivator implements BundleActivator {
 
     private static final String DISABLE_METRIC_SPLITTING = "disable.metrics.splitting";
     private static final String METRIC_FILTER = "metricFilter";
+    private static final String METRICS_USE_JSON = "metrics.useJson";
 
     @Override
     public void start(BundleContext context) throws Exception {
@@ -50,6 +51,7 @@ public class KafkaPersisterActivator implements BundleActivator {
         Boolean forwardMetrics = false;
         String metricTopic = null;
         boolean disableMetricsSplitting = false;
+        boolean useJson = false;
         String metricFilter = null;
         try {
             configAdmin = context.getService(context.getServiceReference(ConfigurationAdmin.class));
@@ -67,6 +69,9 @@ public class KafkaPersisterActivator implements BundleActivator {
                     }
                     if (properties.get(METRIC_FILTER) instanceof String) {
                         metricFilter = (String) properties.get(METRIC_FILTER);
+                    }
+                    if (properties.get(METRICS_USE_JSON) instanceof String) {
+                        useJson = Boolean.parseBoolean((String) properties.get(METRICS_USE_JSON));
                     }
                 }
             }
@@ -88,6 +93,7 @@ public class KafkaPersisterActivator implements BundleActivator {
                 kafkaPersisterFactory.init();
                 kafkaPersisterFactory.setTopicName(metricTopic);
                 kafkaPersisterFactory.setDisableMetricsSplitting(disableMetricsSplitting);
+                kafkaPersisterFactory.setUseJson(useJson);
                 kafkaPersisterFactory.setMetricFilter(metricFilter);
                 Dictionary<String, String> props = new Hashtable<String, String>();
                 // needed to register to onms registry.

--- a/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/collection/KafkaPersisterFactory.java
+++ b/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/collection/KafkaPersisterFactory.java
@@ -51,6 +51,7 @@ public class KafkaPersisterFactory implements PersisterFactory {
     private ConfigurationAdmin configAdmin;
     private String topicName;
     private boolean disableMetricsSplitting = false;
+    private boolean useJson = false;
     private String metricFilter;
 
     @Override
@@ -66,6 +67,7 @@ public class KafkaPersisterFactory implements PersisterFactory {
         persister.setProducer(producer);
         persister.setTopicName(topicName);
         persister.setDisableMetricsSplitting(disableMetricsSplitting);
+        persister.setUseJson(useJson);
         persister.setMetricFilter(metricFilter);
         return persister;
     }
@@ -132,6 +134,10 @@ public class KafkaPersisterFactory implements PersisterFactory {
 
     public void setDisableMetricsSplitting(boolean disableMetricsSplitting) {
         this.disableMetricsSplitting = disableMetricsSplitting;
+    }
+
+    public void setUseJson(boolean useJson) {
+        this.useJson = useJson;
     }
 
     public void setMetricFilter(String metricFilter) {

--- a/features/kafka/producer/src/main/resources/OSGI-INF/blueprint/blueprint-kafka-producer.xml
+++ b/features/kafka/producer/src/main/resources/OSGI-INF/blueprint/blueprint-kafka-producer.xml
@@ -23,6 +23,7 @@
       <cm:property name="metricTopic" value="metrics"/>
       <cm:property name="forward.metrics" value="true"/>
       <cm:property name="disable.metrics.splitting" value="false"/>
+      <cm:property name="metrics.useJson" value="false"/>
       <cm:property name="nodeRefreshTimeoutMs" value="300000"/> <!-- 5 minutes -->
       <cm:property name="alarmSync" value="true"/>
       <cm:property name="eventFilter" value=""/>

--- a/features/kafka/producer/src/test/java/org/opennms/features/kafka/producer/collection/KafkaPersisterJsonTest.java
+++ b/features/kafka/producer/src/test/java/org/opennms/features/kafka/producer/collection/KafkaPersisterJsonTest.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.features.kafka.producer.collection;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.startsWith;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.Before;
+import org.junit.Test;
+import org.opennms.features.kafka.producer.model.CollectionSetProtos;
+
+import com.google.protobuf.DoubleValue;
+import com.google.protobuf.util.JsonFormat;
+
+/**
+ * Verifies that the KafkaPersister can forward metrics encoded as JSON
+ * instead of protobuf when the metrics.useJson option is enabled.
+ */
+public class KafkaPersisterJsonTest {
+
+    private static final String TOPIC = "test-metrics";
+
+    private MockProducer<String, byte[]> mockProducer;
+
+    private KafkaPersister persister;
+
+    @Before
+    public void setUp() {
+        mockProducer = new MockProducer<>(true, new StringSerializer(), new ByteArraySerializer());
+        persister = new KafkaPersister();
+        persister.setProducer(mockProducer);
+        persister.setTopicName(TOPIC);
+    }
+
+    private static CollectionSetProtos.CollectionSet buildCollectionSet(int numAttributes) {
+        CollectionSetProtos.NodeLevelResource nodeLevelResource = CollectionSetProtos.NodeLevelResource.newBuilder()
+                .setNodeId(5)
+                .setNodeLabel("kafka-json-test")
+                .setForeignSource("fs")
+                .setForeignId("fid")
+                .build();
+        CollectionSetProtos.CollectionSetResource.Builder resourceBuilder = CollectionSetProtos.CollectionSetResource
+                .newBuilder().setNode(nodeLevelResource);
+        for (int i = 0; i < numAttributes; i++) {
+            resourceBuilder.addNumeric(CollectionSetProtos.NumericAttribute.newBuilder()
+                    .setName("metric" + i)
+                    .setGroup("group" + i)
+                    .setValue(100 + i)
+                    .setMetricValue(DoubleValue.of(100 + i))
+                    .setType(CollectionSetProtos.NumericAttribute.Type.GAUGE));
+        }
+        return CollectionSetProtos.CollectionSet.newBuilder()
+                .setTimestamp(1662000000000L)
+                .addResource(resourceBuilder)
+                .build();
+    }
+
+    @Test
+    public void testJsonPayloadRoundTrip() throws Exception {
+        persister.setUseJson(true);
+        CollectionSetProtos.CollectionSet collectionSet = buildCollectionSet(2);
+
+        persister.bisectAndSendMessageToKafka(collectionSet);
+
+        assertThat(mockProducer.history().size(), equalTo(1));
+        ProducerRecord<String, byte[]> record = mockProducer.history().get(0);
+        assertThat(record.topic(), equalTo(TOPIC));
+        assertThat(record.key(), equalTo("5"));
+
+        String json = new String(record.value(), StandardCharsets.UTF_8);
+        assertThat(json, startsWith("{"));
+
+        // The JSON must parse back into an equal CollectionSet
+        CollectionSetProtos.CollectionSet.Builder parsed = CollectionSetProtos.CollectionSet.newBuilder();
+        JsonFormat.parser().merge(json, parsed);
+        assertThat(parsed.build(), equalTo(collectionSet));
+    }
+
+    @Test
+    public void testProtobufPayloadByDefault() throws Exception {
+        CollectionSetProtos.CollectionSet collectionSet = buildCollectionSet(2);
+
+        persister.bisectAndSendMessageToKafka(collectionSet);
+
+        assertThat(mockProducer.history().size(), equalTo(1));
+        ProducerRecord<String, byte[]> record = mockProducer.history().get(0);
+        assertThat(CollectionSetProtos.CollectionSet.parseFrom(record.value()), equalTo(collectionSet));
+    }
+
+    @Test
+    public void testJsonPayloadIsSplitByJsonSize() throws Exception {
+        persister = new KafkaPersister() {
+            @Override
+            boolean checkForMaxSize(int length) {
+                // Force splitting on a small threshold; JSON is larger than
+                // protobuf, so the encoded JSON size must be what is checked
+                return length > 2048;
+            }
+        };
+        persister.setProducer(mockProducer);
+        persister.setTopicName(TOPIC);
+        persister.setUseJson(true);
+
+        CollectionSetProtos.CollectionSet collectionSet = buildCollectionSet(100);
+
+        persister.bisectAndSendMessageToKafka(collectionSet);
+
+        assertThat(mockProducer.history().size(), greaterThan(1));
+        // Each message must honor the maximum size and parse as valid JSON
+        CollectionSetProtos.CollectionSet.Builder merged = CollectionSetProtos.CollectionSet.newBuilder();
+        for (ProducerRecord<String, byte[]> record : mockProducer.history()) {
+            assertThat(record.value().length <= 2048, equalTo(true));
+            CollectionSetProtos.CollectionSet.Builder part = CollectionSetProtos.CollectionSet.newBuilder();
+            JsonFormat.parser().merge(new String(record.value(), StandardCharsets.UTF_8), part);
+            merged.mergeFrom(part.build());
+        }
+        // All numeric attributes must survive the split
+        List<String> names = merged.build().getResourceList().stream()
+                .flatMap(r -> r.getNumericList().stream())
+                .map(CollectionSetProtos.NumericAttribute::getName)
+                .collect(Collectors.toList());
+        assertThat(names.size(), equalTo(100));
+    }
+
+    @Test
+    public void testOversizedSingleAttributeTerminates() throws Exception {
+        persister = new KafkaPersister() {
+            @Override
+            boolean checkForMaxSize(int length) {
+                return length > 2048;
+            }
+        };
+        persister.setProducer(mockProducer);
+        persister.setTopicName(TOPIC);
+        persister.setUseJson(true);
+
+        // A single string attribute whose JSON encoding alone exceeds the maximum:
+        // it cannot be split, so it must be sent as-is rather than recursing forever
+        StringBuilder bigValue = new StringBuilder();
+        for (int i = 0; i < 5000; i++) {
+            bigValue.append('x');
+        }
+        CollectionSetProtos.NodeLevelResource nodeLevelResource = CollectionSetProtos.NodeLevelResource.newBuilder()
+                .setNodeId(5)
+                .build();
+        CollectionSetProtos.CollectionSet collectionSet = CollectionSetProtos.CollectionSet.newBuilder()
+                .setTimestamp(1662000000000L)
+                .addResource(CollectionSetProtos.CollectionSetResource.newBuilder()
+                        .setNode(nodeLevelResource)
+                        .addString(CollectionSetProtos.StringAttribute.newBuilder()
+                                .setName("bigString")
+                                .setValue(bigValue.toString())))
+                .build();
+
+        persister.bisectAndSendMessageToKafka(collectionSet);
+
+        assertThat(mockProducer.history().size(), equalTo(1));
+        CollectionSetProtos.CollectionSet.Builder parsed = CollectionSetProtos.CollectionSet.newBuilder();
+        JsonFormat.parser().merge(new String(mockProducer.history().get(0).value(), StandardCharsets.UTF_8), parsed);
+        assertThat(parsed.build(), equalTo(collectionSet));
+    }
+}


### PR DESCRIPTION
When enabled, the metrics persister encodes CollectionSets with protobuf JsonFormat instead of protobuf binary. Message splitting measures the encoded payload size, serializes once per message, and won't recurse forever on a single oversized attribute. Adds the gson bundle the wrapped protobuf-java-util requires, puts the opennms-kafka-producer feature under karaf verify, and documents the the option.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-19840

