### PR TITLE
NMS-20300: Say the topology map needs WebGL instead of failing blank

### DIFF
--- a/ui/src/components/Topology/TopologyCanvas.vue
+++ b/ui/src/components/Topology/TopologyCanvas.vue
@@ -96,7 +96,14 @@ License.
         </text>
       </template>
     </svg>
-    <div ref="canvasEl" class="topology-canvas" />
+    <div v-if="!webglAvailable" class="topology-no-webgl" role="alert">
+      <h3 class="topology-no-webgl__title">This view needs WebGL</h3>
+      <p>
+        The topology map draws through WebGL, and this browser will not provide
+        it. Enabling hardware acceleration usually resolves it.
+      </p>
+    </div>
+    <div v-show="webglAvailable" ref="canvasEl" class="topology-canvas" />
     <div class="topology-labels-layer">
       <!-- Labels are reactively positioned in viewport space via
            cameraVersion (bumped on sigma's afterRender); references it
@@ -210,6 +217,7 @@ import Graph from 'graphology'
 import Sigma from 'sigma'
 import EdgeCurveProgram from '@sigma/edge-curve'
 import { createNodeImageProgram } from '@sigma/node-image'
+import { hasWebGL } from '@/components/Topology/webgl'
 import { drawDiscNodeLabel } from 'sigma/rendering'
 import { downloadAsImage } from '@sigma/export-image'
 import { PALETTE_DRAG_MIME, type PaletteDragPayload } from '@/components/Topology/dragTypes'
@@ -277,6 +285,10 @@ const emit = defineEmits<{
 }>()
 
 const canvasEl = ref<HTMLDivElement>()
+
+// Probed once: the answer cannot change within a page, and each probe costs a
+// context on browsers that ration them.
+const webglAvailable = ref<boolean>(hasWebGL())
 const linkCount = ref(0)
 const placedCount = ref(0)
 const isDropHover = ref(false)
@@ -462,6 +474,11 @@ const mountSigma = (g: Graph) => {
     resizeObserver = null
   }
   if (!canvasEl.value) {
+    return
+  }
+  // Nothing below survives without a context: createNodeImageProgram reads
+  // MAX_TEXTURE_SIZE off it unchecked.
+  if (!webglAvailable.value) {
     return
   }
   sigma = new Sigma(g, canvasEl.value, {
@@ -2721,6 +2738,27 @@ defineExpose({
   gap: 1rem;
   pointer-events: none;
   font-family: monospace;
+}
+
+.topology-no-webgl {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 2rem;
+  text-align: center;
+  color: var(--onms-secondary-text-on-surface);
+}
+
+.topology-no-webgl p {
+  max-width: 34rem;
+}
+
+.topology-no-webgl__title {
+  margin: 0;
+  color: var(--onms-primary-text-on-surface);
 }
 
 .topology-canvas {

--- a/ui/src/components/Topology/webgl.ts
+++ b/ui/src/components/Topology/webgl.ts
@@ -1,0 +1,50 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+/**
+ * Whether this browser will give up a WebGL context.
+ *
+ * Probed rather than assumed because the map cannot degrade: sigma renders
+ * through WebGL, and @sigma/node-image dereferences the context it asks for
+ * without checking, so an unsupported browser throws
+ * "can't access property getParameter, n is null" and nothing renders at all.
+ *
+ * Reasons a context is refused include hardware acceleration being off, a
+ * blocklisted driver, a session with no GPU, fingerprinting protection, and
+ * having reached the browser's limit on live contexts.
+ */
+export const hasWebGL = (): boolean => {
+  try {
+    const canvas = document.createElement('canvas')
+    const gl = canvas.getContext('webgl2') ?? canvas.getContext('webgl')
+    if (!gl) {
+      return false
+    }
+    // Contexts are a limited resource, so the probe hands its own back rather
+    // than waiting for the collector to notice.
+    gl.getExtension('WEBGL_lose_context')?.loseContext()
+    return true
+  } catch {
+    // Some builds throw rather than returning null.
+    return false
+  }
+}

--- a/ui/tests/components/Topology/webgl.test.ts
+++ b/ui/tests/components/Topology/webgl.test.ts
@@ -1,0 +1,67 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { hasWebGL } from '@/components/Topology/webgl'
+
+const stubContext = (impl: (kind: string) => unknown) =>
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext')
+    .mockImplementation((kind: string) => impl(kind) as never)
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('hasWebGL', () => {
+  it('is true when the browser gives up a context', () => {
+    stubContext(kind => (kind === 'webgl2' ? { getExtension: () => null } : null))
+    expect(hasWebGL()).toBe(true)
+  })
+
+  it('accepts webgl where webgl2 is unavailable', () => {
+    stubContext(kind => (kind === 'webgl' ? { getExtension: () => null } : null))
+    expect(hasWebGL()).toBe(true)
+  })
+
+  it('is false when no context is available', () => {
+    stubContext(() => null)
+    expect(hasWebGL()).toBe(false)
+  })
+
+  // Some builds throw instead of returning null.
+  it('is false when asking for a context throws', () => {
+    stubContext(() => {
+      throw new Error('blocked')
+    })
+    expect(hasWebGL()).toBe(false)
+  })
+
+  // Contexts are rationed, so the probe must not keep the one it took.
+  it('hands its probe context back', () => {
+    const loseContext = vi.fn()
+    stubContext(kind => (kind === 'webgl2'
+      ? { getExtension: (name: string) => (name === 'WEBGL_lose_context' ? { loseContext } : null) }
+      : null))
+    expect(hasWebGL()).toBe(true)
+    expect(loseContext).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Browsers without WebGL will show a blank page and throw "TypeError: can't access property getParameter, n is null" in the console.  This will improve that so there's a real error message.

Assisted by Anthropic Claude Opus 5.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20300

