### PR TITLE
NMS-20287: Update to wsman 1.3.7 and add support for new features

### DIFF
--- a/docs/modules/reference/nav.adoc
+++ b/docs/modules/reference/nav.adoc
@@ -95,6 +95,7 @@
 ** xref:service-assurance/monitors/WebMonitor.adoc[]
 ** xref:service-assurance/monitors/Win32ServiceMonitor.adoc[]
 ** xref:service-assurance/monitors/WsManMonitor.adoc[]
+** xref:service-assurance/monitors/WsManShellMonitor.adoc[]
 
 * xref:telemetryd/introduction.adoc[]
 ** xref:telemetryd/listeners/introduction.adoc[]
@@ -164,6 +165,7 @@
 *** xref:provisioning/detectors/Win32ServiceDetector.adoc[Win32 Service]
 *** xref:provisioning/detectors/WsmanDetector.adoc[WS-MAN]
 *** xref:provisioning/detectors/WsmanWqlDetector.adoc[WS-MAN WQL]
+*** xref:provisioning/detectors/WsmanShellDetector.adoc[WS-MAN Shell]
 
 * xref:daemons/introduction.adoc[]
 ** xref:daemons/daemon-config-files/ackd.adoc[]

--- a/docs/modules/reference/nav.adoc
+++ b/docs/modules/reference/nav.adoc
@@ -19,6 +19,7 @@
 ** xref:configuration/selinux.adoc[]
 ** xref:configuration/receive-snmp-traps.adoc[]
 ** xref:configuration/system-properties.adoc[]
+** xref:configuration/wsman-kerberos.adoc[]
 
 
 

--- a/docs/modules/reference/pages/configuration/wsman-kerberos.adoc
+++ b/docs/modules/reference/pages/configuration/wsman-kerberos.adoc
@@ -103,6 +103,7 @@ java.security.auth.login.config=/opt/minion/etc/login.conf
 
 For the container images, pass the same two properties in the `JAVA_OPTS` environment variable and mount the files into the container.
 The `java.security.krb5.conf` property can be omitted when the host's `/etc/krb5.conf` is already correct.
+The file named by `java.security.auth.login.config` must exist and be readable by the user that runs {page-component-title}; a missing file disables the `opennms` login realm that the message broker and JMX rely on (see <<Troubleshooting>>).
 Restart {page-component-title} or the Minion after changing these settings.
 
 == Agent definition
@@ -177,4 +178,9 @@ Re-export the keytab after a password change.
 
 | Polls work from the core but fail for nodes in a Minion location
 | The Kerberos files and system properties are missing on the Minion.
+
+| After setting `java.security.auth.login.config` on the core, Minions can no longer authenticate to the message broker, JMX logins fail, and `output.log` shows `Exception in thread ... SecurityException ... login.conf (No such file or directory)` from `OpenNMSConfiguration`
+| The property points to a file that does not exist or is not readable.
+{page-component-title} adds its own `opennms` login realm on top of the file-based configuration at startup, and it cannot do so when the file cannot be loaded.
+Fix the path or the permissions and restart {page-component-title}.
 |===

