### PR TITLE
NMS-20289: Eventd drops every event until the webapp loads the database eventconf

### DIFF
--- a/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/EventConfDbBootstrap.java
+++ b/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/EventConfDbBootstrap.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.eventd;
+
+import java.util.List;
+
+import org.opennms.netmgt.config.api.EventConfDao;
+import org.opennms.netmgt.dao.api.EventConfEventDao;
+import org.opennms.netmgt.dao.api.EventConfGlobalSecurityDao;
+import org.opennms.netmgt.model.EventConfEvent;
+import org.opennms.netmgt.model.EventConfGlobalSecurity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Loads the event configuration during context refresh, so Eventd never expands
+ * an event against a configuration that has not arrived yet.
+ *
+ * The DAOs are optional: this context is also built by tests with no database.
+ */
+public class EventConfDbBootstrap implements InitializingBean {
+
+    private static final Logger LOG = LoggerFactory.getLogger(EventConfDbBootstrap.class);
+
+    private EventConfEventDao m_eventConfEventDao;
+    private EventConfGlobalSecurityDao m_eventConfGlobalSecurityDao;
+    private EventConfDao m_eventConfDao;
+
+    @Autowired(required = false)
+    public void setEventConfEventDao(final EventConfEventDao eventConfEventDao) {
+        m_eventConfEventDao = eventConfEventDao;
+    }
+
+    @Autowired(required = false)
+    public void setEventConfGlobalSecurityDao(final EventConfGlobalSecurityDao dao) {
+        m_eventConfGlobalSecurityDao = dao;
+    }
+
+    @Autowired(required = false)
+    public void setEventConfDao(final EventConfDao eventConfDao) {
+        m_eventConfDao = eventConfDao;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        if (m_eventConfEventDao == null || m_eventConfGlobalSecurityDao == null || m_eventConfDao == null) {
+            LOG.debug("No database-backed event configuration in this context; nothing to load.");
+            return;
+        }
+        try {
+            final long started = System.currentTimeMillis();
+            final List<EventConfEvent> events = m_eventConfEventDao.findEnabledEvents();
+            final List<EventConfGlobalSecurity> security = m_eventConfGlobalSecurityDao.findAll();
+            m_eventConfDao.loadEventsFromDB(events, security);
+            LOG.info("Loaded {} events from the database in {} ms", events.size(),
+                    System.currentTimeMillis() - started);
+        } catch (final Exception e) {
+            // Starting with no event configuration loses events, but refusing to
+            // start loses the ability to fix it: the web application reloads the
+            // configuration when it comes up.
+            LOG.error("Failed to load the event configuration from the database. Events will be "
+                    + "discarded until it loads.", e);
+        }
+    }
+}