--- a/docs/modules/reference/pages/configuration/wsman-kerberos.adoc
+++ b/docs/modules/reference/pages/configuration/wsman-kerberos.adoc
@@ -1,0 +1,180 @@
+[[ref-configuration-wsman-kerberos]]
+= WS-Management Kerberos authentication and message encryption
+:description: Configure OpenNMS {page-component-title} to authenticate to Windows Remote Management with Kerberos and to encrypt WS-Management traffic over plain HTTP.
+
+{page-component-title} can authenticate to Windows Remote Management (WinRM) with Kerberos in two ways.
+Both are enabled per agent in `etc/wsman-config.xml` (see xref:performance-data-collection/collectors/wsman.adoc#ga-performance-mgmt-collectors-wsman-agent-config[WS-Management agent configuration]) and apply to everything that uses that file: the WsManCollector, the WsManMonitor and WsManShellMonitor, and the WS-Management detectors.
+
+gss-auth::
+Kerberos is used only to authenticate the HTTP connection (HTTP Negotiate).
+The SOAP messages themselves travel in clear text, so this mode should be combined with `ssl="true"` on port 5986 and a trusted certificate.
+
+kerberos-encryption::
+Kerberos authenticates the connection and then encrypts every SOAP message with the negotiated session key, as described in MS-WSMV section 2.2.9.1.
+This is what the Windows `winrs` and PowerShell remoting clients do by default, and it is safe over plain HTTP on port 5985.
+No certificate is needed on the Windows host, and the WinRM service does not need `AllowUnencrypted` or Basic authentication enabled.
+`kerberos-encryption="true"` implies `gss-auth`.
+
+Only the AES256-CTS-HMAC-SHA1-96 encryption type is supported for message encryption.
+
+== Prerequisites
+
+* An Active Directory account for {page-component-title}.
+Membership in the local `Remote Management Users` group on each target is enough for WS-Management queries and WinRS commands.
+* The account must be allowed to use AES 256 Kerberos encryption.
+In Active Directory Users and Computers this is the *This account supports Kerberos AES 256 bit encryption* option on the *Account* tab.
+Tickets issued with RC4 or AES 128 keys are rejected.
+* Reverse DNS for every target.
+{page-component-title} requests a service ticket for `HTTP/<canonical host name>`, and it obtains that name by a reverse lookup of the interface IP address.
+The lookup must return the host's Active Directory name, for example `dc18.ad.example.com`.
+An entry in `/etc/hosts` on the system that performs the polls also works.
+* Forward DNS for the domain controllers, or explicit `kdc` entries in `krb5.conf`.
+* Clocks synchronized to within five minutes of the domain controllers.
+* Network access from the system that performs the polls: TCP 5985 to each target and TCP and UDP 88 to the domain controllers.
+
+The system that performs the polls is the {page-component-title} core for nodes in the `Default` location, and the Minion for nodes in a Minion location.
+Everything in this section has to be in place on that system.
+
+== Kerberos client configuration
+
+The Java runtime reads its Kerberos settings from `/etc/krb5.conf`, or from the file named by the `java.security.krb5.conf` system property.
+A minimal configuration looks like this:
+
+[source, ini]
+----
+[libdefaults]
+ default_realm = AD.EXAMPLE.COM
+ dns_lookup_kdc = true
+ default_tkt_enctypes = aes256-cts-hmac-sha1-96
+ default_tgs_enctypes = aes256-cts-hmac-sha1-96
+ permitted_enctypes = aes256-cts-hmac-sha1-96
+
+[realms]
+ AD.EXAMPLE.COM = {
+  kdc = dc18.ad.example.com
+ }
+
+[domain_realm]
+ .ad.example.com = AD.EXAMPLE.COM
+ ad.example.com = AD.EXAMPLE.COM
+----
+
+== Credentials
+
+Credentials can come from `wsman-config.xml` or from a keytab.
+
+Username and password::
+Set `username` and `password` on the definition, with the username in `user@REALM` form.
+{page-component-title} obtains a ticket-granting ticket with the password when the first connection is made and renews it before it expires.
+Metadata expressions are expanded in these attributes, so the password can be kept in the secure credentials vault, for example `$\{scv:windows-monitor:password}`.
+
+Keytab::
+Leave `username` and `password` unset and provide a Java Authentication and Authorization Service (JAAS) login configuration with an entry named `WSManClient`.
+Name the file with the `java.security.auth.login.config` system property.
+The keytab must contain an AES 256 key for the principal and must be readable only by the user that runs {page-component-title}.
++
+[source, login.conf]
+----
+WSManClient {
+  com.sun.security.auth.module.Krb5LoginModule required
+  useKeyTab=true
+  useTicketCache=false
+  storeKey=true
+  doNotPrompt=true
+  keyTab="/opt/opennms/etc/opennms-ws.keytab"
+  principal="opennms-ws@AD.EXAMPLE.COM";
+};
+----
+
+== Setting the system properties
+
+.Core, in `$OPENNMS_HOME/etc/opennms.conf`
+[source, shell]
+----
+ADDITIONAL_MANAGER_OPTIONS="${ADDITIONAL_MANAGER_OPTIONS} -Djava.security.krb5.conf=/opt/opennms/etc/krb5.conf -Djava.security.auth.login.config=/opt/opennms/etc/login.conf"
+----
+
+.Minion, in `$MINION_HOME/etc/custom.system.properties`
+[source, custom.system.properties]
+----
+java.security.krb5.conf=/opt/minion/etc/krb5.conf
+java.security.auth.login.config=/opt/minion/etc/login.conf
+----
+
+For the container images, pass the same two properties in the `JAVA_OPTS` environment variable and mount the files into the container.
+The `java.security.krb5.conf` property can be omitted when the host's `/etc/krb5.conf` is already correct.
+Restart {page-component-title} or the Minion after changing these settings.
+
+== Agent definition
+
+[source, xml]
+----
+<wsman-config xmlns="http://xmlns.opennms.org/xsd/config/wsman" retry="1" timeout="10000">
+  <!-- Keytab credentials from the WSManClient JAAS entry -->
+  <definition ssl="false" port="5985" path="/wsman" kerberos-encryption="true">
+    <range begin="192.168.1.10" end="192.168.1.99"/>
+  </definition>
+  <!-- Password credentials, kept in the secure credentials vault -->
+  <definition ssl="false" port="5985" path="/wsman" kerberos-encryption="true"
+              username="opennms-ws@AD.EXAMPLE.COM" password="${scv:windows-monitor:password}">
+    <specific>192.168.1.147</specific>
+  </definition>
+</wsman-config>
+----
+
+== Connection handling
+
+Each collector, monitor, and detector keeps one Kerberos session per agent and reuses it for all of its operations, so the login and the handshake are not repeated on every poll.
+Operations on the same agent from the same component run one at a time on that session; this is a constraint of the protocol, because the Windows host binds the session to a single TCP connection.
+The connection is closed after 60 seconds without traffic and re-established transparently on the next poll, which costs one Kerberos exchange with the target but no request to the domain controller.
+A session that stays idle for 15 minutes releases its ticket and login as well; the next poll logs in again.
+
+== Verifying the setup
+
+The WS-Management client library ships a command line tool that uses the same code path as {page-component-title}.
+Download the `org.opennms.core.wsman.cli` jar for the library version listed in the release notes from https://github.com/OpenNMS/wsman/releases[the wsman releases page] and run it on the system that will perform the polls:
+
+[source, shell]
+----
+java -Djava.security.krb5.conf=/opt/opennms/etc/krb5.conf \
+     -Djava.security.auth.login.config=/opt/opennms/etc/login.conf \
+     -jar org.opennms.core.wsman.cli-1.3.4.jar -w WSMAN_1_0 \
+     -r http://dc18.ad.example.com:5985/wsman -kerberosEncryption \
+     -resourceUri http://schemas.microsoft.com/wbem/wsman/1/wmi/root/cimv2/Win32_OperatingSystem
+----
+
+Add `-u opennms-ws@AD.EXAMPLE.COM -p <password>` instead of the login configuration to test password credentials, or `-o SHELL -- ipconfig /all` to test WinRS command execution.
+
+Once {page-component-title} is polling, `poller.log`, `collectd.log`, and `provisiond.log` record `Creating Kerberos message-encryption session` at DEBUG level when a session is established for an agent.
+
+== Troubleshooting
+
+[options="header"]
+[cols="2,3"]
+|===
+| Symptom
+| Likely cause
+
+| `401 Unauthorized` from the target, while the same credentials work with `winrs` on Windows
+| The service ticket was requested for the wrong name.
+Check that a reverse lookup of the target's IP address returns its Active Directory host name.
+
+| `Pre-authentication information was invalid (24)`
+| Wrong password, or a keytab that no longer matches the account's current key version.
+Re-export the keytab after a password change.
+
+| `KDC has no support for encryption type (14)` or `Encryption type AES256 CTS mode with HMAC SHA1-96 is not supported/enabled`
+| AES 256 is not enabled on the account, or `krb5.conf` lists other encryption types first.
+
+| `Cannot locate KDC` or `Cannot get kdc for realm`
+| The realm has no `kdc` entry in `krb5.conf` and DNS SRV lookups are disabled or failing.
+
+| `Clock skew too great (37)`
+| The system performing the polls is more than five minutes off the domain controller's time.
+
+| `No LoginModules configured for WSManClient` or `Unable to locate a login configuration`
+| The `java.security.auth.login.config` property is not set for the process, or the entry is not named `WSManClient`.
+
+| Polls work from the core but fail for nodes in a Minion location
+| The Kerberos files and system properties are missing on the Minion.
+|===

--- a/docs/modules/reference/pages/performance-data-collection/collectors/wsman.adoc
+++ b/docs/modules/reference/pages/performance-data-collection/collectors/wsman.adoc
@@ -206,10 +206,17 @@ When enabled, a reverse lookup is performed on the target IP address to determin
 | kerberos-encryption
 | Enables Kerberos message encryption (MS-WSMV 2.2.9.1).
 The SOAP payload itself is encrypted, so WS-Management can be used safely over plain HTTP (typically port 5985) without SSL.
-Implies `gss-auth`, and requires a Kerberos environment (`krb5.conf` and either a username and password in this file or a JAAS login configuration named `WSManClient`).
-Only the AES256-CTS-HMAC-SHA1-96 encryption type is supported.
+Implies `gss-auth`.
+See xref:configuration/wsman-kerberos.adoc[] for the required setup.
 | False
 |===
+
+[[ga-performance-mgmt-collectors-wsman-kerberos]]
+== Kerberos authentication and message encryption
+
+WS-Management agents can be reached with Kerberos authentication (`gss-auth`) or with Kerberos message encryption (`kerberos-encryption`), which protects the SOAP messages themselves and is safe over plain HTTP.
+Both need a Kerberos environment on the system that performs the polls.
+See xref:configuration/wsman-kerberos.adoc[] for the prerequisites, credentials, system properties, and troubleshooting.
 
 NOTE: If you try to connect against Microsoft Windows Server, make sure to set specific ports for WinRM connections.
 By default, Microsoft Windows Server uses port `TCP/5985` for plain text and port `TCP/5986` for SSL connections.

--- a/docs/modules/reference/pages/performance-data-collection/collectors/wsman.adoc
+++ b/docs/modules/reference/pages/performance-data-collection/collectors/wsman.adoc
@@ -202,6 +202,13 @@ This allows the user to also reference credentials stored in the secure credenti
 | Enables GSS authentication.
 When enabled, a reverse lookup is performed on the target IP address to determine the canonical host name.
 | False
+
+| kerberos-encryption
+| Enables Kerberos message encryption (MS-WSMV 2.2.9.1).
+The SOAP payload itself is encrypted, so WS-Management can be used safely over plain HTTP (typically port 5985) without SSL.
+Implies `gss-auth`, and requires a Kerberos environment (`krb5.conf` and either a username and password in this file or a JAAS login configuration named `WSManClient`).
+Only the AES256-CTS-HMAC-SHA1-96 encryption type is supported.
+| False
 |===
 
 NOTE: If you try to connect against Microsoft Windows Server, make sure to set specific ports for WinRM connections.

--- a/docs/modules/reference/pages/provisioning/detectors/WsmanDetector.adoc
+++ b/docs/modules/reference/pages/provisioning/detectors/WsmanDetector.adoc
@@ -3,6 +3,7 @@
 
 The WSManDetector attempts to connect to the agent defined in `wsman-config.xml` and issues an identify command.
 If the identify command is successful, the service is marked as detected, and the product details returned by the command are optionally stored in the asset fields (see details below).
+Connection details, credentials, and Kerberos settings for the target come from `wsman-config.xml`; see xref:performance-data-collection/collectors/wsman.adoc#ga-performance-mgmt-collectors-wsman-agent-config[WS-Management agent configuration] and xref:configuration/wsman-kerberos.adoc[WS-Management Kerberos authentication and message encryption].
 
 == Detector facts
 

--- a/docs/modules/reference/pages/provisioning/detectors/WsmanShellDetector.adoc
+++ b/docs/modules/reference/pages/provisioning/detectors/WsmanShellDetector.adoc
@@ -3,6 +3,7 @@
 
 The WsManShellDetector connects to the agent defined in `wsman-config.xml`, runs a command through WinRS (the Windows Remote Shell protocol carried over WS-Management), and marks the service as detected when its output matches an optional banner and, if configured, it exits with the expected code.
 Use it to define arbitrary services based on the state of the Windows host.
+Connection details, credentials, and Kerberos settings for the target come from `wsman-config.xml`; see xref:performance-data-collection/collectors/wsman.adoc#ga-performance-mgmt-collectors-wsman-agent-config[WS-Management agent configuration] and xref:configuration/wsman-kerberos.adoc[WS-Management Kerberos authentication and message encryption].
 
 The command runs as the user configured in `wsman-config.xml`.
 Give that account only the rights it needs: membership in the `Remote Management Users` group on the target is enough to run commands.

--- a/docs/modules/reference/pages/provisioning/detectors/WsmanShellDetector.adoc
+++ b/docs/modules/reference/pages/provisioning/detectors/WsmanShellDetector.adoc
@@ -7,6 +7,9 @@ Use it to define arbitrary services based on the state of the Windows host.
 The command runs as the user configured in `wsman-config.xml`.
 Give that account only the rights it needs: membership in the `Remote Management Users` group on the target is enough to run commands.
 
+WARNING: The `command` and `args` values are handed to the Windows command interpreter exactly as written, and `cmd.exe` treats characters such as `&`, `|`, and `>` as command separators.
+Metadata expressions are expanded by provisiond for every parameter, so avoid referencing node or interface metadata in `command` or `args` unless you control who can edit it.
+
 == Detector facts
 
 [options="autowidth"]
@@ -65,7 +68,8 @@ Set a legacy code page such as `437` (US OEM) or `850` (Western European OEM) on
 | Shell default
 
 | timeout
-| Time in milliseconds to wait for the command to complete.
+| Time in milliseconds that bounds each step of the detection: connecting to the host, creating the shell, waiting for the command to complete, and deleting the shell.
+No single step may take longer than this.
 | `2000`
 
 | serviceName

--- a/docs/modules/reference/pages/provisioning/detectors/WsmanShellDetector.adoc
+++ b/docs/modules/reference/pages/provisioning/detectors/WsmanShellDetector.adoc
@@ -1,0 +1,87 @@
+= WS-Management Shell Detector
+:description: Learn how the WsManShellDetector in OpenNMS {page-component-title} runs a command on a Windows host through WinRS and detects a service from its output.
+
+The WsManShellDetector connects to the agent defined in `wsman-config.xml`, runs a command through WinRS (the Windows Remote Shell protocol carried over WS-Management), and marks the service as detected when its output matches an optional banner and, if configured, it exits with the expected code.
+Use it to define arbitrary services based on the state of the Windows host.
+
+The command runs as the user configured in `wsman-config.xml`.
+Give that account only the rights it needs: membership in the `Remote Management Users` group on the target is enough to run commands.
+
+== Detector facts
+
+[options="autowidth"]
+|===
+| Implementation | `org.opennms.netmgt.provision.detector.wsman.WsManShellDetector`
+|===
+
+== Configuration and use
+
+.Parameters for the WsManShellDetector
+[options="header, autowidth"]
+[cols="1,1,4"]
+|===
+| Parameter
+| Description
+| Default value
+
+3+| *Required*
+
+| command
+| The executable to run, for example `sc` or `powershell`.
+| none
+
+3+| *Optional*
+
+| args
+| Arguments passed to the command.
+The value is handed to the Windows host verbatim, so it is the rest of the command line exactly as you would type it there, using Windows quoting rules.
+Write double quotes as `&quot;` in the XML file.
+| none
+
+| banner
+| Text that must appear in the command's standard output.
+If the value starts with `~`, the rest is a regular expression that must match the whole output.
+The expression is compiled so that `.` also matches line breaks.
+Use `*` or leave the parameter out to accept any output.
+| `*`
+
+| exitCode
+| Exit code the command must return, for example `0`.
+By default any exit code is accepted and only the banner is checked.
+| `*`
+
+| noProfile
+| Skip loading the user profile when creating the shell.
+| `true`
+
+| codepage
+| Windows code page number the remote shell uses to encode the command's output, which the detector decodes with the same code page.
+The default, `65001`, is UTF-8 and suits most commands.
+Set a legacy code page such as `437` (US OEM) or `850` (Western European OEM) only if a command writes output in that encoding.
+| `65001` (UTF-8)
+
+| workingDirectory
+| Working directory for the command.
+| Shell default
+
+| timeout
+| Time in milliseconds to wait for the command to complete.
+| `2000`
+
+| serviceName
+| A custom service name to identify this service.
+| WsManShell
+|===
+
+== Examples
+
+Detect a `W32Time` service on hosts where the Windows Time service is running:
+
+[source, xml]
+----
+<detector name="W32Time" class="org.opennms.netmgt.provision.detector.wsman.WsManShellDetector">
+    <parameter key="command" value="sc"/>
+    <parameter key="args" value="query w32time"/>
+    <parameter key="banner" value="~.*STATE\s*:\s*4\s+RUNNING.*"/>
+</detector>
+----

--- a/docs/modules/reference/pages/provisioning/detectors/WsmanWqlDetector.adoc
+++ b/docs/modules/reference/pages/provisioning/detectors/WsmanWqlDetector.adoc
@@ -4,6 +4,7 @@
 The WSManWQLDetector attempts to connect to the agent defined in `wsman-config.xml` and issues a WQL query.
 If the query successfully returns one or more items, the service is marked as detected.
 You can use the WSManWQLDetector to define arbitrary services based on WQL filter results.
+Connection details, credentials, and Kerberos settings for the target come from `wsman-config.xml`; see xref:performance-data-collection/collectors/wsman.adoc#ga-performance-mgmt-collectors-wsman-agent-config[WS-Management agent configuration] and xref:configuration/wsman-kerberos.adoc[WS-Management Kerberos authentication and message encryption].
 
 == Detector facts
 

--- a/docs/modules/reference/pages/service-assurance/monitors/WsManMonitor.adoc
+++ b/docs/modules/reference/pages/service-assurance/monitors/WsManMonitor.adoc
@@ -3,6 +3,7 @@
 :description: Learn about the WsManMonitor in OpenNMS {page-component-title} to issue a WS-Man GET command and validate the results using a Spring language expression.
 
 Use this monitor to issue a WS-Man GET command and validate the results using a link:http://docs.spring.io/spring/docs/current/spring-framework-reference/html/expressions.html[SPEL] expression.
+Connection details, credentials, and Kerberos settings for the target come from `wsman-config.xml`; see xref:performance-data-collection/collectors/wsman.adoc#ga-performance-mgmt-collectors-wsman-agent-config[WS-Management agent configuration] and xref:configuration/wsman-kerberos.adoc[WS-Management Kerberos authentication and message encryption].
 
 == Monitor facts
 

--- a/docs/modules/reference/pages/service-assurance/monitors/WsManShellMonitor.adoc
+++ b/docs/modules/reference/pages/service-assurance/monitors/WsManShellMonitor.adoc
@@ -1,0 +1,112 @@
+= WsManShellMonitor
+:description: Learn about the WsManShellMonitor in OpenNMS {page-component-title}, which runs a command on a Windows host through WinRS and checks its output.
+
+Use this monitor to run a command on a Windows host through WinRS (the Windows Remote Shell protocol carried over WS-Management) and mark the service as up when its output matches an optional banner and, if configured, it exits with the expected code.
+Connection details, credentials, and Kerberos settings for the target come from `wsman-config.xml`, as with the other WS-Management monitors, detectors, and collectors.
+
+The command runs as the user configured in `wsman-config.xml`, in a fresh short-lived shell that is deleted when the command completes.
+Give that account only the rights it needs: membership in the `Remote Management Users` group on the target is enough to run commands, and the command line is taken verbatim from the poller configuration.
+
+== Monitor facts
+
+[cols="1,7"]
+|===
+| Class Name
+| `org.opennms.netmgt.poller.monitors.WsManShellMonitor`
+|===
+
+== Configuration and use
+
+.Monitor-specific parameters for the WsManShellMonitor
+[options="header"]
+[cols="1,3,2"]
+|===
+| Parameter
+| Description
+| Default
+
+3+|*Required*
+
+| command kbd:[{}]
+| The executable to run, for example `ipconfig` or `powershell`.
+| n/a
+
+3+|*Optional*
+
+| args kbd:[{}]
+| Arguments passed to the command.
+The value is handed to the Windows host verbatim, so it is the rest of the command line exactly as you would type it there, using Windows quoting rules.
+Write double quotes as `&quot;` in the XML file.
+| none
+
+| banner kbd:[{}]
+| Text that must appear in the command's standard output for the service to be considered up.
+If the value starts with `~`, the rest is a regular expression that must match the whole output.
+The expression is compiled so that `.` also matches line breaks, so `~.\*Running.*` matches multi-line output.
+Use `*` or leave the parameter out to accept any output.
+| `*`
+
+| exit-code
+| Exit code the command must return, for example `0`.
+By default any exit code is accepted and only the banner is checked.
+| `*`
+
+| no-profile
+| Skip loading the user profile when creating the shell.
+| `true`
+
+| codepage
+| Windows code page number the remote shell uses to encode the command's output, which the monitor decodes with the same code page.
+The default, `65001`, is UTF-8 and suits most commands.
+Set a legacy code page such as `437` (US OEM) or `850` (Western European OEM) only if a command writes output in that encoding.
+| `65001` (UTF-8)
+
+| working-directory
+| Working directory for the command.
+| Shell default
+
+| timeout
+| Time in milliseconds to wait for the command to complete.
+Shell creation and deletion are not counted.
+On timeout the command is terminated and the poll fails.
+Keep this short; a command that needs more than a few seconds is a poor fit for a poll.
+| `3000`
+
+| retry
+| Number of retries after a failed attempt.
+Falls back to the `retry` value from `wsman-config.xml` when not set.
+| `0`
+|===
+
+kbd:[{}] _indicates the parameter supports <<reference:service-assurance/introduction.adoc#ref-service-assurance-monitors-placeholder-substitution-parameters, placeholder substitution>>._
+
+This monitor implements the <<reference:service-assurance/introduction.adoc#ref-service-assurance-monitors-common-parameters, Common Configuration Parameters>>.
+
+== Examples
+
+Check that the Windows Time service is running:
+
+[source, xml]
+----
+<service name="W32Time" interval="300000" user-defined="true" status="on">
+  <parameter key="command" value="sc"/>
+  <parameter key="args" value="query w32time"/>
+  <parameter key="banner" value="~.*STATE\s*:\s*4\s+RUNNING.*"/>
+</service>
+
+<monitor service="W32Time" class-name="org.opennms.netmgt.poller.monitors.WsManShellMonitor" />
+----
+
+Run a PowerShell command and rely on its exit code alone:
+
+[source, xml]
+----
+<service name="Cluster-Health" interval="300000" user-defined="true" status="on">
+  <parameter key="command" value="powershell"/>
+  <parameter key="args" value="-NoProfile -NonInteractive -Command &quot;if ((Get-ClusterNode -Name $env:COMPUTERNAME).State -ne 'Up') { exit 1 }&quot;"/>
+  <parameter key="exit-code" value="0"/>
+  <parameter key="timeout" value="5000"/>
+</service>
+
+<monitor service="Cluster-Health" class-name="org.opennms.netmgt.poller.monitors.WsManShellMonitor" />
+----

--- a/docs/modules/reference/pages/service-assurance/monitors/WsManShellMonitor.adoc
+++ b/docs/modules/reference/pages/service-assurance/monitors/WsManShellMonitor.adoc
@@ -2,7 +2,7 @@
 :description: Learn about the WsManShellMonitor in OpenNMS {page-component-title}, which runs a command on a Windows host through WinRS and checks its output.
 
 Use this monitor to run a command on a Windows host through WinRS (the Windows Remote Shell protocol carried over WS-Management) and mark the service as up when its output matches an optional banner and, if configured, it exits with the expected code.
-Connection details, credentials, and Kerberos settings for the target come from `wsman-config.xml`, as with the other WS-Management monitors, detectors, and collectors.
+Connection details, credentials, and Kerberos settings for the target come from `wsman-config.xml`; see xref:performance-data-collection/collectors/wsman.adoc#ga-performance-mgmt-collectors-wsman-agent-config[WS-Management agent configuration] and xref:configuration/wsman-kerberos.adoc[WS-Management Kerberos authentication and message encryption].
 
 The command runs as the user configured in `wsman-config.xml`, in a fresh short-lived shell that is deleted when the command completes.
 Give that account only the rights it needs: membership in the `Remote Management Users` group on the target is enough to run commands.

--- a/docs/modules/reference/pages/service-assurance/monitors/WsManShellMonitor.adoc
+++ b/docs/modules/reference/pages/service-assurance/monitors/WsManShellMonitor.adoc
@@ -5,7 +5,11 @@ Use this monitor to run a command on a Windows host through WinRS (the Windows R
 Connection details, credentials, and Kerberos settings for the target come from `wsman-config.xml`, as with the other WS-Management monitors, detectors, and collectors.
 
 The command runs as the user configured in `wsman-config.xml`, in a fresh short-lived shell that is deleted when the command completes.
-Give that account only the rights it needs: membership in the `Remote Management Users` group on the target is enough to run commands, and the command line is taken verbatim from the poller configuration.
+Give that account only the rights it needs: membership in the `Remote Management Users` group on the target is enough to run commands.
+
+WARNING: The `command` and `args` values are handed to the Windows command interpreter exactly as written, and `cmd.exe` treats characters such as `&`, `|`, and `>` as command separators.
+For that reason these two parameters do not support placeholder substitution: substituting a value that someone else can influence, such as a node label, would let that person run commands on the host.
+Metadata expressions are still expanded by the poller for every parameter, so avoid referencing node, interface, or asset metadata in `command` or `args` unless you control who can edit it.
 
 == Monitor facts
 
@@ -27,16 +31,18 @@ Give that account only the rights it needs: membership in the `Remote Management
 
 3+|*Required*
 
-| command kbd:[{}]
+| command
 | The executable to run, for example `ipconfig` or `powershell`.
+Placeholder substitution is not applied, see the warning above.
 | n/a
 
 3+|*Optional*
 
-| args kbd:[{}]
+| args
 | Arguments passed to the command.
 The value is handed to the Windows host verbatim, so it is the rest of the command line exactly as you would type it there, using Windows quoting rules.
 Write double quotes as `&quot;` in the XML file.
+Placeholder substitution is not applied, see the warning above.
 | none
 
 | banner kbd:[{}]
@@ -66,9 +72,10 @@ Set a legacy code page such as `437` (US OEM) or `850` (Western European OEM) on
 | Shell default
 
 | timeout
-| Time in milliseconds to wait for the command to complete.
-Shell creation and deletion are not counted.
-On timeout the command is terminated and the poll fails.
+| Time in milliseconds that bounds each step of the poll: connecting to the host, creating the shell, waiting for the command to complete, and deleting the shell.
+No single step may take longer than this, so a poll against an unresponsive host ends after a small multiple of the value.
+When the command itself exceeds it, the command is terminated and the poll fails.
+Falls back to the `timeout` value from `wsman-config.xml` when not set.
 Keep this short; a command that needs more than a few seconds is a poor fit for a poll.
 | `3000`
 

--- a/features/wsman/src/main/java/org/opennms/core/wsman/utils/CachingWSManClientFactory.java
+++ b/features/wsman/src/main/java/org/opennms/core/wsman/utils/CachingWSManClientFactory.java
@@ -113,8 +113,12 @@ public class CachingWSManClientFactory implements WSManClientFactory, AutoClosea
                 return m_delegate.getClient(endpoint);
             });
             return new SharedClient(shared);
-        } catch (ExecutionException e) {
-            throw new WSManException("Failed to create WS-Man client for " + endpoint, e.getCause());
+        } catch (ExecutionException | UncheckedExecutionException e) {
+            final Throwable cause = e.getCause();
+            if (cause instanceof WSManException) {
+                throw (WSManException) cause;
+            }
+            throw new WSManException("Failed to create WS-Man client for " + endpoint, cause);
         }
     }
 

--- a/features/wsman/src/main/java/org/opennms/core/wsman/utils/CachingWSManClientFactory.java
+++ b/features/wsman/src/main/java/org/opennms/core/wsman/utils/CachingWSManClientFactory.java
@@ -75,7 +75,7 @@ import com.google.common.cache.RemovalNotification;
  * threads polling the same endpoint through the same factory instance take turns.
  * That is a protocol constraint, not a choice made here.
  */
-public class CachingWSManClientFactory implements WSManClientFactory {
+public class CachingWSManClientFactory implements WSManClientFactory, AutoCloseable {
     private static final Logger LOG = LoggerFactory.getLogger(CachingWSManClientFactory.class);
 
     static final Duration EXPIRE_AFTER = Duration.ofHours(1);
@@ -121,6 +121,7 @@ public class CachingWSManClientFactory implements WSManClientFactory {
     /**
      * Closes and forgets every cached client.
      */
+    @Override
     public void close() {
         m_clients.invalidateAll();
         m_clients.cleanUp();

--- a/features/wsman/src/main/java/org/opennms/core/wsman/utils/CachingWSManClientFactory.java
+++ b/features/wsman/src/main/java/org/opennms/core/wsman/utils/CachingWSManClientFactory.java
@@ -1,0 +1,272 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.core.wsman.utils;
+
+import java.net.URL;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.opennms.core.wsman.Identity;
+import org.opennms.core.wsman.WSManClient;
+import org.opennms.core.wsman.WSManClientFactory;
+import org.opennms.core.wsman.WSManEndpoint;
+import org.opennms.core.wsman.WSManVersion;
+import org.opennms.core.wsman.cxf.CXFWSManClientFactory;
+import org.opennms.core.wsman.exceptions.WSManException;
+import org.opennms.core.wsman.shell.CommandResult;
+import org.opennms.core.wsman.shell.ShellOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Node;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalNotification;
+
+/**
+ * A {@link WSManClientFactory} that reuses clients for endpoints with Kerberos
+ * message encryption enabled.
+ *
+ * <p>The collector, monitor, detectors and asset adapter each create a client per
+ * operation. That is free for basic or plain GSS authentication, since those clients
+ * hold no state. A Kerberos-encrypted client, however, owns a JAAS login, a GSS
+ * context and the TCP connection the Windows host bound that context to. Recreating
+ * it on every poll means a KDC round trip and a handshake per poll, and closing it
+ * on every poll throws that work away. This factory keeps one client per distinct
+ * endpoint so successive operations share the session, which is how the library is
+ * meant to be used.
+ *
+ * <p>Callers still work with try-with-resources: the client handed out for a cached
+ * endpoint is a thin wrapper whose {@link WSManClient#close()} is a no-op, so the
+ * shared session survives the caller. The library reaps idle sessions on its own
+ * (the connection after a minute, the GSS context and login after fifteen), and a
+ * reaped session re-establishes itself on next use, so an entry that sits in this
+ * cache costs nothing while idle. Entries that go unused for {@link #EXPIRE_AFTER}
+ * are dropped and their client closed, which covers endpoints that disappear from
+ * the configuration.
+ *
+ * <p>Endpoints without Kerberos encryption are passed straight through to the
+ * delegate and are not cached, so their behaviour is unchanged.
+ *
+ * <p>Operations on a shared Kerberos client serialize on its connection, so two
+ * threads polling the same endpoint through the same factory instance take turns.
+ * That is a protocol constraint, not a choice made here.
+ */
+public class CachingWSManClientFactory implements WSManClientFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(CachingWSManClientFactory.class);
+
+    static final Duration EXPIRE_AFTER = Duration.ofHours(1);
+
+    private final WSManClientFactory m_delegate;
+
+    private final Cache<EndpointKey, WSManClient> m_clients;
+
+    public CachingWSManClientFactory() {
+        this(new CXFWSManClientFactory());
+    }
+
+    public CachingWSManClientFactory(WSManClientFactory delegate) {
+        this(delegate, EXPIRE_AFTER);
+    }
+
+    CachingWSManClientFactory(WSManClientFactory delegate, Duration expireAfterAccess) {
+        m_delegate = Objects.requireNonNull(delegate, "delegate");
+        m_clients = CacheBuilder.newBuilder()
+                .expireAfterAccess(expireAfterAccess.toNanos(), TimeUnit.NANOSECONDS)
+                .removalListener((RemovalNotification<EndpointKey, WSManClient> n) -> closeQuietly(n.getValue()))
+                .build();
+    }
+
+    @Override
+    public WSManClient getClient(WSManEndpoint endpoint) {
+        Objects.requireNonNull(endpoint, "endpoint");
+        if (!endpoint.isKerberosEncryption()) {
+            return m_delegate.getClient(endpoint);
+        }
+        final EndpointKey key = new EndpointKey(endpoint);
+        try {
+            final WSManClient shared = m_clients.get(key, () -> {
+                LOG.debug("Creating shared Kerberos-encrypted WS-Man client for {}", endpoint);
+                return m_delegate.getClient(endpoint);
+            });
+            return new SharedClient(shared);
+        } catch (ExecutionException e) {
+            throw new WSManException("Failed to create WS-Man client for " + endpoint, e.getCause());
+        }
+    }
+
+    /**
+     * Closes and forgets every cached client.
+     */
+    public void close() {
+        m_clients.invalidateAll();
+        m_clients.cleanUp();
+    }
+
+    /** Number of clients currently cached. Visible for tests. */
+    long size() {
+        m_clients.cleanUp();
+        return m_clients.size();
+    }
+
+    private static void closeQuietly(WSManClient client) {
+        if (client == null) {
+            return;
+        }
+        try {
+            client.close();
+        } catch (Exception e) {
+            LOG.debug("Error closing WS-Man client {}", client, e);
+        }
+    }
+
+    /**
+     * Identity of a {@link WSManEndpoint}, which has no equals/hashCode of its own.
+     */
+    static final class EndpointKey {
+        private final URL url;
+        private final String username;
+        private final String password;
+        private final boolean gssAuth;
+        private final boolean kerberosEncryption;
+        private final boolean strictSSL;
+        private final WSManVersion serverVersion;
+        private final Integer maxElements;
+        private final Integer maxEnvelopeSize;
+        private final Integer connectionTimeout;
+        private final Integer receiveTimeout;
+
+        EndpointKey(WSManEndpoint e) {
+            url = e.getUrl();
+            username = e.getUsername();
+            password = e.getPassword();
+            gssAuth = e.isGSSAuth();
+            kerberosEncryption = e.isKerberosEncryption();
+            strictSSL = e.isStrictSSL();
+            serverVersion = e.getServerVersion();
+            maxElements = e.getMaxElements();
+            maxEnvelopeSize = e.getMaxEnvelopeSize();
+            connectionTimeout = e.getConnectionTimeout();
+            receiveTimeout = e.getReceiveTimeout();
+        }
+
+        @Override
+        public int hashCode() {
+            // URL.hashCode() resolves the host; compare the external form instead
+            return Objects.hash(url.toExternalForm(), username, password, gssAuth, kerberosEncryption, strictSSL,
+                    serverVersion, maxElements, maxEnvelopeSize, connectionTimeout, receiveTimeout);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof EndpointKey)) {
+                return false;
+            }
+            final EndpointKey other = (EndpointKey) obj;
+            return Objects.equals(url.toExternalForm(), other.url.toExternalForm())
+                    && Objects.equals(username, other.username)
+                    && Objects.equals(password, other.password)
+                    && gssAuth == other.gssAuth
+                    && kerberosEncryption == other.kerberosEncryption
+                    && strictSSL == other.strictSSL
+                    && serverVersion == other.serverVersion
+                    && Objects.equals(maxElements, other.maxElements)
+                    && Objects.equals(maxEnvelopeSize, other.maxEnvelopeSize)
+                    && Objects.equals(connectionTimeout, other.connectionTimeout)
+                    && Objects.equals(receiveTimeout, other.receiveTimeout);
+        }
+    }
+
+    /**
+     * Delegates every operation to the shared client but ignores {@link #close()},
+     * so callers can use try-with-resources uniformly without tearing down the
+     * shared session.
+     */
+    static final class SharedClient implements WSManClient {
+        private final WSManClient m_delegate;
+
+        SharedClient(WSManClient delegate) {
+            m_delegate = Objects.requireNonNull(delegate);
+        }
+
+        WSManClient getDelegate() {
+            return m_delegate;
+        }
+
+        @Override
+        public Identity identify() {
+            return m_delegate.identify();
+        }
+
+        @Override
+        public Node get(String resourceUri, Map<String, String> selectors) {
+            return m_delegate.get(resourceUri, selectors);
+        }
+
+        @Override
+        public String enumerate(String resourceUri) {
+            return m_delegate.enumerate(resourceUri);
+        }
+
+        @Override
+        public String enumerateWithFilter(String resourceUri, String dialect, String filter) {
+            return m_delegate.enumerateWithFilter(resourceUri, dialect, filter);
+        }
+
+        @Override
+        public String pull(String contextId, String resourceUri, List<Node> nodes, boolean recursive) {
+            return m_delegate.pull(contextId, resourceUri, nodes, recursive);
+        }
+
+        @Override
+        public String enumerateAndPull(String resourceUri, List<Node> nodes, boolean recursive) {
+            return m_delegate.enumerateAndPull(resourceUri, nodes, recursive);
+        }
+
+        @Override
+        public String enumerateAndPullUsingFilter(String resourceUri, String dialect, String filter, List<Node> nodes, boolean recursive) {
+            return m_delegate.enumerateAndPullUsingFilter(resourceUri, dialect, filter, nodes, recursive);
+        }
+
+        @Override
+        public CommandResult runCommand(String executable, String[] args, Duration timeout, ShellOptions options) {
+            return m_delegate.runCommand(executable, args, timeout, options);
+        }
+
+        @Override
+        public void close() {
+            // The shared client is owned by the factory
+        }
+
+        @Override
+        public String toString() {
+            return m_delegate.toString();
+        }
+    }
+}

--- a/features/wsman/src/main/java/org/opennms/core/wsman/utils/CachingWSManClientFactory.java
+++ b/features/wsman/src/main/java/org/opennms/core/wsman/utils/CachingWSManClientFactory.java
@@ -45,6 +45,7 @@ import org.w3c.dom.Node;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalNotification;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 
 /**
  * A {@link WSManClientFactory} that reuses clients for endpoints with Kerberos

--- a/features/wsman/src/main/java/org/opennms/core/wsman/utils/ShellCommandUtils.java
+++ b/features/wsman/src/main/java/org/opennms/core/wsman/utils/ShellCommandUtils.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.core.wsman.utils;
+
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import org.opennms.core.wsman.shell.CommandResult;
+import org.opennms.core.wsman.shell.ShellOptions;
+
+import com.google.common.base.Strings;
+
+/**
+ * Helpers shared by the WinRS shell monitor and detector: argument handling,
+ * banner matching, exit code checks and shell option handling.
+ */
+public final class ShellCommandUtils {
+
+    /** Banner value that matches any output, as in the other monitors. */
+    public static final String BANNER_ANY = "*";
+
+    /** Prefix that marks a banner as a regular expression, as in the other monitors and policies. */
+    public static final String REGEX_PREFIX = "~";
+
+    /** Exit code value that disables the exit code check. */
+    public static final String EXIT_CODE_ANY = "*";
+
+    /** Longest output excerpt included in a failure reason. */
+    static final int MAX_EXCERPT = 512;
+
+    private ShellCommandUtils() {
+    }
+
+    /**
+     * Converts the configured argument string into the arguments handed to WinRS.
+     *
+     * <p>WinRS builds the remote command line by joining the command and its arguments
+     * with spaces, and neither it nor the client library adds any quoting. The
+     * argument string is therefore passed through verbatim as a single argument, so
+     * what is written in the configuration is exactly the command line tail the
+     * Windows host executes, with Windows quoting rules applying. In an XML
+     * configuration file double quotes are written as {@code &quot;}, which the XML
+     * parser turns back into plain quotes before the value gets here.
+     *
+     * @param args the raw argument string, may be null or blank
+     * @return an empty array when there are no arguments, otherwise the trimmed string as the only element
+     */
+    public static String[] toArguments(String args) {
+        if (args == null || args.trim().isEmpty()) {
+            return new String[0];
+        }
+        return new String[] { args.trim() };
+    }
+
+    /**
+     * Checks command output against a banner. A null, empty or {@code *} banner matches
+     * anything. A banner starting with {@code ~} is a regular expression that must match
+     * the whole output; it is compiled with {@link Pattern#DOTALL} so {@code .} spans
+     * lines. Any other banner must appear somewhere in the output.
+     *
+     * @throws PatternSyntaxException if a regex banner is invalid
+     */
+    public static boolean bannerMatches(String banner, String output) {
+        if (Strings.isNullOrEmpty(banner) || BANNER_ANY.equals(banner)) {
+            return true;
+        }
+        final String text = output == null ? "" : output;
+        if (banner.startsWith(REGEX_PREFIX)) {
+            return Pattern.compile(banner.substring(REGEX_PREFIX.length()), Pattern.DOTALL).matcher(text).matches();
+        }
+        return text.contains(banner);
+    }
+
+    /**
+     * Checks a command's exit code against the expected value. {@code *} (or null/empty)
+     * accepts any exit code.
+     *
+     * @throws NumberFormatException if the expected value is neither {@code *} nor an integer
+     */
+    public static boolean exitCodeMatches(String expected, int actual) {
+        if (Strings.isNullOrEmpty(expected) || EXIT_CODE_ANY.equals(expected)) {
+            return true;
+        }
+        return Integer.parseInt(expected.trim()) == actual;
+    }
+
+    /**
+     * Builds the {@link ShellOptions} from the optional monitor/detector settings.
+     */
+    public static ShellOptions buildShellOptions(boolean noProfile, Integer codepage, String workingDirectory) {
+        final ShellOptions.Builder builder = new ShellOptions.Builder().withNoProfile(noProfile);
+        if (codepage != null) {
+            builder.withCodepage(codepage);
+        }
+        if (!Strings.isNullOrEmpty(workingDirectory)) {
+            builder.withWorkingDirectory(workingDirectory);
+        }
+        return builder.build();
+    }
+
+    /**
+     * Evaluates a command result against the expected exit code and banner.
+     *
+     * @return an empty optional when the result is acceptable, otherwise the reason it is not
+     */
+    public static Optional<String> checkResult(CommandResult result, String expectedExitCode, String banner) {
+        if (!exitCodeMatches(expectedExitCode, result.exitCode())) {
+            return Optional.of(String.format("Command exited with code %d, expected %s. stderr: '%s' stdout: '%s'",
+                    result.exitCode(), expectedExitCode, excerpt(result.stderr()), excerpt(result.stdout())));
+        }
+        if (!bannerMatches(banner, result.stdout())) {
+            return Optional.of(String.format("Banner '%s' not matched by command output: '%s'",
+                    banner, excerpt(result.stdout())));
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Trims output for inclusion in a status reason or log message.
+     */
+    public static String excerpt(String output) {
+        if (output == null) {
+            return "";
+        }
+        final String trimmed = output.trim();
+        return trimmed.length() <= MAX_EXCERPT ? trimmed : trimmed.substring(0, MAX_EXCERPT) + "...";
+    }
+}

--- a/features/wsman/src/main/java/org/opennms/netmgt/collectd/WsManCollector.java
+++ b/features/wsman/src/main/java/org/opennms/netmgt/collectd/WsManCollector.java
@@ -40,9 +40,9 @@ import org.opennms.core.utils.ParameterMap;
 import org.opennms.core.wsman.WSManClient;
 import org.opennms.core.wsman.WSManClientFactory;
 import org.opennms.core.wsman.WSManEndpoint;
-import org.opennms.core.wsman.cxf.CXFWSManClientFactory;
 import org.opennms.core.wsman.exceptions.InvalidResourceURI;
 import org.opennms.core.wsman.exceptions.WSManException;
+import org.opennms.core.wsman.utils.CachingWSManClientFactory;
 import org.opennms.core.wsman.utils.ResponseHandlingUtils;
 import org.opennms.core.wsman.utils.RetryNTimesLoop;
 import org.opennms.netmgt.collection.api.AbstractRemoteServiceCollector;
@@ -94,7 +94,7 @@ public class WsManCollector extends AbstractRemoteServiceCollector {
 
     static final String ELEMENT_COUNT_ATTRIB_NAME = "##ElementCount##";
 
-    private WSManClientFactory m_factory = new CXFWSManClientFactory();
+    private WSManClientFactory m_factory = new CachingWSManClientFactory();
 
     private WSManDataCollectionConfigDao m_wsManDataCollectionConfigDao;
 
@@ -156,7 +156,6 @@ public class WsManCollector extends AbstractRemoteServiceCollector {
         final Groups groups = (Groups)parameters.get(WSMAN_GROUPS_KEY);
 
         final WSManEndpoint endpoint = WSManConfigDao.getEndpoint(config, agent.getAddress());
-        final WSManClient client = m_factory.getClient(endpoint);
         final CollectionSetBuilder collectionSetBuilder = new CollectionSetBuilder(agent);
 
         if (LOG.isDebugEnabled()) {
@@ -164,16 +163,19 @@ public class WsManCollector extends AbstractRemoteServiceCollector {
             LOG.debug("Collecting attributes on {} from groups: {}", agent, groupNames);
         }
 
-        for (Group group : groups.getGroups()) {
-            try {
-                collectGroupUsing(group, agent, client, config.getRetry() != null ? config.getRetry() : 0, collectionSetBuilder);
-            } catch (InvalidResourceURI e) {
-                LOG.info("Resource URI {} in group named {} is not available on {}.", group.getResourceUri(), group.getName(), agent);
-            } catch (WSManException e) {
-                // If collecting any individual group fails, mark the collection set as
-                // failed, and abort trying to collect any other groups
-                throw new CollectionException(String.format("Collecting group '%s' on %s failed with '%s'. See logs for details.",
-                        group.getName(), agent, e.getMessage()), e);
+        // Close the client when done so any session it holds (Kerberos encryption) is released
+        try (WSManClient client = m_factory.getClient(endpoint)) {
+            for (Group group : groups.getGroups()) {
+                try {
+                    collectGroupUsing(group, agent, client, config.getRetry() != null ? config.getRetry() : 0, collectionSetBuilder);
+                } catch (InvalidResourceURI e) {
+                    LOG.info("Resource URI {} in group named {} is not available on {}.", group.getResourceUri(), group.getName(), agent);
+                } catch (WSManException e) {
+                    // If collecting any individual group fails, mark the collection set as
+                    // failed, and abort trying to collect any other groups
+                    throw new CollectionException(String.format("Collecting group '%s' on %s failed with '%s'. See logs for details.",
+                            group.getName(), agent, e.getMessage()), e);
+                }
             }
         }
 

--- a/features/wsman/src/main/java/org/opennms/netmgt/collectd/WsManCollector.java
+++ b/features/wsman/src/main/java/org/opennms/netmgt/collectd/WsManCollector.java
@@ -310,6 +310,20 @@ public class WsManCollector extends AbstractRemoteServiceCollector {
         m_factory = Objects.requireNonNull(factory);
     }
 
+    /**
+     * Releases any clients the factory is holding on to. Called by the blueprint
+     * container when the bundle stops.
+     */
+    public void destroy() {
+        if (m_factory instanceof AutoCloseable) {
+            try {
+                ((AutoCloseable) m_factory).close();
+            } catch (Exception e) {
+                LOG.debug("Error closing WS-Man client factory", e);
+            }
+        }
+    }
+
     public void setNodeDao(NodeDao nodeDao) {
         m_nodeDao = Objects.requireNonNull(nodeDao);
     }

--- a/features/wsman/src/main/java/org/opennms/netmgt/config/wsman/credentials/Definition.java
+++ b/features/wsman/src/main/java/org/opennms/netmgt/config/wsman/credentials/Definition.java
@@ -100,6 +100,8 @@ public class Definition implements WsmanAgentConfig {
     protected String productVersion;
     @XmlAttribute(name = "gss-auth")
     protected Boolean gssAuth;
+    @XmlAttribute(name = "kerberos-encryption")
+    protected Boolean kerberosEncryption;
 
     public Definition() { }
 
@@ -116,6 +118,7 @@ public class Definition implements WsmanAgentConfig {
         setProductVendor(config.getProductVendor());
         setProductVersion(config.getProductVersion());
         setGssAuth(config.isGssAuth());
+        setKerberosEncryption(config.isKerberosEncryption());
     }
 
     /**
@@ -447,9 +450,18 @@ public class Definition implements WsmanAgentConfig {
     }
 
     @Override
+    public Boolean isKerberosEncryption() {
+        return kerberosEncryption;
+    }
+
+    public void setKerberosEncryption(Boolean value) {
+        this.kerberosEncryption = value;
+    }
+
+    @Override
     public int hashCode() {
         return Objects.hash(range, specific, ipMatch, timeout, retry, username, password, port, maxElements,
-                ssl, strictSsl, path, productVendor, gssAuth);
+                ssl, strictSsl, path, productVendor, productVersion, gssAuth, kerberosEncryption);
     }
 
     @Override
@@ -475,6 +487,7 @@ public class Definition implements WsmanAgentConfig {
                 Objects.equals(this.path, other.path) &&
                 Objects.equals(this.productVendor, other.productVendor) &&
                 Objects.equals(this.productVersion, other.productVersion) &&
-                Objects.equals(this.gssAuth, other.gssAuth);
+                Objects.equals(this.gssAuth, other.gssAuth) &&
+                Objects.equals(this.kerberosEncryption, other.kerberosEncryption);
     }
 }

--- a/features/wsman/src/main/java/org/opennms/netmgt/config/wsman/credentials/WsmanAgentConfig.java
+++ b/features/wsman/src/main/java/org/opennms/netmgt/config/wsman/credentials/WsmanAgentConfig.java
@@ -34,4 +34,5 @@ public interface WsmanAgentConfig {
     String getProductVendor();
     String getProductVersion();
     Boolean isGssAuth();
+    Boolean isKerberosEncryption();
 }

--- a/features/wsman/src/main/java/org/opennms/netmgt/config/wsman/credentials/WsmanConfig.java
+++ b/features/wsman/src/main/java/org/opennms/netmgt/config/wsman/credentials/WsmanConfig.java
@@ -96,6 +96,8 @@ public class WsmanConfig implements WsmanAgentConfig {
     protected String productVersion;
     @XmlAttribute(name = "gss-auth")
     protected Boolean gssAuth;
+    @XmlAttribute(name = "kerberos-encryption")
+    protected Boolean kerberosEncryption;
 
     /**
      * Maps IP addresses to specific WS-Man parameters(retries, timeouts...) Gets the value of the definition property.
@@ -379,9 +381,18 @@ public class WsmanConfig implements WsmanAgentConfig {
     }
 
     @Override
+    public Boolean isKerberosEncryption() {
+        return kerberosEncryption;
+    }
+
+    public void setKerberosEncryption(Boolean value) {
+        this.kerberosEncryption = value;
+    }
+
+    @Override
     public int hashCode() {
         return Objects.hash(definition, timeout, retry, username, password, port,
-                maxElements, ssl, strictSsl, path, productVendor, productVersion, gssAuth);
+                maxElements, ssl, strictSsl, path, productVendor, productVersion, gssAuth, kerberosEncryption);
     }
 
     @Override
@@ -405,6 +416,7 @@ public class WsmanConfig implements WsmanAgentConfig {
                 Objects.equals(this.path, other.path) &&
                 Objects.equals(this.productVendor, other.productVendor) &&
                 Objects.equals(this.productVersion, other.productVersion) &&
-                Objects.equals(this.gssAuth, other.gssAuth);
+                Objects.equals(this.gssAuth, other.gssAuth) &&
+                Objects.equals(this.kerberosEncryption, other.kerberosEncryption);
     }
 }

--- a/features/wsman/src/main/java/org/opennms/netmgt/dao/WSManConfigDao.java
+++ b/features/wsman/src/main/java/org/opennms/netmgt/dao/WSManConfigDao.java
@@ -65,8 +65,11 @@ public interface WSManConfigDao {
             }
 
             String host = agentInetAddress.getHostAddress();
-            if (agentConfig.isGssAuth()!=null && agentConfig.isGssAuth()) {
-                // Always use the canonical host name when using GSS authentication
+            if (isGssAuth(agentConfig) || isKerberosEncryption(agentConfig)) {
+                // Always use the canonical host name when using GSS authentication: the
+                // Kerberos service ticket is requested for HTTP/<host>, so the name has
+                // to match the target's service principal. Kerberos message encryption
+                // implies GSS authentication.
                 host = agentInetAddress.getCanonicalHostName();
             }
 
@@ -80,8 +83,11 @@ public interface WSManConfigDao {
         if (agentConfig.getUsername() != null && agentConfig.getPassword() != null) {
             builder.withBasicAuth(agentConfig.getUsername(), agentConfig.getPassword());
         }
-        if (agentConfig.isGssAuth() != null && agentConfig.isGssAuth()) {
+        if (isGssAuth(agentConfig)) {
             builder.withGSSAuth();
+        }
+        if (isKerberosEncryption(agentConfig)) {
+            builder.withKerberosEncryption();
         }
         if (agentConfig.getMaxElements() != null) {
             builder.withMaxElements(agentConfig.getMaxElements());
@@ -94,5 +100,13 @@ public interface WSManConfigDao {
                    .withReceiveTimeout(agentConfig.getTimeout());
         }
         return builder.build();
+    }
+
+    static boolean isGssAuth(WsmanAgentConfig agentConfig) {
+        return Boolean.TRUE.equals(agentConfig.isGssAuth());
+    }
+
+    static boolean isKerberosEncryption(WsmanAgentConfig agentConfig) {
+        return Boolean.TRUE.equals(agentConfig.isKerberosEncryption());
     }
 }

--- a/features/wsman/src/main/java/org/opennms/netmgt/poller/monitors/WsManMonitor.java
+++ b/features/wsman/src/main/java/org/opennms/netmgt/poller/monitors/WsManMonitor.java
@@ -34,8 +34,8 @@ import org.opennms.core.utils.ParameterMap;
 import org.opennms.core.wsman.WSManClient;
 import org.opennms.core.wsman.WSManClientFactory;
 import org.opennms.core.wsman.WSManEndpoint;
-import org.opennms.core.wsman.cxf.CXFWSManClientFactory;
 import org.opennms.core.wsman.exceptions.WSManException;
+import org.opennms.core.wsman.utils.CachingWSManClientFactory;
 import org.opennms.core.wsman.utils.ResponseHandlingUtils;
 import org.opennms.core.wsman.utils.RetryNTimesLoop;
 import org.opennms.netmgt.config.wsman.credentials.WsmanAgentConfig;
@@ -67,7 +67,7 @@ public class WsManMonitor extends ParameterSubstitutingMonitor {
 
     public static final String SELECTOR_PARAM_PREFIX = "selector.";
 
-    private WSManClientFactory m_factory = new CXFWSManClientFactory();
+    private WSManClientFactory m_factory = new CachingWSManClientFactory();
 
     private WSManConfigDao m_wsManConfigDao;
 
@@ -120,12 +120,11 @@ public class WsManMonitor extends ParameterSubstitutingMonitor {
         } catch (MalformedURLException e) {
             return PollStatus.down(e.getMessage());
         }
-        final WSManClient client = m_factory.getClient(endpoint);
         final RetryNTimesLoop retryLoop = new RetryNTimesLoop(ParameterMap.getKeyedInteger(parameters, WSMAN_RETRY_KEY, 0));
 
-        // Issue a GET
+        // Issue a GET, closing the client afterwards so any session it holds (Kerberos encryption) is released
         Node node = null;
-        try {
+        try (WSManClient client = m_factory.getClient(endpoint)) {
             while (retryLoop.shouldContinue()) {
                 try {
                     node = client.get(resourceUri, selectors);

--- a/features/wsman/src/main/java/org/opennms/netmgt/poller/monitors/WsManMonitor.java
+++ b/features/wsman/src/main/java/org/opennms/netmgt/poller/monitors/WsManMonitor.java
@@ -44,6 +44,8 @@ import org.opennms.netmgt.poller.MonitoredService;
 import org.opennms.netmgt.poller.PollStatus;
 import org.opennms.netmgt.poller.monitors.support.ParameterSubstitutingMonitor;
 import org.opennms.netmgt.provision.detector.wsman.WsmanEndpointUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Node;
 
 import com.google.common.collect.ListMultimap;
@@ -58,6 +60,7 @@ import com.google.common.collect.Maps;
  * @author jwhite
  */
 public class WsManMonitor extends ParameterSubstitutingMonitor {
+    private static final Logger LOG = LoggerFactory.getLogger(WsManMonitor.class);
 
     private static final String WSMAN_RETRY_KEY = "retry";
 
@@ -158,5 +161,19 @@ public class WsManMonitor extends ParameterSubstitutingMonitor {
 
     public void setWSManClientFactory(WSManClientFactory factory) {
         m_factory = Objects.requireNonNull(factory);
+    }
+
+    /**
+     * Releases any clients the factory is holding on to. Called by the blueprint
+     * container when the bundle stops.
+     */
+    public void destroy() {
+        if (m_factory instanceof AutoCloseable) {
+            try {
+                ((AutoCloseable) m_factory).close();
+            } catch (Exception e) {
+                LOG.debug("Error closing WS-Man client factory", e);
+            }
+        }
     }
 }

--- a/features/wsman/src/main/java/org/opennms/netmgt/poller/monitors/WsManShellMonitor.java
+++ b/features/wsman/src/main/java/org/opennms/netmgt/poller/monitors/WsManShellMonitor.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.poller.monitors;
+
+import java.net.MalformedURLException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.opennms.core.mate.api.Interpolator;
+import org.opennms.core.spring.BeanUtils;
+import org.opennms.core.utils.ParameterMap;
+import org.opennms.core.utils.TimeoutTracker;
+import org.opennms.core.wsman.WSManClient;
+import org.opennms.core.wsman.WSManClientFactory;
+import org.opennms.core.wsman.WSManEndpoint;
+import org.opennms.core.wsman.exceptions.WSManException;
+import org.opennms.core.wsman.shell.CommandResult;
+import org.opennms.core.wsman.shell.ShellOptions;
+import org.opennms.core.wsman.utils.CachingWSManClientFactory;
+import org.opennms.core.wsman.utils.ShellCommandUtils;
+import org.opennms.netmgt.config.wsman.credentials.WsmanAgentConfig;
+import org.opennms.netmgt.dao.WSManConfigDao;
+import org.opennms.netmgt.poller.MonitoredService;
+import org.opennms.netmgt.poller.PollStatus;
+import org.opennms.netmgt.poller.monitors.support.ParameterSubstitutingMonitor;
+import org.opennms.netmgt.provision.detector.wsman.WsmanEndpointUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * WS-Man Shell Monitor
+ *
+ * Runs a command on the remote host through WinRS (MS-WSMV) and marks the service
+ * up when its output matches the configured banner and, if an exit code is
+ * configured, the command exits with that code.
+ *
+ * The endpoint details come from wsman-config.xml, resolved on the core in
+ * {@link #getRuntimeAttributes} so the poll itself can run on a Minion.
+ */
+public class WsManShellMonitor extends ParameterSubstitutingMonitor {
+    private static final Logger LOG = LoggerFactory.getLogger(WsManShellMonitor.class);
+
+    public static final String COMMAND_PARAM = "command";
+    public static final String ARGS_PARAM = "args";
+    public static final String BANNER_PARAM = "banner";
+    public static final String EXIT_CODE_PARAM = "exit-code";
+    public static final String NO_PROFILE_PARAM = "no-profile";
+    public static final String CODEPAGE_PARAM = "codepage";
+    public static final String WORKING_DIRECTORY_PARAM = "working-directory";
+
+    private static final String RETRY_KEY = "retry";
+
+    static final int DEFAULT_TIMEOUT = 3000;
+    static final int DEFAULT_RETRY = 0;
+    /** By default the exit code is not checked; set exit-code to require a specific value. */
+    static final String DEFAULT_EXIT_CODE = ShellCommandUtils.EXIT_CODE_ANY;
+
+    private WSManClientFactory m_factory = new CachingWSManClientFactory();
+
+    private WSManConfigDao m_wsManConfigDao;
+
+    @Override
+    public Map<String, Object> getRuntimeAttributes(MonitoredService svc, Map<String, Object> parameters) {
+        final Map<String, Object> runtimeAttributes = super.getRuntimeAttributes(svc, parameters);
+
+        if (m_wsManConfigDao == null) {
+            m_wsManConfigDao = BeanUtils.getBean("daoContext", "wsManConfigDao", WSManConfigDao.class);
+        }
+
+        final WsmanAgentConfig config = m_wsManConfigDao.getAgentConfig(svc.getAddress());
+        WsmanEndpointUtils.toMap(WSManConfigDao.getEndpoint(config, svc.getAddress()))
+                .forEach((key, value) -> runtimeAttributes.put(key, Interpolator.pleaseInterpolate(value)));
+
+        // The service definition's retry wins over the wsman-config default
+        if (!parameters.containsKey(RETRY_KEY) && config.getRetry() != null) {
+            runtimeAttributes.put(RETRY_KEY, config.getRetry());
+        }
+        return runtimeAttributes;
+    }
+
+    @Override
+    public PollStatus poll(MonitoredService svc, Map<String, Object> parameters) {
+        final String command = resolveKeyedString(parameters, COMMAND_PARAM, null);
+        if (command == null || command.trim().isEmpty()) {
+            throw new IllegalArgumentException("'" + COMMAND_PARAM + "' parameter is required.");
+        }
+        final String[] args = ShellCommandUtils.toArguments(resolveKeyedString(parameters, ARGS_PARAM, null));
+        final String banner = resolveKeyedString(parameters, BANNER_PARAM, null);
+        final String expectedExitCode = ParameterMap.getKeyedString(parameters, EXIT_CODE_PARAM, DEFAULT_EXIT_CODE);
+        final ShellOptions shellOptions = ShellCommandUtils.buildShellOptions(
+                ParameterMap.getKeyedBoolean(parameters, NO_PROFILE_PARAM, true),
+                parameters.get(CODEPAGE_PARAM) != null ? ParameterMap.getKeyedInteger(parameters, CODEPAGE_PARAM, 0) : null,
+                ParameterMap.getKeyedString(parameters, WORKING_DIRECTORY_PARAM, null));
+
+        final WSManEndpoint endpoint;
+        try {
+            final Map<String, String> filteredMap = parameters.entrySet().stream()
+                    .filter(e -> e.getValue() != null)
+                    .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().toString()));
+            endpoint = WsmanEndpointUtils.fromMap(filteredMap);
+        } catch (MalformedURLException e) {
+            return PollStatus.down(e.getMessage());
+        }
+
+        final TimeoutTracker tracker = new TimeoutTracker(parameters, DEFAULT_RETRY, DEFAULT_TIMEOUT);
+        final Duration commandTimeout = Duration.ofMillis(tracker.getTimeoutInMillis());
+
+        PollStatus status = PollStatus.unavailable();
+        try (WSManClient client = m_factory.getClient(endpoint)) {
+            for (tracker.reset(); tracker.shouldRetry() && !status.isAvailable(); tracker.nextAttempt()) {
+                tracker.startAttempt();
+                try {
+                    LOG.debug("Running '{}' with arguments {} on {}", command, args, svc.getIpAddr());
+                    final CommandResult result = client.runCommand(command, args, commandTimeout, shellOptions);
+                    final double responseTime = tracker.elapsedTimeInMillis();
+                    LOG.debug("Command '{}' on {} exited with {}: stdout='{}' stderr='{}'", command, svc.getIpAddr(),
+                            result.exitCode(), ShellCommandUtils.excerpt(result.stdout()), ShellCommandUtils.excerpt(result.stderr()));
+
+                    final Optional<String> failure = ShellCommandUtils.checkResult(result, expectedExitCode, banner);
+                    status = failure.isPresent() ? PollStatus.unavailable(failure.get()) : PollStatus.available(responseTime);
+                } catch (WSManException e) {
+                    LOG.debug("Command '{}' failed on {}", command, svc.getIpAddr(), e);
+                    status = PollStatus.unavailable(String.format("Running '%s' failed: %s", command, e.getMessage()));
+                }
+            }
+        }
+        return status;
+    }
+
+    public void setWSManConfigDao(WSManConfigDao wsManConfigDao) {
+        m_wsManConfigDao = Objects.requireNonNull(wsManConfigDao);
+    }
+
+    public void setWSManClientFactory(WSManClientFactory factory) {
+        m_factory = Objects.requireNonNull(factory);
+    }
+}

--- a/features/wsman/src/main/java/org/opennms/netmgt/poller/monitors/WsManShellMonitor.java
+++ b/features/wsman/src/main/java/org/opennms/netmgt/poller/monitors/WsManShellMonitor.java
@@ -56,8 +56,16 @@ import org.slf4j.LoggerFactory;
  * up when its output matches the configured banner and, if an exit code is
  * configured, the command exits with that code.
  *
- * The endpoint details come from wsman-config.xml, resolved on the core in
- * {@link #getRuntimeAttributes} so the poll itself can run on a Minion.
+ * <p>The endpoint details come from wsman-config.xml, resolved on the core in
+ * {@link #getRuntimeAttributes} so the poll itself can run on a Minion. The
+ * {@code timeout} and {@code retry} values from wsman-config.xml serve as defaults
+ * that a service definition can override, as with snmp-config.xml.
+ *
+ * <p>The {@code command} and {@code args} parameters are deliberately excluded from
+ * placeholder substitution: they are passed to the Windows command interpreter
+ * verbatim, so substituting node-controlled text such as the node label into them
+ * would let whoever controls that text run commands on the host. The {@code banner}
+ * parameter, which is only ever matched against output, does support substitution.
  */
 public class WsManShellMonitor extends ParameterSubstitutingMonitor {
     private static final Logger LOG = LoggerFactory.getLogger(WsManShellMonitor.class);
@@ -70,7 +78,8 @@ public class WsManShellMonitor extends ParameterSubstitutingMonitor {
     public static final String CODEPAGE_PARAM = "codepage";
     public static final String WORKING_DIRECTORY_PARAM = "working-directory";
 
-    private static final String RETRY_KEY = "retry";
+    static final String RETRY_KEY = "retry";
+    static final String TIMEOUT_KEY = "timeout";
 
     static final int DEFAULT_TIMEOUT = 3000;
     static final int DEFAULT_RETRY = 0;
@@ -93,39 +102,46 @@ public class WsManShellMonitor extends ParameterSubstitutingMonitor {
         WsmanEndpointUtils.toMap(WSManConfigDao.getEndpoint(config, svc.getAddress()))
                 .forEach((key, value) -> runtimeAttributes.put(key, Interpolator.pleaseInterpolate(value)));
 
-        // The service definition's retry wins over the wsman-config default
+        // wsman-config.xml provides the defaults; the service definition wins when it sets its own
         if (!parameters.containsKey(RETRY_KEY) && config.getRetry() != null) {
             runtimeAttributes.put(RETRY_KEY, config.getRetry());
+        }
+        if (!parameters.containsKey(TIMEOUT_KEY) && config.getTimeout() != null) {
+            runtimeAttributes.put(TIMEOUT_KEY, config.getTimeout());
         }
         return runtimeAttributes;
     }
 
     @Override
     public PollStatus poll(MonitoredService svc, Map<String, Object> parameters) {
-        final String command = resolveKeyedString(parameters, COMMAND_PARAM, null);
+        // command and args intentionally bypass placeholder substitution, see the class comment
+        final String command = ParameterMap.getKeyedString(parameters, COMMAND_PARAM, null);
         if (command == null || command.trim().isEmpty()) {
             throw new IllegalArgumentException("'" + COMMAND_PARAM + "' parameter is required.");
         }
-        final String[] args = ShellCommandUtils.toArguments(resolveKeyedString(parameters, ARGS_PARAM, null));
+        final String[] args = ShellCommandUtils.toArguments(ParameterMap.getKeyedString(parameters, ARGS_PARAM, null));
         final String banner = resolveKeyedString(parameters, BANNER_PARAM, null);
         final String expectedExitCode = ParameterMap.getKeyedString(parameters, EXIT_CODE_PARAM, DEFAULT_EXIT_CODE);
         final ShellOptions shellOptions = ShellCommandUtils.buildShellOptions(
                 ParameterMap.getKeyedBoolean(parameters, NO_PROFILE_PARAM, true),
-                parameters.get(CODEPAGE_PARAM) != null ? ParameterMap.getKeyedInteger(parameters, CODEPAGE_PARAM, 0) : null,
+                parseCodepage(ParameterMap.getKeyedString(parameters, CODEPAGE_PARAM, null)),
                 ParameterMap.getKeyedString(parameters, WORKING_DIRECTORY_PARAM, null));
+
+        final TimeoutTracker tracker = new TimeoutTracker(parameters, DEFAULT_RETRY, DEFAULT_TIMEOUT);
+        final int timeoutMillis = (int) tracker.getTimeoutInMillis();
 
         final WSManEndpoint endpoint;
         try {
             final Map<String, String> filteredMap = parameters.entrySet().stream()
                     .filter(e -> e.getValue() != null)
                     .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().toString()));
-            endpoint = WsmanEndpointUtils.fromMap(filteredMap);
+            // The timeout bounds every exchange with the host (connect, shell creation, output,
+            // shell deletion) as well as the wait for the command itself
+            endpoint = WsmanEndpointUtils.withTimeouts(WsmanEndpointUtils.fromMap(filteredMap), timeoutMillis);
         } catch (MalformedURLException e) {
             return PollStatus.down(e.getMessage());
         }
-
-        final TimeoutTracker tracker = new TimeoutTracker(parameters, DEFAULT_RETRY, DEFAULT_TIMEOUT);
-        final Duration commandTimeout = Duration.ofMillis(tracker.getTimeoutInMillis());
+        final Duration commandTimeout = Duration.ofMillis(timeoutMillis);
 
         PollStatus status = PollStatus.unavailable();
         try (WSManClient client = m_factory.getClient(endpoint)) {
@@ -145,8 +161,25 @@ public class WsManShellMonitor extends ParameterSubstitutingMonitor {
                     status = PollStatus.unavailable(String.format("Running '%s' failed: %s", command, e.getMessage()));
                 }
             }
+        } catch (WSManException e) {
+            return PollStatus.unavailable(String.format("Could not create WS-Man client for %s: %s", svc.getIpAddr(), e.getMessage()));
         }
         return status;
+    }
+
+    private static Integer parseCodepage(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            final int codepage = Integer.parseInt(value.trim());
+            if (codepage <= 0) {
+                throw new IllegalArgumentException("'" + CODEPAGE_PARAM + "' must be a positive code page number, got: " + value);
+            }
+            return codepage;
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("'" + CODEPAGE_PARAM + "' must be a positive code page number, got: " + value);
+        }
     }
 
     public void setWSManConfigDao(WSManConfigDao wsManConfigDao) {
@@ -155,5 +188,19 @@ public class WsManShellMonitor extends ParameterSubstitutingMonitor {
 
     public void setWSManClientFactory(WSManClientFactory factory) {
         m_factory = Objects.requireNonNull(factory);
+    }
+
+    /**
+     * Releases any clients the factory is holding on to. Called by the blueprint
+     * container when the bundle stops.
+     */
+    public void destroy() {
+        if (m_factory instanceof AutoCloseable) {
+            try {
+                ((AutoCloseable) m_factory).close();
+            } catch (Exception e) {
+                LOG.debug("Error closing WS-Man client factory", e);
+            }
+        }
     }
 }

--- a/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsManDetector.java
+++ b/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsManDetector.java
@@ -77,10 +77,9 @@ public class WsManDetector extends SyncAbstractDetector {
 
     public DetectResults isServiceDetected(InetAddress address, WSManEndpoint endpoint) {
         // Issue the "Identify" request
-        final WSManClient client = m_factory.getClient(endpoint);
         Identity identity = null;
         final Map<String, String> attributes = new HashMap<>();
-        try {
+        try (WSManClient client = m_factory.getClient(endpoint)) {
             identity = client.identify();
             LOG.info("Identify succeeded for address {} with product vendor '{}' and product version '{}'.", address, identity.getProductVendor(), identity.getProductVersion());
             attributes.put(UPDATE_ASSETS, Boolean.toString(m_updateAssets));

--- a/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsManDetectorFactory.java
+++ b/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsManDetectorFactory.java
@@ -109,4 +109,18 @@ public class WsManDetectorFactory extends GenericServiceDetectorFactory<WsManDet
             return null;
         });
     }
+
+    /**
+     * Releases any clients the factory is holding on to. Called by the blueprint
+     * container when the bundle stops.
+     */
+    public void destroy() {
+        if (m_factory instanceof AutoCloseable) {
+            try {
+                ((AutoCloseable) m_factory).close();
+            } catch (Exception e) {
+                LOG.debug("Error closing WS-Man client factory", e);
+            }
+        }
+    }
 }

--- a/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsManDetectorFactory.java
+++ b/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsManDetectorFactory.java
@@ -25,7 +25,7 @@ import java.net.InetAddress;
 import java.util.Map;
 
 import org.opennms.core.wsman.WSManClientFactory;
-import org.opennms.core.wsman.cxf.CXFWSManClientFactory;
+import org.opennms.core.wsman.utils.CachingWSManClientFactory;
 import org.opennms.netmgt.dao.WSManConfigDao;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.dao.api.SessionUtils;
@@ -43,7 +43,7 @@ import org.springframework.stereotype.Component;
 public class WsManDetectorFactory extends GenericServiceDetectorFactory<WsManDetector> {
     private static final Logger LOG = LoggerFactory.getLogger(WsManDetectorFactory.class);
 
-    private final WSManClientFactory m_factory = new CXFWSManClientFactory();
+    private final WSManClientFactory m_factory = new CachingWSManClientFactory();
 
     @Autowired
     private WSManConfigDao m_wsmanConfigDao;

--- a/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsManShellDetector.java
+++ b/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsManShellDetector.java
@@ -88,7 +88,9 @@ public class WsManShellDetector extends SyncAbstractDetector {
             throw new IllegalArgumentException("'command' is required.");
         }
         final String[] arguments = ShellCommandUtils.toArguments(args);
-        try (WSManClient client = m_factory.getClient(endpoint)) {
+        // No single exchange with the host may outlive the detector timeout
+        final WSManEndpoint boundedEndpoint = WsmanEndpointUtils.withTimeouts(endpoint, getTimeout());
+        try (WSManClient client = m_factory.getClient(boundedEndpoint)) {
             LOG.debug("Running '{}' with arguments {} on {}", command, arguments, address);
             final CommandResult result = client.runCommand(command, arguments, Duration.ofMillis(getTimeout()),
                     ShellCommandUtils.buildShellOptions(noProfile, codepage, workingDirectory));

--- a/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsManShellDetector.java
+++ b/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsManShellDetector.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.provision.detector.wsman;
+
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.time.Duration;
+import java.util.Optional;
+
+import org.opennms.core.wsman.WSManClient;
+import org.opennms.core.wsman.WSManClientFactory;
+import org.opennms.core.wsman.WSManEndpoint;
+import org.opennms.core.wsman.exceptions.WSManException;
+import org.opennms.core.wsman.shell.CommandResult;
+import org.opennms.core.wsman.utils.ShellCommandUtils;
+import org.opennms.netmgt.provision.DetectRequest;
+import org.opennms.netmgt.provision.DetectResults;
+import org.opennms.netmgt.provision.support.DetectResultsImpl;
+import org.opennms.netmgt.provision.support.SyncAbstractDetector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Detects a service by running a command on the remote host through WinRS
+ * (MS-WSMV) and checking its output and, optionally, its exit code.
+ *
+ * @author dino2gnt
+ */
+public class WsManShellDetector extends SyncAbstractDetector {
+    public static final Logger LOG = LoggerFactory.getLogger(WsManShellDetector.class);
+
+    private static final String PROTOCOL_NAME = "WsManShell";
+
+    private String command;
+    private String args;
+    private String banner;
+    private String exitCode = ShellCommandUtils.EXIT_CODE_ANY;
+    private boolean noProfile = true;
+    private Integer codepage;
+    private String workingDirectory;
+
+    private WSManClientFactory m_factory;
+
+    public WsManShellDetector() {
+        super(PROTOCOL_NAME, 0);
+    }
+
+    public WsManShellDetector(final String serviceName) {
+        super(serviceName, 0);
+    }
+
+    @Override
+    public DetectResults detect(DetectRequest request) {
+        try {
+            final WSManEndpoint endpoint = WsmanEndpointUtils.fromMap(request.getRuntimeAttributes());
+            return isServiceDetected(request.getAddress(), endpoint);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public boolean isServiceDetected(InetAddress address) {
+        throw new UnsupportedOperationException("WSManEndpoint is required.");
+    }
+
+    public DetectResults isServiceDetected(InetAddress address, WSManEndpoint endpoint) {
+        if (command == null || command.trim().isEmpty()) {
+            throw new IllegalArgumentException("'command' is required.");
+        }
+        final String[] arguments = ShellCommandUtils.toArguments(args);
+        try (WSManClient client = m_factory.getClient(endpoint)) {
+            LOG.debug("Running '{}' with arguments {} on {}", command, arguments, address);
+            final CommandResult result = client.runCommand(command, arguments, Duration.ofMillis(getTimeout()),
+                    ShellCommandUtils.buildShellOptions(noProfile, codepage, workingDirectory));
+            LOG.debug("Command '{}' on {} exited with {}: stdout='{}' stderr='{}'", command, address, result.exitCode(),
+                    ShellCommandUtils.excerpt(result.stdout()), ShellCommandUtils.excerpt(result.stderr()));
+
+            final Optional<String> failure = ShellCommandUtils.checkResult(result, exitCode, banner);
+            if (failure.isPresent()) {
+                LOG.debug("Service not detected on {}: {}", address, failure.get());
+            }
+            return new DetectResultsImpl(!failure.isPresent());
+        } catch (WSManException e) {
+            LOG.debug("Running '{}' failed for address '{}' with endpoint '{}'", command, address, endpoint, e);
+            return new DetectResultsImpl(false);
+        }
+    }
+
+    public void setClientFactory(WSManClientFactory factory) {
+        m_factory = factory;
+    }
+
+    public String getCommand() {
+        return command;
+    }
+
+    public void setCommand(String command) {
+        this.command = command;
+    }
+
+    public String getArgs() {
+        return args;
+    }
+
+    public void setArgs(String args) {
+        this.args = args;
+    }
+
+    public String getBanner() {
+        return banner;
+    }
+
+    public void setBanner(String banner) {
+        this.banner = banner;
+    }
+
+    public String getExitCode() {
+        return exitCode;
+    }
+
+    public void setExitCode(String exitCode) {
+        this.exitCode = exitCode;
+    }
+
+    public boolean isNoProfile() {
+        return noProfile;
+    }
+
+    public void setNoProfile(boolean noProfile) {
+        this.noProfile = noProfile;
+    }
+
+    public Integer getCodepage() {
+        return codepage;
+    }
+
+    public void setCodepage(Integer codepage) {
+        this.codepage = codepage;
+    }
+
+    public String getWorkingDirectory() {
+        return workingDirectory;
+    }
+
+    public void setWorkingDirectory(String workingDirectory) {
+        this.workingDirectory = workingDirectory;
+    }
+
+    @Override
+    protected void onInit() {
+        // pass
+    }
+
+    @Override
+    public void dispose() {
+        // pass
+    }
+}

--- a/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsManShellDetectorFactory.java
+++ b/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsManShellDetectorFactory.java
@@ -31,11 +31,14 @@ import org.opennms.netmgt.dao.WSManConfigDao;
 import org.opennms.netmgt.provision.DetectRequest;
 import org.opennms.netmgt.provision.support.DetectRequestImpl;
 import org.opennms.netmgt.provision.support.GenericServiceDetectorFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class WsManShellDetectorFactory extends GenericServiceDetectorFactory<WsManShellDetector> {
+    private static final Logger LOG = LoggerFactory.getLogger(WsManShellDetectorFactory.class);
 
     private final WSManClientFactory m_factory;
 
@@ -62,5 +65,19 @@ public class WsManShellDetectorFactory extends GenericServiceDetectorFactory<WsM
     @Override
     public DetectRequest buildRequest(String location, InetAddress address, Integer port, Map<String, String> attributes) {
         return new DetectRequestImpl(address, port, WsmanEndpointUtils.toMap(m_wsmanConfigDao.getEndpoint(address)));
+    }
+
+    /**
+     * Releases any clients the factory is holding on to. Called by the blueprint
+     * container when the bundle stops.
+     */
+    public void destroy() {
+        if (m_factory instanceof AutoCloseable) {
+            try {
+                ((AutoCloseable) m_factory).close();
+            } catch (Exception e) {
+                LOG.debug("Error closing WS-Man client factory", e);
+            }
+        }
     }
 }

--- a/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsManShellDetectorFactory.java
+++ b/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsManShellDetectorFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.provision.detector.wsman;
+
+import java.net.InetAddress;
+import java.util.Map;
+import java.util.Objects;
+
+import org.opennms.core.wsman.WSManClientFactory;
+import org.opennms.core.wsman.utils.CachingWSManClientFactory;
+import org.opennms.netmgt.dao.WSManConfigDao;
+import org.opennms.netmgt.provision.DetectRequest;
+import org.opennms.netmgt.provision.support.DetectRequestImpl;
+import org.opennms.netmgt.provision.support.GenericServiceDetectorFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WsManShellDetectorFactory extends GenericServiceDetectorFactory<WsManShellDetector> {
+
+    private final WSManClientFactory m_factory;
+
+    @Autowired
+    private WSManConfigDao m_wsmanConfigDao;
+
+    public WsManShellDetectorFactory() {
+        this(new CachingWSManClientFactory());
+    }
+
+    public WsManShellDetectorFactory(WSManClientFactory clientFactory) {
+        super(WsManShellDetector.class);
+        m_factory = Objects.requireNonNull(clientFactory);
+    }
+
+    @Override
+    public WsManShellDetector createDetector(Map<String, String> properties) {
+        final WsManShellDetector detector = new WsManShellDetector();
+        setBeanProperties(detector, properties);
+        detector.setClientFactory(m_factory);
+        return detector;
+    }
+
+    @Override
+    public DetectRequest buildRequest(String location, InetAddress address, Integer port, Map<String, String> attributes) {
+        return new DetectRequestImpl(address, port, WsmanEndpointUtils.toMap(m_wsmanConfigDao.getEndpoint(address)));
+    }
+}

--- a/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsManWQLDetector.java
+++ b/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsManWQLDetector.java
@@ -82,8 +82,7 @@ public class WsManWQLDetector extends SyncAbstractDetector {
 
         // Issue the query!
         List<Node> nodes = Lists.newLinkedList();
-        final WSManClient client = m_factory.getClient(endpoint);
-        try {
+        try (WSManClient client = m_factory.getClient(endpoint)) {
             LOG.debug("Issuing an ENUM on '{}' with query '{}'", resourceUri, wql);
             client.enumerateAndPullUsingFilter(resourceUri, WSManConstants.XML_NS_WQL_DIALECT, wql, nodes, true);
         } catch (WSManException e) {

--- a/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsManWQLDetectorFactory.java
+++ b/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsManWQLDetectorFactory.java
@@ -25,7 +25,7 @@ import java.net.InetAddress;
 import java.util.Map;
 
 import org.opennms.core.wsman.WSManClientFactory;
-import org.opennms.core.wsman.cxf.CXFWSManClientFactory;
+import org.opennms.core.wsman.utils.CachingWSManClientFactory;
 import org.opennms.netmgt.dao.WSManConfigDao;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.provision.DetectRequest;
@@ -40,7 +40,7 @@ import org.springframework.stereotype.Component;
 public class WsManWQLDetectorFactory extends GenericServiceDetectorFactory<WsManWQLDetector> {
     private static final Logger LOG = LoggerFactory.getLogger(WsManWQLDetectorFactory.class);
 
-    private final WSManClientFactory m_factory = new CXFWSManClientFactory();
+    private final WSManClientFactory m_factory = new CachingWSManClientFactory();
 
     @Autowired
     private WSManConfigDao m_wsmanConfigDao;

--- a/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsManWQLDetectorFactory.java
+++ b/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsManWQLDetectorFactory.java
@@ -64,4 +64,18 @@ public class WsManWQLDetectorFactory extends GenericServiceDetectorFactory<WsMan
     public DetectRequest buildRequest(String location, InetAddress address, Integer port, Map<String, String> attributes) {
         return new DetectRequestImpl(address, port, WsmanEndpointUtils.toMap(m_wsmanConfigDao.getEndpoint(address)));
     }
+
+    /**
+     * Releases any clients the factory is holding on to. Called by the blueprint
+     * container when the bundle stops.
+     */
+    public void destroy() {
+        if (m_factory instanceof AutoCloseable) {
+            try {
+                ((AutoCloseable) m_factory).close();
+            } catch (Exception e) {
+                LOG.debug("Error closing WS-Man client factory", e);
+            }
+        }
+    }
 }

--- a/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsmanEndpointUtils.java
+++ b/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsmanEndpointUtils.java
@@ -96,4 +96,21 @@ public class WsmanEndpointUtils {
         return builder.build();
     }
 
+    /**
+     * Returns a copy of the endpoint whose HTTP connection and receive timeouts are both
+     * set to the given value, so that no single exchange with the host outlives the
+     * caller's own time budget.
+     */
+    public static WSManEndpoint withTimeouts(WSManEndpoint endpoint, int timeoutMillis) {
+        final Map<String, String> attributes = toMap(endpoint);
+        attributes.put(CONNECTION_TIMEOUT, Integer.toString(timeoutMillis));
+        attributes.put(RECEIVE_TIMEOUT, Integer.toString(timeoutMillis));
+        try {
+            return fromMap(attributes);
+        } catch (MalformedURLException e) {
+            // The URL came from a valid endpoint
+            throw new IllegalStateException(e);
+        }
+    }
+
 }

--- a/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsmanEndpointUtils.java
+++ b/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsmanEndpointUtils.java
@@ -33,6 +33,7 @@ public class WsmanEndpointUtils {
     private static final String URL = "url";
     private static final String SERVER_VERSION = "server-version";
     private static final String GSS_AUTH = "gss-auth";
+    private static final String KERBEROS_ENCRYPTION = "kerberos-encryption";
     private static final String STRICT_SSL = "strict-ssl";
     private static final String USERNAME = "username";
     private static final String PASSWORD = "password";
@@ -46,6 +47,7 @@ public class WsmanEndpointUtils {
         attributes.put(URL, endpoint.getUrl().toString());
         attributes.put(SERVER_VERSION, endpoint.getServerVersion().toString());
         attributes.put(GSS_AUTH, Boolean.toString(endpoint.isGSSAuth()));
+        attributes.put(KERBEROS_ENCRYPTION, Boolean.toString(endpoint.isKerberosEncryption()));
         attributes.put(STRICT_SSL, Boolean.toString(endpoint.isStrictSSL()));
         if (endpoint.isBasicAuth()) {
             attributes.put(USERNAME, endpoint.getUsername());
@@ -71,6 +73,9 @@ public class WsmanEndpointUtils {
         builder.withServerVersion(WSManVersion.valueOf(attributes.get(SERVER_VERSION)));
         if (Boolean.parseBoolean(attributes.get(GSS_AUTH))) {
             builder.withGSSAuth();
+        }
+        if (Boolean.parseBoolean(attributes.get(KERBEROS_ENCRYPTION))) {
+            builder.withKerberosEncryption();
         }
         builder.withStrictSSL(Boolean.parseBoolean(attributes.get(STRICT_SSL)));
         if (attributes.containsKey(USERNAME)) {

--- a/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsmanEndpointUtils.java
+++ b/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsmanEndpointUtils.java
@@ -49,7 +49,10 @@ public class WsmanEndpointUtils {
         attributes.put(GSS_AUTH, Boolean.toString(endpoint.isGSSAuth()));
         attributes.put(KERBEROS_ENCRYPTION, Boolean.toString(endpoint.isKerberosEncryption()));
         attributes.put(STRICT_SSL, Boolean.toString(endpoint.isStrictSSL()));
-        if (endpoint.isBasicAuth()) {
+        // Credentials are carried whenever they are set, not only for basic authentication:
+        // with gss-auth or kerberos-encryption they are the Kerberos principal and password
+        // used to obtain the ticket, and isBasicAuth() is false in that case.
+        if (endpoint.getUsername() != null && endpoint.getPassword() != null) {
             attributes.put(USERNAME, endpoint.getUsername());
             attributes.put(PASSWORD, endpoint.getPassword());
         }

--- a/features/wsman/src/main/resources/META-INF/services/org.opennms.netmgt.poller.ServiceMonitor
+++ b/features/wsman/src/main/resources/META-INF/services/org.opennms.netmgt.poller.ServiceMonitor
@@ -1,1 +1,2 @@
 org.opennms.netmgt.poller.monitors.WsManMonitor
+org.opennms.netmgt.poller.monitors.WsManShellMonitor

--- a/features/wsman/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/wsman/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -9,17 +9,16 @@
 		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.5.xsd
 ">
 
-	<service interface="org.opennms.netmgt.provision.ServiceDetectorFactory">
-		<bean class="org.opennms.netmgt.provision.detector.wsman.WsManDetectorFactory" destroy-method="destroy" />
-	</service>
+	<!-- Detector factories are top-level beans rather than inlined in their <service> elements:
+	     the Blueprint schema does not allow destroy-method on inlined beans -->
+	<bean id="wsmanDetectorFactory" class="org.opennms.netmgt.provision.detector.wsman.WsManDetectorFactory" destroy-method="destroy" />
+	<service ref="wsmanDetectorFactory" interface="org.opennms.netmgt.provision.ServiceDetectorFactory" />
 
-	<service interface="org.opennms.netmgt.provision.ServiceDetectorFactory">
-		<bean class="org.opennms.netmgt.provision.detector.wsman.WsManWQLDetectorFactory" destroy-method="destroy" />
-	</service>
+	<bean id="wsmanWqlDetectorFactory" class="org.opennms.netmgt.provision.detector.wsman.WsManWQLDetectorFactory" destroy-method="destroy" />
+	<service ref="wsmanWqlDetectorFactory" interface="org.opennms.netmgt.provision.ServiceDetectorFactory" />
 
-	<service interface="org.opennms.netmgt.provision.ServiceDetectorFactory">
-		<bean class="org.opennms.netmgt.provision.detector.wsman.WsManShellDetectorFactory" destroy-method="destroy" />
-	</service>
+	<bean id="wsmanShellDetectorFactory" class="org.opennms.netmgt.provision.detector.wsman.WsManShellDetectorFactory" destroy-method="destroy" />
+	<service ref="wsmanShellDetectorFactory" interface="org.opennms.netmgt.provision.ServiceDetectorFactory" />
 
 	<bean id="wsmanCollector" class="org.opennms.netmgt.collectd.WsManCollector" destroy-method="destroy" />
 	<service ref="wsmanCollector" interface="org.opennms.netmgt.collection.api.ServiceCollector">

--- a/features/wsman/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/wsman/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -10,32 +10,32 @@
 ">
 
 	<service interface="org.opennms.netmgt.provision.ServiceDetectorFactory">
-		<bean class="org.opennms.netmgt.provision.detector.wsman.WsManDetectorFactory" />
+		<bean class="org.opennms.netmgt.provision.detector.wsman.WsManDetectorFactory" destroy-method="destroy" />
 	</service>
 
 	<service interface="org.opennms.netmgt.provision.ServiceDetectorFactory">
-		<bean class="org.opennms.netmgt.provision.detector.wsman.WsManWQLDetectorFactory" />
+		<bean class="org.opennms.netmgt.provision.detector.wsman.WsManWQLDetectorFactory" destroy-method="destroy" />
 	</service>
 
 	<service interface="org.opennms.netmgt.provision.ServiceDetectorFactory">
-		<bean class="org.opennms.netmgt.provision.detector.wsman.WsManShellDetectorFactory" />
+		<bean class="org.opennms.netmgt.provision.detector.wsman.WsManShellDetectorFactory" destroy-method="destroy" />
 	</service>
 
-	<bean id="wsmanCollector" class="org.opennms.netmgt.collectd.WsManCollector" />
+	<bean id="wsmanCollector" class="org.opennms.netmgt.collectd.WsManCollector" destroy-method="destroy" />
 	<service ref="wsmanCollector" interface="org.opennms.netmgt.collection.api.ServiceCollector">
 		<service-properties>
 			<entry key="type" value="org.opennms.netmgt.collectd.WsManCollector" />
 		</service-properties>
 	</service>
 
-	<bean id="wsmanMonitor" class="org.opennms.netmgt.poller.monitors.WsManMonitor" />
+	<bean id="wsmanMonitor" class="org.opennms.netmgt.poller.monitors.WsManMonitor" destroy-method="destroy" />
 	<service ref="wsmanMonitor" interface="org.opennms.netmgt.poller.ServiceMonitor">
 		<service-properties>
 			<entry key="type" value="org.opennms.netmgt.poller.monitors.WsManMonitor" />
 		</service-properties>
 	</service>
 
-	<bean id="wsmanShellMonitor" class="org.opennms.netmgt.poller.monitors.WsManShellMonitor" />
+	<bean id="wsmanShellMonitor" class="org.opennms.netmgt.poller.monitors.WsManShellMonitor" destroy-method="destroy" />
 	<service ref="wsmanShellMonitor" interface="org.opennms.netmgt.poller.ServiceMonitor">
 		<service-properties>
 			<entry key="type" value="org.opennms.netmgt.poller.monitors.WsManShellMonitor" />

--- a/features/wsman/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/wsman/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -17,6 +17,10 @@
 		<bean class="org.opennms.netmgt.provision.detector.wsman.WsManWQLDetectorFactory" />
 	</service>
 
+	<service interface="org.opennms.netmgt.provision.ServiceDetectorFactory">
+		<bean class="org.opennms.netmgt.provision.detector.wsman.WsManShellDetectorFactory" />
+	</service>
+
 	<bean id="wsmanCollector" class="org.opennms.netmgt.collectd.WsManCollector" />
 	<service ref="wsmanCollector" interface="org.opennms.netmgt.collection.api.ServiceCollector">
 		<service-properties>
@@ -28,6 +32,13 @@
 	<service ref="wsmanMonitor" interface="org.opennms.netmgt.poller.ServiceMonitor">
 		<service-properties>
 			<entry key="type" value="org.opennms.netmgt.poller.monitors.WsManMonitor" />
+		</service-properties>
+	</service>
+
+	<bean id="wsmanShellMonitor" class="org.opennms.netmgt.poller.monitors.WsManShellMonitor" />
+	<service ref="wsmanShellMonitor" interface="org.opennms.netmgt.poller.ServiceMonitor">
+		<service-properties>
+			<entry key="type" value="org.opennms.netmgt.poller.monitors.WsManShellMonitor" />
 		</service-properties>
 	</service>
 

--- a/features/wsman/src/main/resources/xsds/wsman-config.xsd
+++ b/features/wsman/src/main/resources/xsds/wsman-config.xsd
@@ -94,6 +94,12 @@
           <documentation>Enables GSS (HTTP Negotiate) authentication.</documentation>
         </annotation>
       </attribute>
+      <attribute name="kerberos-encryption" type="boolean" use="optional">
+        <annotation>
+          <documentation>Enables Kerberos message encryption (MS-WSMV 2.2.9.1), which protects the SOAP payload itself and
+          allows WS-Man over plain HTTP. Implies gss-auth.</documentation>
+        </annotation>
+      </attribute>
     </complexType>
   </element>
   <element name="definition">
@@ -135,6 +141,7 @@
       <attribute name="product-vendor" type="string" use="optional"/>
       <attribute name="product-version" type="string" use="optional"/>
       <attribute name="gss-auth" type="boolean" use="optional" />
+      <attribute name="kerberos-encryption" type="boolean" use="optional" />
     </complexType>
   </element>
   <element name="ip-match">

--- a/features/wsman/src/test/java/org/opennms/core/wsman/utils/CachingWSManClientFactoryTest.java
+++ b/features/wsman/src/test/java/org/opennms/core/wsman/utils/CachingWSManClientFactoryTest.java
@@ -22,6 +22,7 @@
 package org.opennms.core.wsman.utils;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -34,6 +35,17 @@ import static org.mockito.Mockito.when;
 
 import java.net.MalformedURLException;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
 import org.opennms.core.wsman.WSManClient;
@@ -117,6 +129,80 @@ public class CachingWSManClientFactoryTest {
 
         verify(delegate, times(5)).getClient(any());
         assertEquals(5, factory.size());
+    }
+
+    @Test
+    public void sharesOneClientPerEndpointUnderConcurrentLoad() throws Exception {
+        final int endpoints = 4;
+        final int threads = 32;
+        final int iterations = 250;
+
+        // Count real client creations and make each one slow enough to expose races in the loader
+        final AtomicInteger created = new AtomicInteger();
+        WSManClientFactory delegate = endpoint -> {
+            created.incrementAndGet();
+            try {
+                Thread.sleep(20);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return mock(WSManClient.class);
+        };
+        CachingWSManClientFactory factory = new CachingWSManClientFactory(delegate);
+
+        final List<WSManEndpoint> kerberos = new ArrayList<>();
+        for (int i = 0; i < endpoints; i++) {
+            kerberos.add(new WSManEndpoint.Builder("http://host" + i + ".example.org:5985/wsman").withKerberosEncryption().build());
+        }
+        final WSManEndpoint plain = new WSManEndpoint.Builder("http://plain.example.org:5985/wsman").withBasicAuth("u", "p").build();
+
+        // Every handle observed per endpoint must wrap the same delegate instance
+        final Map<Integer, Set<WSManClient>> delegatesSeen = new ConcurrentHashMap<>();
+        final AtomicInteger plainClients = new AtomicInteger();
+        final ExecutorService pool = Executors.newFixedThreadPool(threads);
+        final CountDownLatch start = new CountDownLatch(1);
+        final List<Future<?>> futures = new ArrayList<>();
+        for (int t = 0; t < threads; t++) {
+            final int seed = t;
+            futures.add(pool.submit(() -> {
+                start.await();
+                for (int i = 0; i < iterations; i++) {
+                    if ((seed + i) % 5 == 0) {
+                        try (WSManClient c = factory.getClient(plain)) {
+                            assertFalse(c instanceof SharedClient);
+                            plainClients.incrementAndGet();
+                        }
+                    } else {
+                        final int idx = (seed + i) % endpoints;
+                        try (WSManClient c = factory.getClient(kerberos.get(idx))) {
+                            assertTrue(c instanceof SharedClient);
+                            delegatesSeen.computeIfAbsent(idx, k -> ConcurrentHashMap.newKeySet()).add(((SharedClient) c).getDelegate());
+                            c.identify();
+                        }
+                    }
+                }
+                return null;
+            }));
+        }
+        start.countDown();
+        for (Future<?> f : futures) {
+            f.get(30, TimeUnit.SECONDS);
+        }
+        pool.shutdown();
+
+        // Exactly one real client per Kerberos endpoint, plus one per plain request
+        assertEquals(endpoints + plainClients.get(), created.get());
+        assertEquals(endpoints, factory.size());
+        for (int i = 0; i < endpoints; i++) {
+            assertEquals("endpoint " + i + " must map to a single shared client", 1, delegatesSeen.get(i).size());
+            verify(delegatesSeen.get(i).iterator().next(), never()).close();
+        }
+
+        // And closing the factory releases each of them exactly once
+        factory.close();
+        for (int i = 0; i < endpoints; i++) {
+            verify(delegatesSeen.get(i).iterator().next(), times(1)).close();
+        }
     }
 
     @Test

--- a/features/wsman/src/test/java/org/opennms/core/wsman/utils/CachingWSManClientFactoryTest.java
+++ b/features/wsman/src/test/java/org/opennms/core/wsman/utils/CachingWSManClientFactoryTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.core.wsman.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.MalformedURLException;
+import java.time.Duration;
+
+import org.junit.Test;
+import org.opennms.core.wsman.WSManClient;
+import org.opennms.core.wsman.WSManClientFactory;
+import org.opennms.core.wsman.WSManEndpoint;
+import org.opennms.core.wsman.utils.CachingWSManClientFactory.SharedClient;
+
+public class CachingWSManClientFactoryTest {
+
+    @Test
+    public void passesThroughEndpointsWithoutKerberosEncryption() throws MalformedURLException {
+        WSManClientFactory delegate = mock(WSManClientFactory.class);
+        WSManClient first = mock(WSManClient.class);
+        WSManClient second = mock(WSManClient.class);
+        when(delegate.getClient(any())).thenReturn(first, second);
+        CachingWSManClientFactory factory = new CachingWSManClientFactory(delegate);
+
+        WSManEndpoint endpoint = new WSManEndpoint.Builder("http://win.example.org:5985/wsman")
+                .withBasicAuth("user", "pass")
+                .build();
+
+        // A fresh client every time, handed back unwrapped
+        assertSame(first, factory.getClient(endpoint));
+        assertSame(second, factory.getClient(endpoint));
+        assertEquals(0, factory.size());
+    }
+
+    @Test
+    public void sharesClientsForKerberosEncryptedEndpoints() throws Exception {
+        WSManClientFactory delegate = mock(WSManClientFactory.class);
+        WSManClient shared = mock(WSManClient.class);
+        when(delegate.getClient(any())).thenReturn(shared);
+        CachingWSManClientFactory factory = new CachingWSManClientFactory(delegate);
+
+        WSManEndpoint endpoint = new WSManEndpoint.Builder("http://win.example.org:5985/wsman")
+                .withKerberosEncryption()
+                .build();
+        // An equal endpoint built separately must hit the same cache entry
+        WSManEndpoint sameEndpoint = new WSManEndpoint.Builder("http://win.example.org:5985/wsman")
+                .withKerberosEncryption()
+                .build();
+
+        WSManClient a = factory.getClient(endpoint);
+        WSManClient b = factory.getClient(sameEndpoint);
+        assertTrue(a instanceof SharedClient);
+        assertNotSame(a, b);
+        assertSame(shared, ((SharedClient) a).getDelegate());
+        assertSame(shared, ((SharedClient) b).getDelegate());
+        verify(delegate, times(1)).getClient(any());
+        assertEquals(1, factory.size());
+
+        // Closing the handle must not close the shared client
+        a.close();
+        b.close();
+        verify(shared, never()).close();
+
+        // Operations go to the shared client
+        a.identify();
+        verify(shared, times(1)).identify();
+
+        // Closing the factory releases it
+        factory.close();
+        verify(shared, times(1)).close();
+        assertEquals(0, factory.size());
+    }
+
+    @Test
+    public void distinguishesEndpointsByEveryField() throws Exception {
+        WSManClientFactory delegate = mock(WSManClientFactory.class);
+        when(delegate.getClient(any())).thenAnswer(inv -> mock(WSManClient.class));
+        CachingWSManClientFactory factory = new CachingWSManClientFactory(delegate);
+
+        factory.getClient(new WSManEndpoint.Builder("http://a.example.org:5985/wsman").withKerberosEncryption().build());
+        factory.getClient(new WSManEndpoint.Builder("http://b.example.org:5985/wsman").withKerberosEncryption().build());
+        factory.getClient(new WSManEndpoint.Builder("http://a.example.org:5985/wsman").withKerberosEncryption()
+                .withBasicAuth("svc", "secret").build());
+        factory.getClient(new WSManEndpoint.Builder("http://a.example.org:5985/wsman").withKerberosEncryption()
+                .withBasicAuth("svc", "other").build());
+        factory.getClient(new WSManEndpoint.Builder("http://a.example.org:5985/wsman").withKerberosEncryption()
+                .withConnectionTimeout(5000).build());
+
+        verify(delegate, times(5)).getClient(any());
+        assertEquals(5, factory.size());
+    }
+
+    @Test
+    public void expiresIdleClients() throws Exception {
+        WSManClientFactory delegate = mock(WSManClientFactory.class);
+        WSManClient shared = mock(WSManClient.class);
+        when(delegate.getClient(any())).thenReturn(shared);
+        CachingWSManClientFactory factory = new CachingWSManClientFactory(delegate, Duration.ofMillis(50));
+
+        WSManEndpoint endpoint = new WSManEndpoint.Builder("http://win.example.org:5985/wsman")
+                .withKerberosEncryption()
+                .build();
+        factory.getClient(endpoint);
+        assertEquals(1, factory.size());
+
+        Thread.sleep(200);
+        assertEquals(0, factory.size());
+        verify(shared, times(1)).close();
+    }
+}

--- a/features/wsman/src/test/java/org/opennms/core/wsman/utils/ShellCommandUtilsTest.java
+++ b/features/wsman/src/test/java/org/opennms/core/wsman/utils/ShellCommandUtilsTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.core.wsman.utils;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Optional;
+import java.util.regex.PatternSyntaxException;
+
+import org.junit.Test;
+import org.opennms.core.wsman.shell.CommandResult;
+import org.opennms.core.wsman.shell.ShellOptions;
+
+public class ShellCommandUtilsTest {
+
+    @Test
+    public void passesArgumentsThroughVerbatim() {
+        assertArrayEquals(new String[0], ShellCommandUtils.toArguments(null));
+        assertArrayEquals(new String[0], ShellCommandUtils.toArguments("   "));
+        assertArrayEquals(new String[] {"/all"}, ShellCommandUtils.toArguments("/all"));
+        assertArrayEquals(new String[] {"query   w32time"}, ShellCommandUtils.toArguments("  query   w32time "));
+        // Quotes and backslashes are left for the Windows host to interpret
+        assertArrayEquals(new String[] {"\"C:\\Program Files\" /s"}, ShellCommandUtils.toArguments("\"C:\\Program Files\" /s"));
+        assertArrayEquals(new String[] {"-Command \"Write-Host 'hi there'\""},
+                ShellCommandUtils.toArguments("-Command \"Write-Host 'hi there'\""));
+    }
+
+    @Test
+    public void matchesBanners() {
+        final String output = "SERVICE_NAME: w32time\r\n        STATE              : 4  RUNNING\r\n";
+        // Anything
+        assertTrue(ShellCommandUtils.bannerMatches(null, output));
+        assertTrue(ShellCommandUtils.bannerMatches("", output));
+        assertTrue(ShellCommandUtils.bannerMatches("*", output));
+        assertTrue(ShellCommandUtils.bannerMatches("*", null));
+        // Substring
+        assertTrue(ShellCommandUtils.bannerMatches("RUNNING", output));
+        assertFalse(ShellCommandUtils.bannerMatches("STOPPED", output));
+        assertFalse(ShellCommandUtils.bannerMatches("RUNNING", null));
+        // Regex, whole output, dot spans lines
+        assertTrue(ShellCommandUtils.bannerMatches("~.*STATE\\s*:\\s*4\\s+RUNNING.*", output));
+        assertFalse(ShellCommandUtils.bannerMatches("~.*STOPPED.*", output));
+        // Regex is anchored to the whole output
+        assertFalse(ShellCommandUtils.bannerMatches("~RUNNING", output));
+    }
+
+    @Test(expected = PatternSyntaxException.class)
+    public void rejectsInvalidRegexBanner() {
+        ShellCommandUtils.bannerMatches("~(unclosed", "x");
+    }
+
+    @Test
+    public void matchesExitCodes() {
+        assertTrue(ShellCommandUtils.exitCodeMatches(null, 3));
+        assertTrue(ShellCommandUtils.exitCodeMatches("*", 3));
+        assertTrue(ShellCommandUtils.exitCodeMatches("0", 0));
+        assertTrue(ShellCommandUtils.exitCodeMatches(" 1 ", 1));
+        assertFalse(ShellCommandUtils.exitCodeMatches("0", 1));
+    }
+
+    @Test
+    public void checksResults() {
+        assertEquals(Optional.empty(), ShellCommandUtils.checkResult(new CommandResult(0, "ok", ""), "0", "ok"));
+        assertEquals(Optional.empty(), ShellCommandUtils.checkResult(new CommandResult(7, "ok", ""), "*", null));
+
+        final Optional<String> badExit = ShellCommandUtils.checkResult(new CommandResult(1, "", "boom"), "0", null);
+        assertTrue(badExit.isPresent());
+        assertTrue(badExit.get(), badExit.get().contains("exited with code 1"));
+        assertTrue(badExit.get(), badExit.get().contains("boom"));
+
+        final Optional<String> badBanner = ShellCommandUtils.checkResult(new CommandResult(0, "STOPPED", ""), "0", "RUNNING");
+        assertTrue(badBanner.isPresent());
+        assertTrue(badBanner.get(), badBanner.get().contains("RUNNING"));
+        assertTrue(badBanner.get(), badBanner.get().contains("STOPPED"));
+    }
+
+    @Test
+    public void buildsShellOptions() {
+        ShellOptions defaults = ShellCommandUtils.buildShellOptions(true, null, null);
+        assertTrue(defaults.isNoProfile());
+        assertEquals(65001, defaults.getCodepage());
+        assertEquals(null, defaults.getWorkingDirectory());
+
+        ShellOptions custom = ShellCommandUtils.buildShellOptions(false, 437, "C:\\Temp");
+        assertFalse(custom.isNoProfile());
+        assertEquals(437, custom.getCodepage());
+        assertEquals("C:\\Temp", custom.getWorkingDirectory());
+    }
+
+    @Test
+    public void truncatesExcerpts() {
+        assertEquals("", ShellCommandUtils.excerpt(null));
+        assertEquals("abc", ShellCommandUtils.excerpt("  abc \r\n"));
+        String excerpt = ShellCommandUtils.excerpt("x".repeat(ShellCommandUtils.MAX_EXCERPT + 10));
+        assertEquals(ShellCommandUtils.MAX_EXCERPT + 3, excerpt.length());
+        assertTrue(excerpt.endsWith("..."));
+    }
+}

--- a/features/wsman/src/test/java/org/opennms/netmgt/config/wsman/credentials/WsmanConfigTest.java
+++ b/features/wsman/src/test/java/org/opennms/netmgt/config/wsman/credentials/WsmanConfigTest.java
@@ -72,6 +72,13 @@ public class WsmanConfigTest extends XmlTestNoCastor<WsmanConfig> {
         definition.setProductVersion("OS: Vista");
         wsmanConfig.getDefinition().add(definition);
 
+        Definition kerberosDefinition = new Definition();
+        kerberosDefinition.setSsl(false);
+        kerberosDefinition.setPort(5985);
+        kerberosDefinition.setKerberosEncryption(true);
+        kerberosDefinition.getSpecific().add("172.23.1.3");
+        wsmanConfig.getDefinition().add(kerberosDefinition);
+
         return wsmanConfig;
     }
 }

--- a/features/wsman/src/test/java/org/opennms/netmgt/dao/jaxb/WSManConfigDaoJaxbTest.java
+++ b/features/wsman/src/test/java/org/opennms/netmgt/dao/jaxb/WSManConfigDaoJaxbTest.java
@@ -22,6 +22,8 @@
 package org.opennms.netmgt.dao.jaxb;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -33,10 +35,40 @@ import org.springframework.core.io.FileSystemResource;
 public class WSManConfigDaoJaxbTest {
     @Test
     public void canBuildEndpointForSpecific() throws UnknownHostException {
-        WSManConfigDaoJaxb configDao = new WSManConfigDaoJaxb();
-        configDao.setConfigResource(new FileSystemResource("src/test/resources/wsman-config.xml"));
-        configDao.afterPropertiesSet();
+        WSManConfigDaoJaxb configDao = load("src/test/resources/wsman-config.xml");
         WSManEndpoint endpoint = configDao.getEndpoint(InetAddress.getByName("172.23.1.2"));
         assertEquals("http://172.23.1.2:5985/ws-man", endpoint.getUrl().toString());
+        assertTrue(endpoint.isBasicAuth());
+        assertFalse(endpoint.isGSSAuth());
+        assertFalse(endpoint.isKerberosEncryption());
+    }
+
+    @Test
+    public void canBuildKerberosEncryptedEndpoint() throws UnknownHostException {
+        WSManConfigDaoJaxb configDao = load("src/test/resources/wsman-config-endpoints.xml");
+        WSManEndpoint endpoint = configDao.getEndpoint(InetAddress.getByName("127.0.0.1"));
+        assertTrue(endpoint.isKerberosEncryption());
+        // Kerberos encryption implies GSS authentication
+        assertTrue(endpoint.isGSSAuth());
+        assertFalse(endpoint.isBasicAuth());
+        // The canonical host name is used, as with gss-auth, so the URL must not contain the bare address
+        assertEquals("http", endpoint.getUrl().getProtocol());
+        assertEquals(5985, endpoint.getUrl().getPort());
+        assertEquals(InetAddress.getByName("127.0.0.1").getCanonicalHostName(), endpoint.getUrl().getHost());
+    }
+
+    @Test
+    public void gssAuthAloneDoesNotEnableKerberosEncryption() throws UnknownHostException {
+        WSManConfigDaoJaxb configDao = load("src/test/resources/wsman-config-endpoints.xml");
+        WSManEndpoint endpoint = configDao.getEndpoint(InetAddress.getByName("127.0.0.2"));
+        assertTrue(endpoint.isGSSAuth());
+        assertFalse(endpoint.isKerberosEncryption());
+    }
+
+    private static WSManConfigDaoJaxb load(String path) {
+        WSManConfigDaoJaxb configDao = new WSManConfigDaoJaxb();
+        configDao.setConfigResource(new FileSystemResource(path));
+        configDao.afterPropertiesSet();
+        return configDao;
     }
 }

--- a/features/wsman/src/test/java/org/opennms/netmgt/poller/monitors/WsManShellMonitorTest.java
+++ b/features/wsman/src/test/java/org/opennms/netmgt/poller/monitors/WsManShellMonitorTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -43,6 +44,7 @@ import org.opennms.core.mate.api.EmptyScope;
 import org.opennms.core.mate.api.Interpolator;
 import org.opennms.core.wsman.WSManClient;
 import org.opennms.core.wsman.WSManClientFactory;
+import org.opennms.core.wsman.WSManEndpoint;
 import org.opennms.core.wsman.exceptions.WSManException;
 import org.opennms.core.wsman.shell.CommandResult;
 import org.opennms.core.wsman.shell.ShellOptions;
@@ -61,6 +63,7 @@ public class WsManShellMonitorTest {
     private static final String SC_STOPPED = "\r\nSERVICE_NAME: w32time \r\n        STATE              : 1  STOPPED \r\n";
 
     private WSManClient client;
+    private WSManClientFactory clientFactory;
     private WsManShellMonitor monitor;
     private MonitoredService svc;
     private Definition agentConfig;
@@ -72,7 +75,7 @@ public class WsManShellMonitorTest {
         when(configDao.getAgentConfig(any())).thenReturn(agentConfig);
 
         client = mock(WSManClient.class);
-        WSManClientFactory clientFactory = mock(WSManClientFactory.class);
+        clientFactory = mock(WSManClientFactory.class);
         when(clientFactory.getClient(any())).thenReturn(client);
 
         monitor = new WsManShellMonitor();
@@ -166,14 +169,79 @@ public class WsManShellMonitorTest {
     }
 
     @Test
+    public void serviceRetryOverridesWsmanConfig() {
+        agentConfig.setRetry(2);
+        when(client.runCommand(eq("sc"), any(), any(), any())).thenThrow(new WSManException("down"));
+        poll(params("command", "sc", "retry", "0"));
+        verify(client, times(1)).runCommand(eq("sc"), any(), any(), any());
+    }
+
+    @Test
+    public void timeoutBoundsCommandAndEveryExchange() {
+        when(client.runCommand(any(), any(), any(), any())).thenReturn(new CommandResult(0, "", ""));
+
+        // Default
+        poll(params("command", "dir"));
+        assertTimeouts(WsManShellMonitor.DEFAULT_TIMEOUT);
+
+        // wsman-config.xml default applies when the service has none
+        agentConfig.setTimeout(7000);
+        poll(params("command", "dir"));
+        assertTimeouts(7000);
+
+        // The service definition wins over wsman-config.xml
+        poll(params("command", "dir", "timeout", "1500"));
+        assertTimeouts(1500);
+    }
+
+    private void assertTimeouts(int expectedMillis) {
+        ArgumentCaptor<WSManEndpoint> endpoint = ArgumentCaptor.forClass(WSManEndpoint.class);
+        verify(clientFactory, atLeastOnce()).getClient(endpoint.capture());
+        assertEquals(Integer.valueOf(expectedMillis), endpoint.getValue().getConnectionTimeout());
+        assertEquals(Integer.valueOf(expectedMillis), endpoint.getValue().getReceiveTimeout());
+
+        ArgumentCaptor<Duration> timeout = ArgumentCaptor.forClass(Duration.class);
+        verify(client, atLeastOnce()).runCommand(any(), any(), timeout.capture(), any());
+        assertEquals(Duration.ofMillis(expectedMillis), timeout.getValue());
+    }
+
+    @Test
+    public void doesNotSubstitutePlaceholdersIntoCommandOrArgs() {
+        when(client.runCommand(any(), any(), any(), any())).thenReturn(new CommandResult(0, "", ""));
+        poll(params("command", "{nodeLabel}", "args", "query {nodeLabel} {ipAddr}"));
+
+        ArgumentCaptor<String[]> args = ArgumentCaptor.forClass(String[].class);
+        verify(client).runCommand(eq("{nodeLabel}"), args.capture(), any(), any());
+        assertArrayEquals(new String[] {"query {nodeLabel} {ipAddr}"}, args.getValue());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsNonNumericCodepage() {
+        poll(params("command", "dir", "codepage", "utf8"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsNonPositiveCodepage() {
+        poll(params("command", "dir", "codepage", "0"));
+    }
+
+    @Test
+    public void isDownWhenClientCannotBeCreated() {
+        when(clientFactory.getClient(any())).thenThrow(new WSManException("no kerberos login"));
+        PollStatus status = poll(params("command", "dir"));
+        assertEquals(PollStatus.SERVICE_UNAVAILABLE, status.getStatusCode());
+        assertTrue(status.getReason(), status.getReason().contains("no kerberos login"));
+    }
+
+    @Test
     public void passesTimeoutAndShellOptions() {
         when(client.runCommand(any(), any(), any(), any())).thenReturn(new CommandResult(0, "", ""));
-        poll(params("command", "dir", "timeout", "5000", "no-profile", "false", "codepage", "437", "working-directory", "C:\\Temp"));
+        poll(params("command", "dir", "timeout", "2500", "no-profile", "false", "codepage", "437", "working-directory", "C:\\Temp"));
 
         ArgumentCaptor<Duration> timeout = ArgumentCaptor.forClass(Duration.class);
         ArgumentCaptor<ShellOptions> options = ArgumentCaptor.forClass(ShellOptions.class);
         verify(client).runCommand(eq("dir"), any(), timeout.capture(), options.capture());
-        assertEquals(Duration.ofMillis(5000), timeout.getValue());
+        assertEquals(Duration.ofMillis(2500), timeout.getValue());
         assertEquals(false, options.getValue().isNoProfile());
         assertEquals(437, options.getValue().getCodepage());
         assertEquals("C:\\Temp", options.getValue().getWorkingDirectory());

--- a/features/wsman/src/test/java/org/opennms/netmgt/poller/monitors/WsManShellMonitorTest.java
+++ b/features/wsman/src/test/java/org/opennms/netmgt/poller/monitors/WsManShellMonitorTest.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.poller.monitors;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.opennms.core.mate.api.EmptyScope;
+import org.opennms.core.mate.api.Interpolator;
+import org.opennms.core.wsman.WSManClient;
+import org.opennms.core.wsman.WSManClientFactory;
+import org.opennms.core.wsman.exceptions.WSManException;
+import org.opennms.core.wsman.shell.CommandResult;
+import org.opennms.core.wsman.shell.ShellOptions;
+import org.opennms.core.xml.JaxbUtils;
+import org.opennms.netmgt.config.poller.Service;
+import org.opennms.netmgt.config.wsman.credentials.Definition;
+import org.opennms.netmgt.dao.WSManConfigDao;
+import org.opennms.netmgt.poller.MonitoredService;
+import org.opennms.netmgt.poller.PollStatus;
+
+import com.google.common.collect.Maps;
+
+public class WsManShellMonitorTest {
+    private static final String SC_RUNNING = "\r\nSERVICE_NAME: w32time \r\n        TYPE               : 20  WIN32_SHARE_PROCESS  \r\n"
+            + "        STATE              : 4  RUNNING \r\n";
+    private static final String SC_STOPPED = "\r\nSERVICE_NAME: w32time \r\n        STATE              : 1  STOPPED \r\n";
+
+    private WSManClient client;
+    private WsManShellMonitor monitor;
+    private MonitoredService svc;
+    private Definition agentConfig;
+
+    @Before
+    public void setUp() throws UnknownHostException {
+        agentConfig = new Definition();
+        WSManConfigDao configDao = mock(WSManConfigDao.class);
+        when(configDao.getAgentConfig(any())).thenReturn(agentConfig);
+
+        client = mock(WSManClient.class);
+        WSManClientFactory clientFactory = mock(WSManClientFactory.class);
+        when(clientFactory.getClient(any())).thenReturn(client);
+
+        monitor = new WsManShellMonitor();
+        monitor.setWSManConfigDao(configDao);
+        monitor.setWSManClientFactory(clientFactory);
+
+        svc = mock(MonitoredService.class);
+        when(svc.getAddress()).thenReturn(InetAddress.getByName("127.0.0.1"));
+        when(svc.getIpAddr()).thenReturn("127.0.0.1");
+        when(svc.getNodeLabel()).thenReturn("win-host");
+    }
+
+    @Test
+    public void isUpWhenExitCodeAndBannerMatch() {
+        when(client.runCommand(eq("sc"), any(), any(), any())).thenReturn(new CommandResult(0, SC_RUNNING, ""));
+        PollStatus status = poll(params("command", "sc", "args", "query w32time", "banner", "~.*STATE\\s*:\\s*4\\s+RUNNING.*"));
+        assertEquals(status.getReason(), PollStatus.SERVICE_AVAILABLE, status.getStatusCode());
+        assertTrue(status.getResponseTime() >= 0);
+
+        ArgumentCaptor<String[]> args = ArgumentCaptor.forClass(String[].class);
+        ArgumentCaptor<Duration> timeout = ArgumentCaptor.forClass(Duration.class);
+        ArgumentCaptor<ShellOptions> options = ArgumentCaptor.forClass(ShellOptions.class);
+        verify(client).runCommand(eq("sc"), args.capture(), timeout.capture(), options.capture());
+        assertArrayEquals(new String[] {"query w32time"}, args.getValue());
+        assertEquals(Duration.ofMillis(WsManShellMonitor.DEFAULT_TIMEOUT), timeout.getValue());
+        assertTrue(options.getValue().isNoProfile());
+        verify(client).close();
+    }
+
+    @Test
+    public void isUpWithSubstringBannerAndNoArgs() {
+        when(client.runCommand(eq("hostname"), any(), any(), any())).thenReturn(new CommandResult(0, "WIN-HOST\r\n", ""));
+        PollStatus status = poll(params("command", "hostname", "banner", "WIN-HOST"));
+        assertEquals(status.getReason(), PollStatus.SERVICE_AVAILABLE, status.getStatusCode());
+
+        ArgumentCaptor<String[]> args = ArgumentCaptor.forClass(String[].class);
+        verify(client).runCommand(eq("hostname"), args.capture(), any(), any());
+        assertEquals(0, args.getValue().length);
+    }
+
+    @Test
+    public void isDownWhenBannerDoesNotMatch() {
+        when(client.runCommand(eq("sc"), any(), any(), any())).thenReturn(new CommandResult(0, SC_STOPPED, ""));
+        PollStatus status = poll(params("command", "sc", "args", "query w32time", "banner", "~.*STATE\\s*:\\s*4\\s+RUNNING.*"));
+        assertEquals(PollStatus.SERVICE_UNAVAILABLE, status.getStatusCode());
+        assertTrue(status.getReason(), status.getReason().contains("Banner"));
+        assertTrue(status.getReason(), status.getReason().contains("STOPPED"));
+    }
+
+    @Test
+    public void isDownWhenConfiguredExitCodeDoesNotMatch() {
+        when(client.runCommand(eq("sc"), any(), any(), any())).thenReturn(new CommandResult(1060, "", "The specified service does not exist"));
+        PollStatus status = poll(params("command", "sc", "args", "query nosuchsvc", "exit-code", "0"));
+        assertEquals(PollStatus.SERVICE_UNAVAILABLE, status.getStatusCode());
+        assertTrue(status.getReason(), status.getReason().contains("1060"));
+        assertTrue(status.getReason(), status.getReason().contains("does not exist"));
+    }
+
+    @Test
+    public void ignoresExitCodeByDefault() {
+        when(client.runCommand(eq("sc"), any(), any(), any())).thenReturn(new CommandResult(1060, "nope", ""));
+        PollStatus status = poll(params("command", "sc", "args", "query nosuchsvc", "banner", "nope"));
+        assertEquals(status.getReason(), PollStatus.SERVICE_AVAILABLE, status.getStatusCode());
+    }
+
+    @Test
+    public void isDownWhenCommandFails() {
+        when(client.runCommand(eq("sc"), any(), any(), any())).thenThrow(new WSManException("WinRS Receive failed"));
+        PollStatus status = poll(params("command", "sc", "args", "query w32time"));
+        assertEquals(PollStatus.SERVICE_UNAVAILABLE, status.getStatusCode());
+        assertTrue(status.getReason(), status.getReason().contains("WinRS Receive failed"));
+    }
+
+    @Test
+    public void retriesFailedAttempts() {
+        when(client.runCommand(eq("sc"), any(), any(), any()))
+                .thenThrow(new WSManException("transient"))
+                .thenReturn(new CommandResult(0, SC_RUNNING, ""));
+        PollStatus status = poll(params("command", "sc", "args", "query w32time", "banner", "RUNNING", "retry", "1"));
+        assertEquals(status.getReason(), PollStatus.SERVICE_AVAILABLE, status.getStatusCode());
+        verify(client, times(2)).runCommand(eq("sc"), any(), any(), any());
+    }
+
+    @Test
+    public void usesRetryFromWsmanConfigWhenServiceHasNone() {
+        agentConfig.setRetry(2);
+        when(client.runCommand(eq("sc"), any(), any(), any())).thenThrow(new WSManException("down"));
+        PollStatus status = poll(params("command", "sc"));
+        assertEquals(PollStatus.SERVICE_UNAVAILABLE, status.getStatusCode());
+        verify(client, times(3)).runCommand(eq("sc"), any(), any(), any());
+    }
+
+    @Test
+    public void passesTimeoutAndShellOptions() {
+        when(client.runCommand(any(), any(), any(), any())).thenReturn(new CommandResult(0, "", ""));
+        poll(params("command", "dir", "timeout", "5000", "no-profile", "false", "codepage", "437", "working-directory", "C:\\Temp"));
+
+        ArgumentCaptor<Duration> timeout = ArgumentCaptor.forClass(Duration.class);
+        ArgumentCaptor<ShellOptions> options = ArgumentCaptor.forClass(ShellOptions.class);
+        verify(client).runCommand(eq("dir"), any(), timeout.capture(), options.capture());
+        assertEquals(Duration.ofMillis(5000), timeout.getValue());
+        assertEquals(false, options.getValue().isNoProfile());
+        assertEquals(437, options.getValue().getCodepage());
+        assertEquals("C:\\Temp", options.getValue().getWorkingDirectory());
+    }
+
+    @Test
+    public void substitutesPlaceholders() {
+        when(client.runCommand(eq("hostname"), any(), any(), any())).thenReturn(new CommandResult(0, "win-host\r\n", ""));
+        PollStatus status = poll(params("command", "hostname", "banner", "{nodeLabel}"));
+        assertEquals(status.getReason(), PollStatus.SERVICE_AVAILABLE, status.getStatusCode());
+    }
+
+    @Test
+    public void passesQuotedArgumentsFromXmlConfigVerbatim() {
+        // The args value as it would be written in poller-configuration.xml, with &quot; for the double quotes
+        final String xml = "<service name=\"Cluster-Health\" interval=\"300000\" user-defined=\"true\" status=\"on\">"
+                + "<parameter key=\"command\" value=\"powershell\"/>"
+                + "<parameter key=\"args\" value=\"-NoProfile -NonInteractive -Command &quot;if ((Get-ClusterNode -Name $env:COMPUTERNAME).State -ne 'Up') { exit 1 }&quot;\"/>"
+                + "<parameter key=\"exit-code\" value=\"0\"/>"
+                + "</service>";
+        final Service service = JaxbUtils.unmarshal(Service.class, xml);
+        final Map<String, Object> parameters = Maps.newHashMap(service.getParameterMap());
+
+        when(client.runCommand(eq("powershell"), any(), any(), any())).thenReturn(new CommandResult(0, "", ""));
+        PollStatus status = poll(parameters);
+        assertEquals(status.getReason(), PollStatus.SERVICE_AVAILABLE, status.getStatusCode());
+
+        // The XML parser restores the quotes and the monitor hands the string over untouched
+        ArgumentCaptor<String[]> args = ArgumentCaptor.forClass(String[].class);
+        verify(client).runCommand(eq("powershell"), args.capture(), any(), any());
+        assertArrayEquals(new String[] {
+                "-NoProfile -NonInteractive -Command \"if ((Get-ClusterNode -Name $env:COMPUTERNAME).State -ne 'Up') { exit 1 }\""},
+                args.getValue());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void requiresCommand() {
+        poll(params("banner", "x"));
+    }
+
+    private PollStatus poll(Map<String, Object> parameters) {
+        Map<String, Object> subbedParams = Interpolator.interpolateAttributes(monitor.getRuntimeAttributes(svc, parameters), EmptyScope.EMPTY);
+        // this would normally happen in the poller request builder implementation
+        parameters.putAll(subbedParams);
+        return monitor.poll(svc, parameters);
+    }
+
+    private static Map<String, Object> params(String... keyValues) {
+        Map<String, Object> parameters = Maps.newHashMap();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            parameters.put(keyValues[i], keyValues[i + 1]);
+        }
+        return parameters;
+    }
+}

--- a/features/wsman/src/test/java/org/opennms/netmgt/provision/detector/wsman/WsManShellDetectorTest.java
+++ b/features/wsman/src/test/java/org/opennms/netmgt/provision/detector/wsman/WsManShellDetectorTest.java
@@ -54,6 +54,7 @@ public class WsManShellDetectorTest {
     private static final String SC_RUNNING = "SERVICE_NAME: w32time\r\n        STATE              : 4  RUNNING\r\n";
 
     private WSManClient client;
+    private WSManClientFactory clientFactory;
     private WsManShellDetectorFactory factory;
     private WSManEndpoint endpoint;
     private InetAddress address;
@@ -61,7 +62,7 @@ public class WsManShellDetectorTest {
     @Before
     public void setUp() throws Exception {
         client = mock(WSManClient.class);
-        WSManClientFactory clientFactory = mock(WSManClientFactory.class);
+        clientFactory = mock(WSManClientFactory.class);
         when(clientFactory.getClient(any())).thenReturn(client);
         factory = new WsManShellDetectorFactory(clientFactory);
         endpoint = new WSManEndpoint.Builder("http://127.0.0.1:5985/wsman").withBasicAuth("user", "pass").build();
@@ -84,6 +85,7 @@ public class WsManShellDetectorTest {
         assertArrayEquals(new String[] {"query w32time"}, args.getValue());
         assertEquals(Duration.ofMillis(detector.getTimeout()), timeout.getValue());
         assertEquals(2000, detector.getTimeout());
+        assertEndpointTimeouts(2000);
         assertTrue(options.getValue().isNoProfile());
         verify(client).close();
     }
@@ -132,6 +134,7 @@ public class WsManShellDetectorTest {
         ArgumentCaptor<ShellOptions> options = ArgumentCaptor.forClass(ShellOptions.class);
         verify(client).runCommand(eq("dir"), any(), timeout.capture(), options.capture());
         assertEquals(Duration.ofMillis(5000), timeout.getValue());
+        assertEndpointTimeouts(5000);
         assertFalse(options.getValue().isNoProfile());
         assertEquals(437, options.getValue().getCodepage());
         assertEquals("C:\\Temp", options.getValue().getWorkingDirectory());
@@ -149,6 +152,18 @@ public class WsManShellDetectorTest {
 
         DetectResults results = detector.detect(request);
         assertTrue(results.isServiceDetected());
+    }
+
+    /** Every exchange with the host is bounded by the detector timeout, not only the wait for output. */
+    private void assertEndpointTimeouts(int expectedMillis) {
+        ArgumentCaptor<WSManEndpoint> captor = ArgumentCaptor.forClass(WSManEndpoint.class);
+        verify(clientFactory).getClient(captor.capture());
+        assertEquals(Integer.valueOf(expectedMillis), captor.getValue().getConnectionTimeout());
+        assertEquals(Integer.valueOf(expectedMillis), captor.getValue().getReceiveTimeout());
+        // Everything else is carried over unchanged
+        assertEquals(endpoint.getUrl(), captor.getValue().getUrl());
+        assertEquals(endpoint.getUsername(), captor.getValue().getUsername());
+        assertEquals(endpoint.getPassword(), captor.getValue().getPassword());
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/features/wsman/src/test/java/org/opennms/netmgt/provision/detector/wsman/WsManShellDetectorTest.java
+++ b/features/wsman/src/test/java/org/opennms/netmgt/provision/detector/wsman/WsManShellDetectorTest.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.netmgt.provision.detector.wsman;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.time.Duration;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.opennms.core.wsman.WSManClient;
+import org.opennms.core.wsman.WSManClientFactory;
+import org.opennms.core.wsman.WSManEndpoint;
+import org.opennms.core.wsman.exceptions.WSManException;
+import org.opennms.core.wsman.shell.CommandResult;
+import org.opennms.core.wsman.shell.ShellOptions;
+import org.opennms.netmgt.provision.DetectRequest;
+import org.opennms.netmgt.provision.DetectResults;
+
+import com.google.common.collect.ImmutableMap;
+
+public class WsManShellDetectorTest {
+    private static final String SC_RUNNING = "SERVICE_NAME: w32time\r\n        STATE              : 4  RUNNING\r\n";
+
+    private WSManClient client;
+    private WsManShellDetectorFactory factory;
+    private WSManEndpoint endpoint;
+    private InetAddress address;
+
+    @Before
+    public void setUp() throws Exception {
+        client = mock(WSManClient.class);
+        WSManClientFactory clientFactory = mock(WSManClientFactory.class);
+        when(clientFactory.getClient(any())).thenReturn(client);
+        factory = new WsManShellDetectorFactory(clientFactory);
+        endpoint = new WSManEndpoint.Builder("http://127.0.0.1:5985/wsman").withBasicAuth("user", "pass").build();
+        address = InetAddress.getByName("127.0.0.1");
+    }
+
+    @Test
+    public void detectsWhenExitCodeAndBannerMatch() {
+        when(client.runCommand(eq("sc"), any(), any(), any())).thenReturn(new CommandResult(0, SC_RUNNING, ""));
+        WsManShellDetector detector = factory.createDetector(ImmutableMap.of(
+                "command", "sc", "args", "query w32time", "banner", "~.*STATE\\s*:\\s*4\\s+RUNNING.*"));
+        assertEquals("WsManShell", detector.getServiceName());
+
+        assertTrue(detector.isServiceDetected(address, endpoint).isServiceDetected());
+
+        ArgumentCaptor<String[]> args = ArgumentCaptor.forClass(String[].class);
+        ArgumentCaptor<Duration> timeout = ArgumentCaptor.forClass(Duration.class);
+        ArgumentCaptor<ShellOptions> options = ArgumentCaptor.forClass(ShellOptions.class);
+        verify(client).runCommand(eq("sc"), args.capture(), timeout.capture(), options.capture());
+        assertArrayEquals(new String[] {"query w32time"}, args.getValue());
+        assertEquals(Duration.ofMillis(detector.getTimeout()), timeout.getValue());
+        assertEquals(2000, detector.getTimeout());
+        assertTrue(options.getValue().isNoProfile());
+        verify(client).close();
+    }
+
+    @Test
+    public void doesNotDetectWhenBannerDoesNotMatch() {
+        when(client.runCommand(eq("sc"), any(), any(), any())).thenReturn(new CommandResult(0, "STATE : 1 STOPPED", ""));
+        WsManShellDetector detector = factory.createDetector(ImmutableMap.of("command", "sc", "args", "query w32time", "banner", "RUNNING"));
+        assertFalse(detector.isServiceDetected(address, endpoint).isServiceDetected());
+    }
+
+    @Test
+    public void checksExitCodeOnlyWhenConfigured() {
+        when(client.runCommand(eq("sc"), any(), any(), any())).thenReturn(new CommandResult(1060, "", "no such service"));
+        // Ignored by default
+        WsManShellDetector detector = factory.createDetector(ImmutableMap.of("command", "sc", "args", "query nosuchsvc"));
+        assertTrue(detector.isServiceDetected(address, endpoint).isServiceDetected());
+
+        // Enforced when set
+        detector = factory.createDetector(ImmutableMap.of("command", "sc", "args", "query nosuchsvc", "exitCode", "0"));
+        assertFalse(detector.isServiceDetected(address, endpoint).isServiceDetected());
+    }
+
+    @Test
+    public void doesNotDetectWhenCommandFails() {
+        when(client.runCommand(any(), any(), any(), any())).thenThrow(new WSManException("boom"));
+        WsManShellDetector detector = factory.createDetector(ImmutableMap.of("command", "sc"));
+        assertFalse(detector.isServiceDetected(address, endpoint).isServiceDetected());
+    }
+
+    @Test
+    public void bindsAllProperties() {
+        when(client.runCommand(any(), any(), any(), any())).thenReturn(new CommandResult(0, "", ""));
+        WsManShellDetector detector = factory.createDetector(ImmutableMap.<String, String>builder()
+                .put("command", "dir")
+                .put("serviceName", "TempDir")
+                .put("timeout", "5000")
+                .put("noProfile", "false")
+                .put("codepage", "437")
+                .put("workingDirectory", "C:\\Temp")
+                .build());
+        assertEquals("TempDir", detector.getServiceName());
+        detector.isServiceDetected(address, endpoint);
+
+        ArgumentCaptor<Duration> timeout = ArgumentCaptor.forClass(Duration.class);
+        ArgumentCaptor<ShellOptions> options = ArgumentCaptor.forClass(ShellOptions.class);
+        verify(client).runCommand(eq("dir"), any(), timeout.capture(), options.capture());
+        assertEquals(Duration.ofMillis(5000), timeout.getValue());
+        assertFalse(options.getValue().isNoProfile());
+        assertEquals(437, options.getValue().getCodepage());
+        assertEquals("C:\\Temp", options.getValue().getWorkingDirectory());
+    }
+
+    @Test
+    public void detectsFromRequestRuntimeAttributes() throws MalformedURLException {
+        when(client.runCommand(eq("hostname"), any(), any(), any())).thenReturn(new CommandResult(0, "WIN-HOST", ""));
+        WsManShellDetector detector = factory.createDetector(ImmutableMap.of("command", "hostname", "banner", "WIN-HOST"));
+
+        Map<String, String> runtimeAttributes = WsmanEndpointUtils.toMap(endpoint);
+        DetectRequest request = mock(DetectRequest.class);
+        when(request.getAddress()).thenReturn(address);
+        when(request.getRuntimeAttributes()).thenReturn(runtimeAttributes);
+
+        DetectResults results = detector.detect(request);
+        assertTrue(results.isServiceDetected());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void requiresCommand() {
+        factory.createDetector(ImmutableMap.of("banner", "x")).isServiceDetected(address, endpoint);
+    }
+}

--- a/features/wsman/src/test/java/org/opennms/netmgt/provision/detector/wsman/WsmanEndpointUtilsTest.java
+++ b/features/wsman/src/test/java/org/opennms/netmgt/provision/detector/wsman/WsmanEndpointUtilsTest.java
@@ -51,6 +51,31 @@ public class WsmanEndpointUtilsTest {
     }
 
     @Test
+    public void keepsCredentialsWithGssAuthAndKerberosEncryption() throws MalformedURLException {
+        // With GSS or Kerberos encryption the credentials are the Kerberos principal and password;
+        // isBasicAuth() is false, but they must still survive the trip through the map
+        WSManEndpoint kerberos = WsmanEndpointUtils.fromMap(WsmanEndpointUtils.toMap(
+                new WSManEndpoint.Builder("http://win.example.org:5985/wsman")
+                        .withKerberosEncryption()
+                        .withBasicAuth("svc@EXAMPLE.ORG", "secret")
+                        .build()));
+        assertTrue(kerberos.isKerberosEncryption());
+        assertFalse(kerberos.isBasicAuth());
+        assertEquals("svc@EXAMPLE.ORG", kerberos.getUsername());
+        assertEquals("secret", kerberos.getPassword());
+
+        WSManEndpoint gss = WsmanEndpointUtils.fromMap(WsmanEndpointUtils.toMap(
+                new WSManEndpoint.Builder("https://win.example.org:5986/wsman")
+                        .withGSSAuth()
+                        .withBasicAuth("svc@EXAMPLE.ORG", "secret")
+                        .build()));
+        assertTrue(gss.isGSSAuth());
+        assertFalse(gss.isKerberosEncryption());
+        assertEquals("svc@EXAMPLE.ORG", gss.getUsername());
+        assertEquals("secret", gss.getPassword());
+    }
+
+    @Test
     public void canConvertKerberosEncryptionToAndFromMap() throws MalformedURLException {
         WSManEndpoint expectedEndpoint = new WSManEndpoint.Builder("http://win.example.org:5985/wsman")
                 .withKerberosEncryption()

--- a/features/wsman/src/test/java/org/opennms/netmgt/provision/detector/wsman/WsmanEndpointUtilsTest.java
+++ b/features/wsman/src/test/java/org/opennms/netmgt/provision/detector/wsman/WsmanEndpointUtilsTest.java
@@ -22,6 +22,8 @@
 package org.opennms.netmgt.provision.detector.wsman;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.net.MalformedURLException;
 
@@ -44,5 +46,22 @@ public class WsmanEndpointUtilsTest {
         assertEquals(expectedEndpoint.getUsername(), actualEndpoint.getUsername());
         assertEquals(expectedEndpoint.getPassword(), actualEndpoint.getPassword());
         assertEquals(expectedEndpoint.getConnectionTimeout(), actualEndpoint.getConnectionTimeout());
+        assertFalse(actualEndpoint.isGSSAuth());
+        assertFalse(actualEndpoint.isKerberosEncryption());
+    }
+
+    @Test
+    public void canConvertKerberosEncryptionToAndFromMap() throws MalformedURLException {
+        WSManEndpoint expectedEndpoint = new WSManEndpoint.Builder("http://win.example.org:5985/wsman")
+                .withKerberosEncryption()
+                .build();
+
+        WSManEndpoint actualEndpoint = WsmanEndpointUtils.fromMap(WsmanEndpointUtils.toMap(expectedEndpoint));
+
+        assertEquals(expectedEndpoint.getUrl(), actualEndpoint.getUrl());
+        assertTrue(actualEndpoint.isKerberosEncryption());
+        // Kerberos encryption implies GSS authentication
+        assertTrue(actualEndpoint.isGSSAuth());
+        assertFalse(actualEndpoint.isBasicAuth());
     }
 }

--- a/features/wsman/src/test/resources/wsman-config-endpoints.xml
+++ b/features/wsman/src/test/resources/wsman-config-endpoints.xml
@@ -1,0 +1,8 @@
+<wsman-config xmlns="http://xmlns.opennms.org/xsd/config/wsman" retry="2" timeout="1500">
+  <definition ssl="false" port="5985" kerberos-encryption="true">
+    <specific>127.0.0.1</specific>
+  </definition>
+  <definition ssl="false" port="5985" gss-auth="true">
+    <specific>127.0.0.2</specific>
+  </definition>
+</wsman-config>

--- a/features/wsman/src/test/resources/wsman-config.xml
+++ b/features/wsman/src/test/resources/wsman-config.xml
@@ -2,4 +2,7 @@
   <definition ssl="false" port="5985" path="ws-man" username="Administrator" password="!Administrator#" product-vendor="Microsoft" product-version="OS: Vista">
     <specific>172.23.1.2</specific>
   </definition>
+  <definition ssl="false" port="5985" kerberos-encryption="true">
+    <specific>172.23.1.3</specific>
+  </definition>
 </wsman-config>

--- a/integrations/opennms-wsman-asset-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/WsManAssetProvisioningAdapter.java
+++ b/integrations/opennms-wsman-asset-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/WsManAssetProvisioningAdapter.java
@@ -38,7 +38,7 @@ import org.opennms.core.wsman.WSManClient;
 import org.opennms.core.wsman.WSManClientFactory;
 import org.opennms.core.wsman.WSManConstants;
 import org.opennms.core.wsman.WSManEndpoint;
-import org.opennms.core.wsman.cxf.CXFWSManClientFactory;
+import org.opennms.core.wsman.utils.CachingWSManClientFactory;
 import org.opennms.netmgt.config.WsManAssetAdapterConfig;
 import org.opennms.netmgt.config.wsman.credentials.WsmanAgentConfig;
 import org.opennms.netmgt.config.wsmanAsset.adapter.AssetField;
@@ -69,7 +69,7 @@ public class WsManAssetProvisioningAdapter extends SimplerQueuedProvisioningAdap
 
     private NodeDao m_nodeDao;
     private WsManAssetAdapterConfig m_config;
-    private WSManClientFactory m_factory = new CXFWSManClientFactory();
+    private WSManClientFactory m_factory = new CachingWSManClientFactory();
     private WSManConfigDao m_wsManConfigDao;
 
     private static final String NAME = "WsManAssetProvisioningAdapter";
@@ -120,12 +120,11 @@ public class WsManAssetProvisioningAdapter extends SimplerQueuedProvisioningAdap
             }
             final WsmanAgentConfig config = m_wsManConfigDao.getAgentConfig(ipaddress);
             final WSManEndpoint endpoint = WSManConfigDao.getEndpoint(config, ipaddress);
-            final WSManClient client = m_factory.getClient(endpoint);
             LOG.debug("doAdd: m_config: {} ", m_config);
 
             final OnmsAssetRecord asset = node.getAssetRecord();
             m_config.getReadLock().lock();
-            try {
+            try (WSManClient client = m_factory.getClient(endpoint)) {
                 for (final AssetField field : m_config.getAssetFieldsForAddress(ipaddress, vendor)) {
                     try {
                         final String value = fetchWsManAssetString(client, endpoint, field.getWqlObjs(), field.getFormatString());
@@ -241,12 +240,11 @@ public class WsManAssetProvisioningAdapter extends SimplerQueuedProvisioningAdap
             }
             final WsmanAgentConfig config = m_wsManConfigDao.getAgentConfig(ipaddress);
             final WSManEndpoint endpoint = WSManConfigDao.getEndpoint(config, ipaddress);
-            final WSManClient client = m_factory.getClient(endpoint);
             LOG.debug("doUpdate: m_config: \"{}\"", m_config);
 
             final OnmsAssetRecord asset = node.getAssetRecord();
             m_config.getReadLock().lock();
-            try {
+            try (WSManClient client = m_factory.getClient(endpoint)) {
                 for (final AssetField field : m_config.getAssetFieldsForAddress(ipaddress, vendor)) {
                     try {
                         final String value = fetchWsManAssetString(client, endpoint, field.getWqlObjs(), field.getFormatString());

--- a/pom.xml
+++ b/pom.xml
@@ -2002,7 +2002,7 @@
     <xmlSchemaVersion>2.3.1</xmlSchemaVersion>
     <xmlgraphicsCommonsVersion>2.9</xmlgraphicsCommonsVersion>
     <xstreamVersion>1.4.21</xstreamVersion>
-    <wsmanVersion>1.3.6</wsmanVersion>
+    <wsmanVersion>1.3.7</wsmanVersion>
     <zookeeperVersion>3.7.2</zookeeperVersion>
     <zstdJniVersion>1.5.2-1</zstdJniVersion>
     <minaSshdVersion>2.15.0</minaSshdVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -2002,7 +2002,7 @@
     <xmlSchemaVersion>2.3.1</xmlSchemaVersion>
     <xmlgraphicsCommonsVersion>2.9</xmlgraphicsCommonsVersion>
     <xstreamVersion>1.4.21</xstreamVersion>
-    <wsmanVersion>1.3.4</wsmanVersion>
+    <wsmanVersion>1.3.5</wsmanVersion>
     <zookeeperVersion>3.7.2</zookeeperVersion>
     <zstdJniVersion>1.5.2-1</zstdJniVersion>
     <minaSshdVersion>2.15.0</minaSshdVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -2002,7 +2002,7 @@
     <xmlSchemaVersion>2.3.1</xmlSchemaVersion>
     <xmlgraphicsCommonsVersion>2.9</xmlgraphicsCommonsVersion>
     <xstreamVersion>1.4.21</xstreamVersion>
-    <wsmanVersion>1.3.5</wsmanVersion>
+    <wsmanVersion>1.3.6</wsmanVersion>
     <zookeeperVersion>3.7.2</zookeeperVersion>
     <zstdJniVersion>1.5.2-1</zstdJniVersion>
     <minaSshdVersion>2.15.0</minaSshdVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -2002,7 +2002,7 @@
     <xmlSchemaVersion>2.3.1</xmlSchemaVersion>
     <xmlgraphicsCommonsVersion>2.9</xmlgraphicsCommonsVersion>
     <xstreamVersion>1.4.21</xstreamVersion>
-    <wsmanVersion>1.3.3</wsmanVersion>
+    <wsmanVersion>1.3.4</wsmanVersion>
     <zookeeperVersion>3.7.2</zookeeperVersion>
     <zstdJniVersion>1.5.2-1</zstdJniVersion>
     <minaSshdVersion>2.15.0</minaSshdVersion>

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/DetectorsCommandIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/DetectorsCommandIT.java
@@ -109,6 +109,7 @@ public class DetectorsCommandIT {
             .put("WEB", "org.opennms.netmgt.provision.detector.web.WebDetector")
             .put("WS-Man", "org.opennms.netmgt.provision.detector.wsman.WsManDetector")
             .put("WSManWQL", "org.opennms.netmgt.provision.detector.wsman.WsManWQLDetector")
+            .put("WsManShell", "org.opennms.netmgt.provision.detector.wsman.WsManShellDetector")
             .put("Win32Service", "org.opennms.netmgt.provision.detector.snmp.Win32ServiceDetector").build();
 
     @Test

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/MonitorsListCommandIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/MonitorsListCommandIT.java
@@ -111,6 +111,7 @@ public class MonitorsListCommandIT {
             "org.opennms.netmgt.poller.monitors.VmwareMonitor",
             "org.opennms.netmgt.poller.monitors.VmwareCimMonitor",
             "org.opennms.netmgt.poller.monitors.WsManMonitor",
+            "org.opennms.netmgt.poller.monitors.WsManShellMonitor",
             "org.opennms.netmgt.poller.monitors.DhcpMonitor")
             .build();
 


### PR DESCRIPTION
Update wsman to 1.3.7: Kerberos message encryption, WinRS monitor and detector
  
  Library
  - wsmanVersion 1.3.4 → 1.3.5 (WinRS command execution, Kerberos message
    encryption per MS-WSMV 2.2.9.1, AutoCloseable clients; 1.3.5 fixes WinRS
    inside OpenNMS, where Xalan rejects the JAXP 1.5 transformer attributes).
 - wsmanVersion 1.3.5 → 1.3.6 (whoops, you didn't see nothing)
 - wsmanVersion 1.3.6 → 1.3.7 (Don't allow wsman to populate and then
   destroy the default CXF bus)

  Configuration
  - New wsman-config.xml attribute kerberos-encryption (XSD, JAXB model,
    WsmanAgentConfig, endpoint map). Implies gss-auth and uses the canonical
    host name for the SPN like gss-auth does.
  - WsmanEndpointUtils now carries username/password for GSS and Kerberos
    endpoints; previously monitors and detectors silently dropped them and
    fell back to the JAAS entry (also fixes gss-auth with a password).

  Client lifecycle
  - CachingWSManClientFactory (AutoCloseable): one shared client per
    Kerberos-encrypted endpoint so the login, GSS context, and connection are
    reused across polls; non-Kerberos endpoints pass straight through.
  - try-with-resources at every call site (collector, monitors, detectors,
    asset adapter); destroy() on the collector, monitors, and detector
    factories wired as blueprint destroy-method.

  New components
  - WsManShellMonitor and WsManShellDetector (+ factory): run a command via
    WinRS, match stdout against a banner (substring, or regex when prefixed
    with ~, matched with DOTALL), optionally require an exit code. args is
    passed to WinRS verbatim since the server joins command and arguments
    with spaces and adds no quoting. command/args are excluded from
    placeholder substitution (they reach cmd.exe as written). timeout bounds
    every exchange with the host; timeout and retry default from
    wsman-config.xml, service definition wins. Registered for core
    (META-INF/services) and Minion (blueprint), added to the Minion smoke
    test lists, documented.

  Docs
  - New reference page configuration/wsman-kerberos.adoc: modes,
    prerequisites (AES256 only, reverse DNS for the SPN, clock, ports),
    krb5.conf, keytab (JAAS WSManClient) vs password (incl. SCV), system
    properties for core/Minion/containers, connection handling,
    verification with the wsman CLI, troubleshooting. Cross-linked from the
    collector, both monitors, and all three detector pages.

  Testing
  - Unit: features/wsman 66 tests (endpoint map round trips, config
    parsing, caching factory incl. 32-thread concurrency, monitor and
    detector behaviour, XML &quot; round trip through the poller JAXB model);
    wsman library adds CxfShellOperationsTest for the Xalan case.
  - **Live, against a Windows Server 2019 DC** (dc18) with WinRM on plain HTTP
    5985 and Kerberos message encryption, using a Horizon container built
    from this tree and a Minion container built from the same tree sharing
    the core's network namespace (broker failover:tcp://127.0.0.1:61616):
    * Core (Default location): WS-Man identify and WQL detectors, both shell
      detectors positive and one negative, WsManMonitor GET, two shell
      services up, one intentionally down with the exit-code reason in the
      lost-service event, WS-Man collector collecting; keytab path and
      vault-backed password path (${scv:...}) both verified.
    * Minion (MINION location): same detectors and monitors executed on the
      Minion with credentials resolved on the core and Kerberos on the
      Minion; session reuse confirmed from the client-creation log lines.
  - CI: Minion and Sentinel smoke tests pass after the blueprint fix
    (destroy-method is only valid on top-level beans).

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20287
* https://opennms.atlassian.net/browse/NMS-9350
* https://github.com/OpenNMS/wsman/pull/32
* https://github.com/OpenNMS/wsman/pull/31