--- a/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/processor/HibernateEventWriter.java
+++ b/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/processor/HibernateEventWriter.java
@@ -127,15 +127,24 @@ public class HibernateEventWriter implements EventWriter {
      * @param logPrefix a {@link java.lang.String} object.
      * @return a boolean.
      */
-    private static boolean checkEventSanityAndDoWeProcess(Event event, String logPrefix) {
+    static boolean checkEventSanityAndDoWeProcess(Event event, String logPrefix) {
         Assert.notNull(event, "event argument must not be null");
+
+        /*
+         * No logmsg means nothing matched. Skipped rather than thrown: this runs
+         * in a stream over the whole log, and throwing discarded the rest of it.
+         */
+        if (event.getLogmsg() == null) {
+            LOG.warn("{}: uei '{}' has no logmsg, which means no event definition matched it; "
+                    + "not processing event.", logPrefix, event.getUei());
+            return false;
+        }
 
         /*
          * Check value of <logmsg> attribute 'dest', if set to
          * "donotpersist" or "suppress" then simply return, the UEI is not to be
          * persisted to the database
          */
-        Assert.notNull(event.getLogmsg(), "event does not have a logmsg");
         if (
             LOG_MSG_DEST_DO_NOT_PERSIST.equalsIgnoreCase(event.getLogmsg().getDest()) ||
             LOG_MSG_DEST_SUPRRESS.equalsIgnoreCase(event.getLogmsg().getDest())

--- a/features/events/daemon/src/main/resources/META-INF/opennms/applicationContext-eventDaemon.xml
+++ b/features/events/daemon/src/main/resources/META-INF/opennms/applicationContext-eventDaemon.xml
@@ -31,13 +31,17 @@
   <onmsgi:reference id="eventdServiceManager" interface="org.opennms.netmgt.dao.api.EventdServiceManager"/>
   -->
 
-  <bean id="eventExpander" class="org.opennms.netmgt.eventd.EventExpander">
+  <bean id="eventConfDbBootstrap" class="org.opennms.netmgt.eventd.EventConfDbBootstrap"/>
+
+  <bean id="eventExpander" class="org.opennms.netmgt.eventd.EventExpander"
+        depends-on="eventConfDbBootstrap">
     <constructor-arg ref="eventdMetricRegistry"/>
     <property name="eventConfDao" ref="eventConfDao"/>
     <property name="eventUtil" ref="eventUtil"/>
   </bean>
   
-  <bean id="eventParmRegexFilter" class="org.opennms.netmgt.eventd.processor.EventParmRegexFilterProcessor">
+  <bean id="eventParmRegexFilter" class="org.opennms.netmgt.eventd.processor.EventParmRegexFilterProcessor"
+        depends-on="eventConfDbBootstrap">
     <property name="eventConfDao" ref="eventConfDao"/>
   </bean>
 

--- a/features/events/daemon/src/test/java/org/opennms/netmgt/eventd/EventConfDbBootstrapTest.java
+++ b/features/events/daemon/src/test/java/org/opennms/netmgt/eventd/EventConfDbBootstrapTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.eventd;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.opennms.netmgt.config.api.EventConfDao;
+import org.opennms.netmgt.dao.api.EventConfEventDao;
+import org.opennms.netmgt.dao.api.EventConfGlobalSecurityDao;
+import org.opennms.netmgt.model.EventConfEvent;
+import org.opennms.netmgt.model.EventConfGlobalSecurity;
+
+public class EventConfDbBootstrapTest {
+
+    private EventConfDbBootstrap bootstrap(final EventConfEventDao events,
+                                           final EventConfGlobalSecurityDao security,
+                                           final EventConfDao target) {
+        final EventConfDbBootstrap bootstrap = new EventConfDbBootstrap();
+        bootstrap.setEventConfEventDao(events);
+        bootstrap.setEventConfGlobalSecurityDao(security);
+        bootstrap.setEventConfDao(target);
+        return bootstrap;
+    }
+
+    @Test
+    public void loadsTheConfigurationBeforeAnythingReadsIt() {
+        final EventConfEventDao events = mock(EventConfEventDao.class);
+        final EventConfGlobalSecurityDao security = mock(EventConfGlobalSecurityDao.class);
+        final EventConfDao target = mock(EventConfDao.class);
+        final List<EventConfEvent> enabled = List.of(new EventConfEvent());
+        final List<EventConfGlobalSecurity> globals = List.of(new EventConfGlobalSecurity());
+        when(events.findEnabledEvents()).thenReturn(enabled);
+        when(security.findAll()).thenReturn(globals);
+
+        bootstrap(events, security, target).afterPropertiesSet();
+
+        verify(target).loadEventsFromDB(enabled, globals);
+    }
+
+    @Test
+    public void doesNothingWhereThereIsNoDatabaseBackedConfiguration() {
+        final EventConfDao target = mock(EventConfDao.class);
+
+        bootstrap(null, null, target).afterPropertiesSet();
+
+        verify(target, never()).loadEventsFromDB(any(), any());
+    }
+
+    @Test
+    public void asksNothingWhenOnlySomeOfTheConfigurationIsAvailable() {
+        final EventConfEventDao events = mock(EventConfEventDao.class);
+        final EventConfDao target = mock(EventConfDao.class);
+
+        bootstrap(events, null, target).afterPropertiesSet();
+
+        verify(events, never()).findEnabledEvents();
+        verify(target, never()).loadEventsFromDB(any(), any());
+    }
+
+    @Test
+    public void startsAnywayWhenTheDatabaseCannotBeRead() {
+        final EventConfEventDao events = mock(EventConfEventDao.class);
+        final EventConfGlobalSecurityDao security = mock(EventConfGlobalSecurityDao.class);
+        final EventConfDao target = mock(EventConfDao.class);
+        doThrow(new IllegalStateException("no connection")).when(events).findEnabledEvents();
+
+        bootstrap(events, security, target).afterPropertiesSet();
+
+        verify(target, never()).loadEventsFromDB(any(), any());
+    }
+
+    @Test
+    public void keepsWhateverTheDatabaseReturned() {
+        final EventConfEventDao events = mock(EventConfEventDao.class);
+        final EventConfGlobalSecurityDao security = mock(EventConfGlobalSecurityDao.class);
+        final EventConfDao target = mock(EventConfDao.class);
+        when(events.findEnabledEvents()).thenReturn(List.of());
+        when(security.findAll()).thenReturn(List.of());
+
+        bootstrap(events, security, target).afterPropertiesSet();
+
+        verify(target).loadEventsFromDB(List.of(), List.of());
+        assertEquals(0, events.findEnabledEvents().size());
+    }
+}

--- a/features/events/daemon/src/test/java/org/opennms/netmgt/eventd/processor/HibernateEventWriterSanityTest.java
+++ b/features/events/daemon/src/test/java/org/opennms/netmgt/eventd/processor/HibernateEventWriterSanityTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.eventd.processor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+import org.opennms.netmgt.xml.event.Event;
+import org.opennms.netmgt.xml.event.Logmsg;
+
+public class HibernateEventWriterSanityTest {
+
+    private Event event(final String uei, final String dest) {
+        final Event event = new Event();
+        event.setUei(uei);
+        if (dest != null) {
+            final Logmsg logmsg = new Logmsg();
+            logmsg.setDest(dest);
+            event.setLogmsg(logmsg);
+        }
+        return event;
+    }
+
+    @Test
+    public void persistsAnEventThatMatchedADefinition() {
+        assertTrue(HibernateEventWriter.checkEventSanityAndDoWeProcess(
+                event("uei.opennms.org/nodes/nodeLostService", "logndisplay"), "test"));
+    }
+
+    @Test
+    public void skipsAnEventThatMatchedNothing() {
+        assertFalse(HibernateEventWriter.checkEventSanityAndDoWeProcess(
+                event("uei.opennms.org/nodes/nodeLostService", null), "test"));
+    }
+
+    @Test
+    public void skipsWhatTheDefinitionAsksNotToPersist() {
+        assertFalse(HibernateEventWriter.checkEventSanityAndDoWeProcess(
+                event("uei.opennms.org/internal/capsd/updateServer", "donotpersist"), "test"));
+        assertFalse(HibernateEventWriter.checkEventSanityAndDoWeProcess(
+                event("uei.opennms.org/internal/capsd/updateServer", "suppress"), "test"));
+    }
+
+    /** The reported symptom: one unmatched event took the whole log with it. */
+    @Test
+    public void oneUnmatchedEventDoesNotDiscardTheRestOfTheLog() {
+        final List<Event> log = List.of(
+                event("uei.opennms.org/nodes/dataCollectionSucceeded", "logndisplay"),
+                event("uei.opennms.org/nodes/nodeLostService", null),
+                event("uei.opennms.org/nodes/nodeRegainedService", "logndisplay"));
+
+        final List<Event> toPersist = log.stream()
+                .filter(e -> HibernateEventWriter.checkEventSanityAndDoWeProcess(e, "test"))
+                .collect(Collectors.toList());
+
+        assertEquals(2, toPersist.size());
+        assertEquals("uei.opennms.org/nodes/dataCollectionSucceeded", toPersist.get(0).getUei());
+        assertEquals("uei.opennms.org/nodes/nodeRegainedService", toPersist.get(1).getUei());
+    }
+}

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/DefaultEventConfDao.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/DefaultEventConfDao.java
@@ -250,8 +250,8 @@ public class DefaultEventConfDao implements EventConfDao, InitializingBean {
 	}
 
 	/**
-	 * Unmarshalled in parallel, added in order: parsing is nearly all of the cost
-	 * and the load blocks startup, but the order events are added in decides
+	 * Unmarshalled in parallel and added in order: parsing is nearly all of the cost
+	 * and loading blocks startup, but the order events are added in determines
 	 * which definition wins a match. Safe because JaxbUtils holds an unmarshaller
 	 * per thread.
 	 */

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/DefaultEventConfDao.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/DefaultEventConfDao.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -248,25 +249,34 @@ public class DefaultEventConfDao implements EventConfDao, InitializingBean {
 				.toList();
 	}
 
+	/**
+	 * Unmarshalled in parallel, added in order: parsing is nearly all of the cost
+	 * and the load blocks startup, but the order events are added in decides
+	 * which definition wins a match. Safe because JaxbUtils holds an unmarshaller
+	 * per thread.
+	 */
 	private Events buildEventsForSource(List<EventConfEvent> sourceEvents) {
 		Events eventsForSource = new Events();
-		for (EventConfEvent dbEvent : sourceEvents) {
-			parseAndAddEvent(eventsForSource, dbEvent);
+		List<Event> parsed = sourceEvents.parallelStream()
+				.map(this::parseEvent)
+				.filter(Objects::nonNull)
+				.collect(Collectors.toList());
+		for (Event event : parsed) {
+			eventsForSource.addEvent(event);
 		}
 		return eventsForSource;
 	}
 
-	private void parseAndAddEvent(Events eventsForSource, EventConfEvent dbEvent) {
+	private Event parseEvent(EventConfEvent dbEvent) {
 		String xmlContent = dbEvent.getXmlContent();
-		if (xmlContent != null && !xmlContent.trim().isEmpty()) {
-			try {
-				Event event = JaxbUtils.unmarshal(Event.class, xmlContent);
-				if (event != null) {
-					eventsForSource.addEvent(event);
-				}
-			} catch (Exception e) {
-				LOG.warn("Failed to parse event XML content for UEI {}", dbEvent.getUei(), e);
-			}
+		if (xmlContent == null || xmlContent.trim().isEmpty()) {
+			return null;
+		}
+		try {
+			return JaxbUtils.unmarshal(Event.class, xmlContent);
+		} catch (Exception e) {
+			LOG.warn("Failed to parse event XML content for UEI {}", dbEvent.getUei(), e);
+			return null;
 		}
 	}
 

--- a/opennms-config/src/test/java/org/opennms/netmgt/config/EventConfParallelLoadTest.java
+++ b/opennms-config/src/test/java/org/opennms/netmgt/config/EventConfParallelLoadTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.opennms.netmgt.model.EventConfEvent;
+import org.opennms.netmgt.model.EventConfSource;
+
+/** Parallel unmarshalling must not change what loads, or in what order. */
+public class EventConfParallelLoadTest {
+
+    private static final String XML =
+            "<event xmlns=\"http://xmlns.opennms.org/xsd/eventconf\">"
+            + "<uei>%s</uei><event-label>%s</event-label>"
+            + "<descr>a description</descr>"
+            + "<logmsg dest=\"logndisplay\">a log message</logmsg>"
+            + "<severity>Warning</severity></event>";
+
+    private EventConfSource source(final String name, final int fileOrder) {
+        final EventConfSource source = new EventConfSource();
+        source.setName(name);
+        source.setFileOrder(fileOrder);
+        return source;
+    }
+
+    private EventConfEvent event(final EventConfSource source, final String uei) {
+        final EventConfEvent event = new EventConfEvent();
+        event.setSource(source);
+        event.setUei(uei);
+        event.setXmlContent(String.format(XML, uei, uei));
+        return event;
+    }
+
+    @Test
+    public void loadsEveryDefinitionItWasGiven() {
+        final EventConfSource source = source("test.events", 1);
+        final List<EventConfEvent> events = new ArrayList<>();
+        for (int i = 0; i < 500; i++) {
+            events.add(event(source, "uei.opennms.org/test/event" + i));
+        }
+
+        final DefaultEventConfDao dao = new DefaultEventConfDao();
+        dao.loadEventsFromDB(events, List.of());
+
+        assertEquals(500, dao.getEventUEIs().size());
+        for (int i = 0; i < 500; i++) {
+            assertNotNull(dao.getEvents("uei.opennms.org/test/event" + i));
+        }
+    }
+
+    /** Order decides which definition wins a match. */
+    @Test
+    public void keepsTheOrderTheQueryReturned() {
+        final EventConfSource source = source("test.events", 1);
+        final List<EventConfEvent> events = new ArrayList<>();
+        final List<String> expected = new ArrayList<>();
+        for (int i = 0; i < 200; i++) {
+            final String uei = "uei.opennms.org/test/ordered" + i;
+            events.add(event(source, uei));
+            expected.add(uei);
+        }
+
+        final DefaultEventConfDao dao = new DefaultEventConfDao();
+        dao.loadEventsFromDB(events, List.of());
+
+        final List<String> loaded = new ArrayList<>();
+        for (final org.opennms.netmgt.xml.eventconf.Event e : dao.getAllEvents()) {
+            loaded.add(e.getUei());
+        }
+        assertEquals(expected, loaded);
+    }
+
+    @Test
+    public void skipsWhatItCannotParseAndKeepsTheRest() {
+        final EventConfSource source = source("test.events", 1);
+        final EventConfEvent broken = event(source, "uei.opennms.org/test/broken");
+        broken.setXmlContent("<event><this is not xml");
+        final EventConfEvent empty = event(source, "uei.opennms.org/test/empty");
+        empty.setXmlContent("   ");
+
+        final DefaultEventConfDao dao = new DefaultEventConfDao();
+        dao.loadEventsFromDB(
+                List.of(event(source, "uei.opennms.org/test/good"), broken, empty), List.of());
+
+        assertNotNull(dao.getEvents("uei.opennms.org/test/good"));
+        assertNull(dao.getEvents("uei.opennms.org/test/broken"));
+        assertEquals(1, dao.getEventUEIs().size());
+    }
+}


### PR DESCRIPTION
Events received during startup are discarded with "event does not have a logmsg", because nothing populates the database-backed eventconf until the web application starts.

Related to this, checkEventSanityAndDoWeProcess throws from inside a stream filter over the whole event log, and DefaultEventHandlerImpl breaks out of the processor loop, so one unmatched event discards every event batched with it. A MATCH-ANY-UEI catch-all masks this once the config is loaded, so today it only compounds losses inside the startup window.

This should resolve these.  Thanks to @dino2gnt for spotting this.

Assisted by Anthropic Claude Opus 5.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20289
