### PR TITLE
NMS-20031: Vue Node Details - Complete Basic Layout

### DIFF
--- a/ui/src/components/Map/LeafletMap.vue
+++ b/ui/src/components/Map/LeafletMap.vue
@@ -284,7 +284,7 @@ const getNodeCoordinateMap = computed(() => {
   const map = new Map<string, Coordinates>()
 
   allNodes.value.forEach((node: Node) => {
-    const coord = { latitude: node.assetRecord.latitude, longitude: node.assetRecord.longitude }
+    const coord = { latitude: node.assetRecord.latitude ?? 0, longitude: node.assetRecord.longitude ?? 0 }
     map.set(node.id, coord)
     map.set(node.label, coord)
   })

--- a/ui/src/components/Map/MapNodesGrid.vue
+++ b/ui/src/components/Map/MapNodesGrid.vue
@@ -124,7 +124,7 @@ const nodes = computed<Node[]>(() => mapStore.getNodes())
 const nodeLabelAlarmSeverityMap = computed(() => mapStore.getNodeAlarmSeverityMap())
 
 const doubleClickHandler = (node: Node) => {
-  const coordinate: Coordinates = { latitude: node.assetRecord.latitude, longitude: node.assetRecord.longitude }
+  const coordinate: Coordinates = { latitude: node.assetRecord.latitude ?? 0, longitude: node.assetRecord.longitude ?? 0 }
   mapStore.setMapCenter(coordinate)
 }
 

--- a/ui/src/components/Map/MarkerPopup.vue
+++ b/ui/src/components/Map/MarkerPopup.vue
@@ -45,20 +45,27 @@ import { OnmsIcon } from '@opennms/onms-ui'
 import Location from '@opennms/onms-ui/icons/action/Location.vue'
 import { LPopup } from '@vue-leaflet/vue-leaflet'
 import { Node } from '@/types'
-import { mapPopupOptions, stringToFixedFloat } from './utils'
+import { mapPopupOptions } from './utils'
 
 const props = defineProps({
-  baseHref: { type: Object as PropType<string> },
-  baseNodeUrl: { type: Object as PropType<string> },
+  baseHref: { type: String, required: true },
+  baseNodeUrl: { type: String, required: true },
   node: { type: Object as PropType<Node>, default: () => {
     return
   } },
-  ipAddress: { type: Object as PropType<string> },
+  ipAddress: { type: String },
   nodeLabelToAlarmSeverity: { type: Function as PropType<(label: string) => string>, required: true }
 })
 
-const latitude = computed(() => stringToFixedFloat(props.node.assetRecord.latitude, 6))
-const longitude = computed(() => stringToFixedFloat(props.node.assetRecord.longitude, 6))
+const numToFixedFloat = (num: number | null, decimalPlaces: number): string => {
+  if (num === null || num === undefined) {
+    return 'N/A'
+  }
+  return num.toFixed(decimalPlaces)
+}
+
+const latitude = computed(() => numToFixedFloat(props.node.assetRecord.latitude ?? null, 6))
+const longitude = computed(() => numToFixedFloat(props.node.assetRecord.longitude ?? null, 6))
 
 const getTopologyLink = (node: Node) => {
   return `${props.baseHref}topology?provider=Enhanced Linkd&focus-vertices=${node.id}`

--- a/ui/src/components/Map/utils.ts
+++ b/ui/src/components/Map/utils.ts
@@ -42,18 +42,6 @@ const numericSeverityLevel = (severity: string | undefined) => {
   return 0
 }
 
-const stringToFixedFloat = (floatAsString: string, decimalPoints: number): string => {
-  if (floatAsString) {
-    const num = parseFloat(floatAsString)
-
-    if (!Number.isNaN(num)) {
-      return num.toFixed(decimalPoints)
-    }
-  }
-
-  return floatAsString
-}
-
 // Shared options for marker + cluster popups. Popups open BELOW the marker
 // (the downward offset is applied per-popup in LeafletMap's popupopen handler,
 // and the .onms-popup-below CSS hides the now-pointless tip) instead of
@@ -69,4 +57,4 @@ const mapPopupOptions: PopupOptions = {
   keepInView: false
 }
 
-export { mapPopupOptions, numericSeverityLevel, stringToFixedFloat }
+export { mapPopupOptions, numericSeverityLevel }

--- a/ui/src/components/Nodes/EventsTable.vue
+++ b/ui/src/components/Nodes/EventsTable.vue
@@ -1,4 +1,5 @@
 <template>
+  <div class="onms-col-12 title headline3">Recent Events</div>
   <OnmsTable
     lazy
     :value="eventStore.events"

--- a/ui/src/components/Nodes/EventsTable.vue
+++ b/ui/src/components/Nodes/EventsTable.vue
@@ -52,7 +52,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { OnmsColumn, OnmsIconButton, OnmsTable, OnmsTag, type OnmsTablePageEvent, type OnmsTagSeverity } from '@opennms/onms-ui'
 import IconViewDetails from '@opennms/onms-ui/icons/action/ViewDetails.vue'
@@ -75,9 +75,11 @@ const route = useRoute()
 const { showSnackBar } = useSnackbar()
 const { downloadRecords } = useRecordDownload()
 
-const nodeId = computed(() => route.params.id)
+const nodeId = computed(() => route.params.id as string)
 
-const pageSize = ref(5)
+const DEFAULT_PAGE_SIZE = 5
+
+const pageSize = ref(DEFAULT_PAGE_SIZE)
 const first = ref(0)
 const emptyListContent = { msg: 'No results found.' }
 
@@ -91,10 +93,12 @@ const severityMap: Record<string, OnmsTagSeverity> = {
   indeterminate: 'secondary'
 }
 
+const nodeFilter = (id: string) => `node.id==${id}`
+
 const queryParameters = ref({
-  limit: 5,
+  limit: DEFAULT_PAGE_SIZE,
   offset: 0,
-  _s: `node.id==${route.params.id}`
+  _s: nodeFilter(nodeId.value)
 })
 
 const onEventsForNodeClick = () => {
@@ -133,12 +137,26 @@ const onPage = (event: OnmsTablePageEvent) => {
     ...queryParameters.value,
     offset: event.first,
     limit: event.rows,
-    _s: `node.id==${route.params.id}`
+    _s: nodeFilter(nodeId.value)
   }
   eventStore.getEvents(queryParameters.value)
 }
 
 onMounted(() => {
+  eventStore.getEvents(queryParameters.value)
+})
+
+// The details page keeps one instance of this panel across node ids, so the id has to be
+// followed rather than read once: otherwise the table, its "Events for this Node" link and its
+// downloads would disagree about which node they are for. Back to the first page, since the
+// page the user was on says nothing about the new node.
+watch(nodeId, (id) => {
+  first.value = 0
+  queryParameters.value = {
+    ...queryParameters.value,
+    offset: 0,
+    _s: nodeFilter(id)
+  }
   eventStore.getEvents(queryParameters.value)
 })
 

--- a/ui/src/components/Nodes/EventsTable.vue
+++ b/ui/src/components/Nodes/EventsTable.vue
@@ -62,8 +62,7 @@ import NodeDownloadDropdown from './NodeDownloadDropdown.vue'
 import useSnackbar from '@/composables/useSnackbar'
 import { useEventStore } from '@/stores/eventStore'
 import { useMenuStore } from '@/stores/menuStore'
-import { useNodeExport } from './hooks/useNodeExport'
-import { Event, ServiceType } from '@/types'
+import { useRecordDownload } from './hooks/useRecordDownload'
 
 // The legacy event list page, which accepts a node filter.
 // Will need to replace with the Vue page once it's implemented.
@@ -74,7 +73,7 @@ const menuStore = useMenuStore()
 const route = useRoute()
 
 const { showSnackBar } = useSnackbar()
-const { generateBlob, generateDownload } = useNodeExport()
+const { downloadRecords } = useRecordDownload()
 
 const nodeId = computed(() => route.params.id)
 
@@ -102,56 +101,6 @@ const onEventsForNodeClick = () => {
   window.location.assign(`${menuStore.mainMenu.baseHref}${EVENT_LIST_PATH}?filter=node%3D${nodeId.value}`)
 }
 
-// The CSV columns are whatever fields the events actually carry, in the order the API returns
-// them, rather than the four the table displays. Taken from the data and not from the Event type,
-// which does not declare every field the API sends (serviceType among them).
-const getCsvColumns = (events: Record<string, unknown>[]) => {
-  const columns: string[] = []
-
-  for (const event of events) {
-    for (const field of Object.keys(event)) {
-      if (!columns.includes(field)) {
-        columns.push(field)
-      }
-    }
-  }
-
-  return columns
-}
-
-// serviceType arrives as an object; its name is the part worth a CSV cell. Anything else
-// non-primitive keeps its JSON form rather than stringifying to '[object Object]'.
-const flattenCsvValue = (field: string, value: unknown) => {
-  if (value === null || value === undefined) {
-    return ''
-  }
-
-  if (field === 'serviceType') {
-    return (value as ServiceType).name ?? ''
-  }
-
-  return typeof value === 'object' ? JSON.stringify(value) : String(value)
-}
-
-// Quote a field only when it needs it, doubling any embedded quote, per RFC 4180. Event log
-// messages carry markup and commas, so unquoted values would break the row apart.
-const toCsvValue = (value: string) =>
-  /[",\r\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value
-
-const buildCsv = (events: Event[]) => {
-  // Read the records as plain field bags: the export covers whatever the API sent, including
-  // the fields Event does not declare.
-  const rows = events as unknown as Record<string, unknown>[]
-  const columns = getCsvColumns(rows)
-
-  return [
-    columns.join(','),
-    ...rows.map(row => columns.map(field => toCsvValue(flattenCsvValue(field, row[field]))).join(','))
-  ].join('\n')
-}
-
-const buildJson = (events: Event[]) => JSON.stringify(events, null, 2)
-
 const onDownload = async (format: 'csv' | 'json') => {
   // The paginator's current page: its limit/offset are already tracked in queryParameters, so
   // raising rows-per-page is how a user downloads more than the default 5.
@@ -166,10 +115,7 @@ const onDownload = async (format: 'csv' | 'json') => {
     return
   }
 
-  const contentType = format === 'json' ? 'application/json' : 'text/csv'
-  const data = format === 'json' ? buildJson(events) : buildCsv(events)
-
-  generateDownload(generateBlob(data, contentType), `Events.${format}`)
+  downloadRecords(events, 'Events', format)
 }
 
 const onCsvDownload = async () => {

--- a/ui/src/components/Nodes/EventsTable.vue
+++ b/ui/src/components/Nodes/EventsTable.vue
@@ -105,10 +105,11 @@ const onEventsForNodeClick = () => {
   window.location.assign(`${menuStore.mainMenu.baseHref}${EVENT_LIST_PATH}?filter=node%3D${nodeId.value}`)
 }
 
-const onDownload = async (format: 'csv' | 'json') => {
-  // The paginator's current page: its limit/offset are already tracked in queryParameters, so
-  // raising rows-per-page is how a user downloads more than the default 5.
-  const events = await eventStore.getEventsForExport(queryParameters.value)
+// The download is the page the paginator is showing, which the store already holds -- no
+// second request, and no way for the file to disagree with the table. Raising rows-per-page is
+// how a user takes more than the default page.
+const onDownload = (format: 'csv' | 'json') => {
+  const events = eventStore.events
 
   if (!events || events.length === 0) {
     showSnackBar({
@@ -122,12 +123,12 @@ const onDownload = async (format: 'csv' | 'json') => {
   downloadRecords(events, 'Events', format)
 }
 
-const onCsvDownload = async () => {
-  return onDownload('csv')
+const onCsvDownload = () => {
+  onDownload('csv')
 }
 
-const onJsonDownload = async () => {
-  return onDownload('json')
+const onJsonDownload = () => {
+  onDownload('json')
 }
 
 const onPage = (event: OnmsTablePageEvent) => {

--- a/ui/src/components/Nodes/EventsTable.vue
+++ b/ui/src/components/Nodes/EventsTable.vue
@@ -1,51 +1,84 @@
 <template>
-  <div class="onms-col-12 title headline3">Recent Events</div>
-  <OnmsTable
-    lazy
-    :value="eventStore.events"
-    paginator
-    :rows="pageSize"
-    :first="first"
-    :totalRecords="eventStore.totalCount"
-    :rowsPerPageOptions="[5, 10, 20, 50]"
-    data-test="events-table"
-    @page="onPage"
-  >
-    <OnmsColumn field="id" header="Id">
-      <template #body="{ data }">
-        <router-link :to="`/event/${data.id}`">{{ data.id }}</router-link>
+  <div class="card">
+    <div class="title-row">
+      <div class="title headline3">Recent Events</div>
+      <div class="action-buttons-container">
+        <OnmsIconButton
+          aria-label="Events for this Node"
+          tooltip="Events for this Node"
+          data-test="events-for-node-button"
+          :icon="IconViewDetails"
+          @click="onEventsForNodeClick"
+        />
+        <NodeDownloadDropdown
+          :onCsvDownload="onCsvDownload"
+          :onJsonDownload="onJsonDownload"
+        />
+      </div>
+    </div>
+    <OnmsTable
+      lazy
+      :value="eventStore.events"
+      paginator
+      :rows="pageSize"
+      :first="first"
+      :totalRecords="eventStore.totalCount"
+      :rowsPerPageOptions="[5, 10, 20, 50]"
+      data-test="events-table"
+      @page="onPage"
+    >
+      <OnmsColumn field="id" header="Id">
+        <template #body="{ data }">
+          <router-link :to="`/event/${data.id}`">{{ data.id }}</router-link>
+        </template>
+      </OnmsColumn>
+      <OnmsColumn field="createTime" header="Created">
+        <template #body="{ data }">
+          <span v-date>{{ data.createTime }}</span>
+        </template>
+      </OnmsColumn>
+      <OnmsColumn field="severity" header="Severity">
+        <template #body="{ data }">
+          <OnmsTag :value="data.severity" :severity="severityMap[data.severity?.toLowerCase()] ?? 'secondary'" />
+        </template>
+      </OnmsColumn>
+      <OnmsColumn field="logMessage" header="Message">
+        <template #body="{ data }">
+          <span v-html="data.logMessage" class="log-message" />
+        </template>
+      </OnmsColumn>
+      <template #empty>
+        <EmptyList :content="emptyListContent" data-test="empty-list" />
       </template>
-    </OnmsColumn>
-    <OnmsColumn field="createTime" header="Created">
-      <template #body="{ data }">
-        <span v-date>{{ data.createTime }}</span>
-      </template>
-    </OnmsColumn>
-    <OnmsColumn field="severity" header="Severity">
-      <template #body="{ data }">
-        <OnmsTag :value="data.severity" :severity="severityMap[data.severity?.toLowerCase()] ?? 'secondary'" />
-      </template>
-    </OnmsColumn>
-    <OnmsColumn field="logMessage" header="Message">
-      <template #body="{ data }">
-        <span v-html="data.logMessage" class="log-message" />
-      </template>
-    </OnmsColumn>
-    <template #empty>
-      <EmptyList :content="emptyListContent" data-test="empty-list" />
-    </template>
-  </OnmsTable>
+    </OnmsTable>
+  </div>
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useRoute } from 'vue-router'
-import { OnmsColumn, OnmsTable, OnmsTag, type OnmsTablePageEvent, type OnmsTagSeverity } from '@opennms/onms-ui'
+import { OnmsColumn, OnmsIconButton, OnmsTable, OnmsTag, type OnmsTablePageEvent, type OnmsTagSeverity } from '@opennms/onms-ui'
+import IconViewDetails from '@opennms/onms-ui/icons/action/ViewDetails.vue'
 import EmptyList from '@/components/Common/EmptyList.vue'
+import NodeDownloadDropdown from './NodeDownloadDropdown.vue'
+import useSnackbar from '@/composables/useSnackbar'
 import { useEventStore } from '@/stores/eventStore'
+import { useMenuStore } from '@/stores/menuStore'
+import { useNodeExport } from './hooks/useNodeExport'
+import { Event, ServiceType } from '@/types'
+
+// The legacy event list page, which accepts a node filter.
+// Will need to replace with the Vue page once it's implemented.
+const EVENT_LIST_PATH = 'event/list'
 
 const eventStore = useEventStore()
+const menuStore = useMenuStore()
 const route = useRoute()
+
+const { showSnackBar } = useSnackbar()
+const { generateBlob, generateDownload } = useNodeExport()
+
+const nodeId = computed(() => route.params.id)
 
 const pageSize = ref(5)
 const first = ref(0)
@@ -67,6 +100,88 @@ const queryParameters = ref({
   _s: `node.id==${route.params.id}`
 })
 
+const onEventsForNodeClick = () => {
+  window.location.assign(`${menuStore.mainMenu.baseHref}${EVENT_LIST_PATH}?filter=node%3D${nodeId.value}`)
+}
+
+// The CSV columns are whatever fields the events actually carry, in the order the API returns
+// them, rather than the four the table displays. Taken from the data and not from the Event type,
+// which does not declare every field the API sends (serviceType among them).
+const getCsvColumns = (events: Record<string, unknown>[]) => {
+  const columns: string[] = []
+
+  for (const event of events) {
+    for (const field of Object.keys(event)) {
+      if (!columns.includes(field)) {
+        columns.push(field)
+      }
+    }
+  }
+
+  return columns
+}
+
+// serviceType arrives as an object; its name is the part worth a CSV cell. Anything else
+// non-primitive keeps its JSON form rather than stringifying to '[object Object]'.
+const flattenCsvValue = (field: string, value: unknown) => {
+  if (value === null || value === undefined) {
+    return ''
+  }
+
+  if (field === 'serviceType') {
+    return (value as ServiceType).name ?? ''
+  }
+
+  return typeof value === 'object' ? JSON.stringify(value) : String(value)
+}
+
+// Quote a field only when it needs it, doubling any embedded quote, per RFC 4180. Event log
+// messages carry markup and commas, so unquoted values would break the row apart.
+const toCsvValue = (value: string) =>
+  /[",\r\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value
+
+const buildCsv = (events: Event[]) => {
+  // Read the records as plain field bags: the export covers whatever the API sent, including
+  // the fields Event does not declare.
+  const rows = events as unknown as Record<string, unknown>[]
+  const columns = getCsvColumns(rows)
+
+  return [
+    columns.join(','),
+    ...rows.map(row => columns.map(field => toCsvValue(flattenCsvValue(field, row[field]))).join(','))
+  ].join('\n')
+}
+
+const buildJson = (events: Event[]) => JSON.stringify(events, null, 2)
+
+const onDownload = async (format: 'csv' | 'json') => {
+  // The paginator's current page: its limit/offset are already tracked in queryParameters, so
+  // raising rows-per-page is how a user downloads more than the default 5.
+  const events = await eventStore.getEventsForExport(queryParameters.value)
+
+  if (!events || events.length === 0) {
+    showSnackBar({
+      msg: `No events found for '${format}' download for this node`,
+      error: true
+    })
+
+    return
+  }
+
+  const contentType = format === 'json' ? 'application/json' : 'text/csv'
+  const data = format === 'json' ? buildJson(events) : buildCsv(events)
+
+  generateDownload(generateBlob(data, contentType), `Events.${format}`)
+}
+
+const onCsvDownload = async () => {
+  return onDownload('csv')
+}
+
+const onJsonDownload = async () => {
+  return onDownload('json')
+}
+
 const onPage = (event: OnmsTablePageEvent) => {
   first.value = event.first
   pageSize.value = event.rows
@@ -87,6 +202,29 @@ defineExpose({ onPage })
 </script>
 
 <style lang="scss" scoped>
+.card {
+  background: var(--p-content-background);
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 5px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.08);
+  padding: 15px;
+  margin-bottom: 15px;
+
+  .title-row {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+  }
+
+  .action-buttons-container {
+    display: flex;
+    flex: 1;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.5rem;
+  }
+}
+
 .log-message {
   p {
     margin: 0;

--- a/ui/src/components/Nodes/EventsTable.vue
+++ b/ui/src/components/Nodes/EventsTable.vue
@@ -1,21 +1,18 @@
 <template>
-  <div class="card">
-    <div class="title-row">
-      <div class="title headline3">Recent Events</div>
-      <div class="action-buttons-container">
-        <OnmsIconButton
-          aria-label="Events for this Node"
-          tooltip="Events for this Node"
-          data-test="events-for-node-button"
-          :icon="IconViewDetails"
-          @click="onEventsForNodeClick"
-        />
-        <NodeDownloadDropdown
-          :onCsvDownload="onCsvDownload"
-          :onJsonDownload="onJsonDownload"
-        />
-      </div>
-    </div>
+  <NodeDetailsPanel title="Recent Events">
+    <template #actions>
+      <OnmsIconButton
+        aria-label="Events for this Node"
+        tooltip="Events for this Node"
+        data-test="events-for-node-button"
+        :icon="IconViewDetails"
+        @click="onEventsForNodeClick"
+      />
+      <NodeDownloadDropdown
+        :onCsvDownload="onCsvDownload"
+        :onJsonDownload="onJsonDownload"
+      />
+    </template>
     <OnmsTable
       lazy
       :value="eventStore.events"
@@ -51,7 +48,7 @@
         <EmptyList :content="emptyListContent" data-test="empty-list" />
       </template>
     </OnmsTable>
-  </div>
+  </NodeDetailsPanel>
 </template>
 
 <script setup lang="ts">
@@ -60,6 +57,7 @@ import { useRoute } from 'vue-router'
 import { OnmsColumn, OnmsIconButton, OnmsTable, OnmsTag, type OnmsTablePageEvent, type OnmsTagSeverity } from '@opennms/onms-ui'
 import IconViewDetails from '@opennms/onms-ui/icons/action/ViewDetails.vue'
 import EmptyList from '@/components/Common/EmptyList.vue'
+import NodeDetailsPanel from './NodeDetailsPanel.vue'
 import NodeDownloadDropdown from './NodeDownloadDropdown.vue'
 import useSnackbar from '@/composables/useSnackbar'
 import { useEventStore } from '@/stores/eventStore'
@@ -202,29 +200,6 @@ defineExpose({ onPage })
 </script>
 
 <style lang="scss" scoped>
-.card {
-  background: var(--p-content-background);
-  border: 1px solid var(--p-content-border-color);
-  border-radius: 5px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.08);
-  padding: 15px;
-  margin-bottom: 15px;
-
-  .title-row {
-    display: flex;
-    align-items: center;
-    gap: 5px;
-  }
-
-  .action-buttons-container {
-    display: flex;
-    flex: 1;
-    align-items: center;
-    justify-content: flex-end;
-    gap: 0.5rem;
-  }
-}
-
 .log-message {
   p {
     margin: 0;

--- a/ui/src/components/Nodes/IpInterfacesTable.vue
+++ b/ui/src/components/Nodes/IpInterfacesTable.vue
@@ -27,7 +27,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { OnmsColumn, OnmsTable, type OnmsTablePageEvent } from '@opennms/onms-ui'
 import EmptyList from '@/components/Common/EmptyList.vue'
@@ -36,25 +36,42 @@ import { useNodeStore } from '@/stores/nodeStore'
 const nodeStore = useNodeStore()
 const route = useRoute()
 
-const pageSize = ref(5)
+const nodeId = computed(() => route.params.id as string)
+
+const DEFAULT_PAGE_SIZE = 5
+
+const pageSize = ref(DEFAULT_PAGE_SIZE)
 const first = ref(0)
 const emptyListContent = { msg: 'No results found.' }
 
 const queryParameters = ref({
-  limit: 5,
+  limit: DEFAULT_PAGE_SIZE,
   offset: 0,
   _s: 'isManaged==U,isManaged==P,isManaged==N,isManaged==M'
 })
+
+const fetchInterfaces = () => {
+  nodeStore.getNodeIpInterfaces({ id: nodeId.value, queryParameters: queryParameters.value })
+}
 
 const onPage = (event: OnmsTablePageEvent) => {
   first.value = event.first
   pageSize.value = event.rows
   queryParameters.value = { ...queryParameters.value, offset: event.first, limit: event.rows }
-  nodeStore.getNodeIpInterfaces({ id: route.params.id as string, queryParameters: queryParameters.value })
+  fetchInterfaces()
 }
 
-onMounted(() => {
-  nodeStore.getNodeIpInterfaces({ id: route.params.id as string, queryParameters: queryParameters.value })
+onMounted(fetchInterfaces)
+
+// The details page keeps one instance of this table across node ids, so the id has to be
+// followed rather than read once, or the tab keeps showing the IP interfaces of the node the user
+// navigated away from. Back to the first page, since the page the user was on says nothing
+// about the new node.
+watch(nodeId, () => {
+  first.value = 0
+  pageSize.value = DEFAULT_PAGE_SIZE
+  queryParameters.value = { ...queryParameters.value, offset: 0, limit: DEFAULT_PAGE_SIZE }
+  fetchInterfaces()
 })
 
 defineExpose({ onPage })

--- a/ui/src/components/Nodes/IpInterfacesTable.vue
+++ b/ui/src/components/Nodes/IpInterfacesTable.vue
@@ -69,8 +69,7 @@ onMounted(fetchInterfaces)
 // about the new node.
 watch(nodeId, () => {
   first.value = 0
-  pageSize.value = DEFAULT_PAGE_SIZE
-  queryParameters.value = { ...queryParameters.value, offset: 0, limit: DEFAULT_PAGE_SIZE }
+  queryParameters.value = { ...queryParameters.value, offset: 0 }
   fetchInterfaces()
 })
 

--- a/ui/src/components/Nodes/NodeActionsDropdown.vue
+++ b/ui/src/components/Nodes/NodeActionsDropdown.vue
@@ -31,6 +31,13 @@ const props = defineProps({
     required: true,
     type: Object as PropType<Node>
   },
+  // Supplied by the call site from its interface data; without it the Update SNMP action is
+  // omitted rather than pointed at an address that is not the node's.
+  snmpPrimaryIpAddress: {
+    required: false,
+    type: String,
+    default: undefined
+  },
   triggerNodeInfo: {
     required: false,
     type: Function as PropType<(node: Node) => void>,
@@ -53,7 +60,7 @@ const items = computed<OnmsMenuItem[]>(() => {
   // Status for a node with no building.
   return [
     ...infoItem,
-    ...createLinkItemsList(props.node).map(li => ({
+    ...createLinkItemsList(props.node, { snmpPrimaryIpAddress: props.snmpPrimaryIpAddress }).map(li => ({
       label: li.label,
       command: () => window.location.assign(`${props.baseHref}${li.link}`)
     }))

--- a/ui/src/components/Nodes/NodeActionsDropdown.vue
+++ b/ui/src/components/Nodes/NodeActionsDropdown.vue
@@ -19,6 +19,7 @@
 import MoreVert from '@opennms/onms-ui/icons/navigation/MoreVert.vue'
 import { OnmsIconButton, OnmsMenu, OnmsMenuItem } from '@opennms/onms-ui'
 import { markRaw, computed, ref, PropType } from 'vue'
+import { createLinkItemsList } from './nodeActionLinks'
 import { Node } from '@/types'
 
 const props = defineProps({
@@ -41,23 +42,6 @@ const menuIcon = markRaw(MoreVert)
 const menu = ref()
 const menuId = computed(() => `node-actions-menu-${props.node.id}`)
 
-const linkItems = [
-  { name: 'events', label: 'Events' },
-  { name: 'alarms', label: 'Alarms' },
-  { name: 'view-outages', label: 'Outages' },
-  { name: 'assets', label: 'Assets' },
-  { name: 'metadata', label: 'Metadata' },
-  { name: 'hardware', label: 'Hardware Inventory' },
-  { name: 'availability', label: 'Availability' },
-  { name: 'graphs', label: 'Resource Graphs' },
-  { name: 'rescan', label: 'Node Rescan' },
-  { name: 'admin', label: 'Admin / Node Management' },
-  { name: 'updateSnmp', label: 'Update SNMP Information' },
-  { name: 'schedule-outage', label: 'Schedule an Outage' },
-  { name: 'topology', label: 'View Topology Map' },
-  { name: 'node-link', label: 'Node Link Detailed Info' }
-]
-
 // Info... opens a dialog describing the node, which is redundant on a page already showing it:
 // a call site that omits the handler gets the navigation links alone.
 const items = computed<OnmsMenuItem[]>(() => {
@@ -65,57 +49,19 @@ const items = computed<OnmsMenuItem[]>(() => {
     ? [{ label: 'Info...', command: () => props.triggerNodeInfo?.(props.node) }]
     : []
 
+  // createLinkItemsList drops any link the node cannot supply the data for, such as Site
+  // Status for a node with no building.
   return [
     ...infoItem,
-    ...linkItems.map(li => ({
+    ...createLinkItemsList(props.node).map(li => ({
       label: li.label,
-      command: () => onNodeLink(li.name, props.node)
+      command: () => window.location.assign(`${props.baseHref}${li.link}`)
     }))
   ]
 })
 
 const toggle = (event: Event) => {
   menu.value?.toggle(event)
-}
-
-const onNodeLink = (name: string, node: Node) => {
-  const link = mapLink(name, node)
-  window.location.assign(`${props.baseHref}${link}`)
-}
-
-const mapLink = (name: string, node: Node) => {
-  switch (name) {
-    case 'events':
-      return `event/list?filter=node%3D${node.id}`
-    case 'alarms':
-      return `alarm/list.htm?filter=node%3D${node.id}`
-    case 'view-outages':
-      return `outage/list.htm?filter=node%3D${node.id}`
-    case 'assets':
-      return `asset/modify.jsp?node=${node.id}`
-    case 'metadata':
-      return `element/node-metadata.jsp?node=${node.id}`
-    case 'hardware':
-      return `hardware/list.jsp?node=${node.id}`
-    case 'availability':
-      return `element/availability.jsp?node=${node.id}`
-    case 'graphs':
-      return `graph/chooseresource.jsp?node=${node.id}&reports=all`
-    case 'rescan':
-      return `element/rescan.jsp?node=${node.id}`
-    case 'admin':
-      return `admin/nodemanagement/index.jsp?node=${node.id}`
-    case 'updateSnmp':
-      // TODO: Get IP Address
-      return `admin/updateSnmp.jsp?node=${node.id}&ipaddr=0.0.0.0`
-    case 'schedule-outage':
-      return `admin/sched-outages/editoutage.jsp?newName=${node.label}&addNew=true&nodeID=${node.id}`
-    case 'topology':
-      return `topology?provider=Enhanced+Linkd&szl=1&focus-vertices=${node.id}`
-    case 'node-link':
-      return `element/linkednode.jsp?node=${node.id}`
-    default: return ''
-  }
 }
 
 defineExpose({ items })

--- a/ui/src/components/Nodes/NodeActionsDropdown.vue
+++ b/ui/src/components/Nodes/NodeActionsDropdown.vue
@@ -31,8 +31,9 @@ const props = defineProps({
     type: Object as PropType<Node>
   },
   triggerNodeInfo: {
-    required: true,
-    type: Function as PropType<(node: Node) => void>
+    required: false,
+    type: Function as PropType<(node: Node) => void>,
+    default: undefined
   }
 })
 
@@ -53,16 +54,25 @@ const linkItems = [
   { name: 'admin', label: 'Admin / Node Management' },
   { name: 'updateSnmp', label: 'Update SNMP Information' },
   { name: 'schedule-outage', label: 'Schedule an Outage' },
-  { name: 'topology', label: 'View Topology Map' }
+  { name: 'topology', label: 'View Topology Map' },
+  { name: 'node-link', label: 'Node Link Detailed Info' }
 ]
 
-const items = computed<OnmsMenuItem[]>(() => [
-  { label: 'Info...', command: () => props.triggerNodeInfo(props.node) },
-  ...linkItems.map(li => ({
-    label: li.label,
-    command: () => onNodeLink(li.name, props.node)
-  }))
-])
+// Info... opens a dialog describing the node, which is redundant on a page already showing it:
+// a call site that omits the handler gets the navigation links alone.
+const items = computed<OnmsMenuItem[]>(() => {
+  const infoItem = props.triggerNodeInfo
+    ? [{ label: 'Info...', command: () => props.triggerNodeInfo?.(props.node) }]
+    : []
+
+  return [
+    ...infoItem,
+    ...linkItems.map(li => ({
+      label: li.label,
+      command: () => onNodeLink(li.name, props.node)
+    }))
+  ]
+})
 
 const toggle = (event: Event) => {
   menu.value?.toggle(event)
@@ -102,6 +112,8 @@ const mapLink = (name: string, node: Node) => {
       return `admin/sched-outages/editoutage.jsp?newName=${node.label}&addNew=true&nodeID=${node.id}`
     case 'topology':
       return `topology?provider=Enhanced+Linkd&szl=1&focus-vertices=${node.id}`
+    case 'node-link':
+      return `element/linkednode.jsp?node=${node.id}`
     default: return ''
   }
 }

--- a/ui/src/components/Nodes/NodeAvailabilityGraph.vue
+++ b/ui/src/components/Nodes/NodeAvailabilityGraph.vue
@@ -1,35 +1,62 @@
 <template>
   <div class="card">
-    <div class="title headline3">Availability (last 24 hours)</div>
+    <div class="title headline3">Availability</div>
 
     <div class="flex-container availability-header headline4">
-      <div>Availability</div>
-      <div class="timeline" ref="timeline">{{ Math.round(100 * availability.availability) / 100 }}%</div>
+      <div class="onms-row">
+          <div class="onms-col-12">
+            <div>Availability (last 24 hours)</div>
+        </div>
+      </div>
+      <div class="onms-row">
+        <div class="onms-col-10">
+        </div>
+        <div class="onms-col-2">
+          <div class="timeline" ref="timeline">{{ Math.round(100 * availability.availability) / 100 }}%</div>
+        </div>
+      </div>
     </div>
 
     <template v-for="ipinterface of availability.ipinterfaces" :key="ipinterface.id">
       <div v-if="ipinterface.services.length">
         <hr class="divider" />
-        <div class="flex-container">
-          <div class="service subtitle2">{{ ipinterface.address }}</div>
-          <div>
+        <div class="onms-row">
+          <div class="onms-col-1">
+            XXX
+          </div>
+          <div class="onms-col-3">
+            <div class="subtitle2">{{ ipinterface.address }}</div>
+          </div>
+          <div class="onms-col-6 timeline-header">
             <img
-              :src="`${baseUrl}/opennms/rest/timeline/header/${startTime}/${endTime}/${width}`"
-              :data-imgsrc="`/opennms/rest/timeline/header/${startTime}/${endTime}/`"
+              :src="`${baseHref}rest/timeline/header/${startTime}/${endTime}/${width}`"
+              :data-imgsrc="`${baseHref}rest/timeline/header/${startTime}/${endTime}/`"
             />
+          </div>
+          <div class="onms-col-2">
+            <div class="percentage subtitle2">{{ Math.round(100 * ipinterface.availability) / 100 }}%</div>
           </div>
         </div>
       </div>
 
       <template v-for="service of ipinterface.services" :key="service.name">
-        <div class="flex-container">
-          <div class="service subtitle2">{{ service.name }}</div>
-          <div>
+        <div class="onms-row">
+          <div class="onms-col-1">
+            XXX
+          </div>
+          <div class="onms-col-3">
+            <div class="service subtitle2">
+              <a :href="getServiceLink(ipinterface, service)">{{ service.name }}</a>
+            </div>
+          </div>
+          <div class="onms-col-6">
             <img
-              :src="`${baseUrl}/opennms/rest/timeline/image/${nodeId}/${ipinterface.address}/${service.name}/${startTime}/${endTime}/${width}`"
+              :src="getServiceAvailabilityImageLink(ipinterface, service)"
             />
           </div>
-          <div class="percentage subtitle2">{{ Math.round(100 * service.availability) / 100 }}%</div>
+          <div class="onms-col-2">
+            <div class="percentage subtitle2">{{ Math.round(100 * service.availability) / 100 }}%</div>
+          </div>
         </div>
       </template>
     </template>
@@ -37,36 +64,71 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from 'vue'
-import { useRoute } from 'vue-router'
+import { computed, onMounted, onUnmounted, ref, PropType, watch } from 'vue'
+import { useNodeStore } from '@/stores/nodeStore'
+import { useNodeListStore } from '@/stores/nodeListStore'
 
 import { debounce } from 'lodash'
 import { sub, getUnixTime } from 'date-fns'
-import { useNodeStore } from '@/stores/nodeStore'
+import { Node } from '@/types'
 
-const baseUrl = ref(import.meta.env.VITE_BASE_URL || '')
+const props = defineProps({
+  baseHref: {
+    required: true,
+    type: String
+  },
+  node: {
+    required: true,
+    type: Object as PropType<Node>
+  }
+})
+
+// const baseUrl = ref(import.meta.env.VITE_BASE_URL || '')
 const nodeStore = useNodeStore()
-const route = useRoute()
-const nodeId = ref(route.params.id as string)
+const nodeListStore = useNodeListStore()
 const now = new Date()
 const startTime = ref(getUnixTime(sub(now, { days: 1 })))
 const endTime = ref(getUnixTime(now))
-const width = ref(200)
+// const width = ref(200)
+const width = ref(400)
 const timeline = ref<any>(null)
+
 const recalculateWidth = debounce(() => {
   if (!timeline.value) {
     return
   }
-  width.value = timeline.value.clientWidth - 60
-}, 100)
+  // width.value = timeline.value.clientWidth - 60
+  // width.value = Math.max(timeline.value.clientWidth - 60, 300)
+  width.value = 400
+}, 500)
+
+const availability = computed(() => nodeStore.availability)
+
+const getServiceLink = (ipinterface: any, service: any) => {
+  const serviceId = nodeListStore.getServiceTypeByName(service.name)?.id
+  if (!serviceId) {
+    return '#'
+  }
+  return `${props.baseHref}element/service.jsp?node=${props.node.id}&intf=${encodeURIComponent(ipinterface.address)}&service=${serviceId}`
+}
+
+const getServiceAvailabilityImageLink = (ipinterface: any, service: any) => {
+  const serviceId = nodeListStore.getServiceTypeByName(service.name)?.id
+  if (!serviceId) {
+    return '#'
+  }
+
+  return `${props.baseHref}rest/timeline/image/${props.node.id}/${ipinterface.address}/${serviceId}/${startTime.value}/${endTime.value}/${width.value}`
+}
+
+watch([() => props.node?.id], () => {
+  nodeStore.getNodeAvailabilityPercentage(props.node.id)
+})
 
 onMounted(async () => {
-  nodeStore.getNodeAvailabilityPercentage(nodeId.value)
   recalculateWidth()
   window.addEventListener('resize', recalculateWidth)
 })
-
-const availability = computed(() => nodeStore.availability)
 
 onUnmounted(() => {
   recalculateWidth.cancel()
@@ -82,6 +144,7 @@ onUnmounted(() => {
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.08);
   padding: 15px;
   margin-bottom: 15px;
+
   .title {
     padding: 5px 10px 0px 10px;
   }
@@ -90,19 +153,28 @@ onUnmounted(() => {
   min-width: 103px;
   margin-left: 8px;
 }
+
 .timeline {
   flex-grow: 1;
   text-align: end;
 }
+
+.timeline-header {
+  background-color: lightgray;
+}
+
 .availability-header {
   padding: 0px 0px 0px 10px;
 }
+
 .percentage {
   margin-left: 3px;
 }
+
 .divider {
   width: 98%;
 }
+
 .flex-container {
   padding: 0;
   margin: 0;

--- a/ui/src/components/Nodes/NodeAvailabilityGraph.vue
+++ b/ui/src/components/Nodes/NodeAvailabilityGraph.vue
@@ -144,10 +144,6 @@ onUnmounted(() => {
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.08);
   padding: 15px;
   margin-bottom: 15px;
-
-  .title {
-    padding: 5px 10px 0px 10px;
-  }
 }
 .service {
   min-width: 103px;

--- a/ui/src/components/Nodes/NodeAvailabilityGraph.vue
+++ b/ui/src/components/Nodes/NodeAvailabilityGraph.vue
@@ -12,7 +12,7 @@
         <div class="onms-col-10">
         </div>
         <div class="onms-col-2">
-          <div class="timeline" ref="timeline">{{ Math.round(100 * availability.availability) / 100 }}%</div>
+          <div class="timeline">{{ Math.round(100 * availability.availability) / 100 }}%</div>
         </div>
       </div>
     </div>
@@ -29,7 +29,7 @@
           </div>
           <div class="onms-col-6 timeline-header">
             <img
-              :src="`${baseHref}rest/timeline/header/${startTime}/${endTime}/${width}`"
+              :src="`${baseHref}rest/timeline/header/${startTime}/${endTime}/${TIMELINE_WIDTH}`"
               :data-imgsrc="`${baseHref}rest/timeline/header/${startTime}/${endTime}/`"
             />
           </div>
@@ -64,11 +64,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, PropType, watch } from 'vue'
+import { computed, ref, PropType, watch } from 'vue'
 import { useNodeStore } from '@/stores/nodeStore'
 import { useNodeListStore } from '@/stores/nodeListStore'
 
-import { debounce } from 'lodash'
 import { sub, getUnixTime } from 'date-fns'
 import { Node } from '@/types'
 
@@ -83,24 +82,15 @@ const props = defineProps({
   }
 })
 
-// const baseUrl = ref(import.meta.env.VITE_BASE_URL || '')
 const nodeStore = useNodeStore()
 const nodeListStore = useNodeListStore()
 const now = new Date()
 const startTime = ref(getUnixTime(sub(now, { days: 1 })))
 const endTime = ref(getUnixTime(now))
-// const width = ref(200)
-const width = ref(400)
-const timeline = ref<any>(null)
 
-const recalculateWidth = debounce(() => {
-  if (!timeline.value) {
-    return
-  }
-  // width.value = timeline.value.clientWidth - 60
-  // width.value = Math.max(timeline.value.clientWidth - 60, 300)
-  width.value = 400
-}, 500)
+// Width the timeline strips are requested at. Fixed for now; sizing them to the panel is part
+// of the rework this panel is due.
+const TIMELINE_WIDTH = 400
 
 const availability = computed(() => nodeStore.availability)
 
@@ -118,22 +108,21 @@ const getServiceAvailabilityImageLink = (ipinterface: any, service: any) => {
     return '#'
   }
 
-  return `${props.baseHref}rest/timeline/image/${props.node.id}/${ipinterface.address}/${serviceId}/${startTime.value}/${endTime.value}/${width.value}`
+  // The address is a path segment here, so it has to be encoded: a scope-qualified IPv6
+  // address (fe80::1%eth0) would otherwise leave a bare % and an invalid escape.
+  return `${props.baseHref}rest/timeline/image/${props.node.id}/${encodeURIComponent(ipinterface.address)}/${serviceId}/${startTime.value}/${endTime.value}/${TIMELINE_WIDTH}`
 }
 
-watch([() => props.node?.id], () => {
-  nodeStore.getNodeAvailabilityPercentage(props.node.id)
-})
+// immediate, because the details page keeps one instance of this panel across node ids and the
+// node store is never reset: on a return visit to the same node nothing changes, so a
+// change-only watch would leave the availability from the last fetch -- or none at all.
+watch(() => props.node?.id, (id) => {
+  if (!id) {
+    return
+  }
 
-onMounted(async () => {
-  recalculateWidth()
-  window.addEventListener('resize', recalculateWidth)
-})
-
-onUnmounted(() => {
-  recalculateWidth.cancel()
-  window.removeEventListener('resize', recalculateWidth)
-})
+  nodeStore.getNodeAvailabilityPercentage(id)
+}, { immediate: true })
 </script>
 
 <style lang="scss" scoped>

--- a/ui/src/components/Nodes/NodeAvailabilityGraph.vue
+++ b/ui/src/components/Nodes/NodeAvailabilityGraph.vue
@@ -1,7 +1,5 @@
 <template>
-  <div class="card">
-    <div class="title headline3">Availability</div>
-
+  <NodeDetailsPanel title="Availability">
     <div class="flex-container availability-header headline4">
       <div class="onms-row">
           <div class="onms-col-12">
@@ -60,11 +58,12 @@
         </div>
       </template>
     </template>
-  </div>
+  </NodeDetailsPanel>
 </template>
 
 <script setup lang="ts">
 import { computed, ref, PropType, watch } from 'vue'
+import NodeDetailsPanel from './NodeDetailsPanel.vue'
 import { useNodeStore } from '@/stores/nodeStore'
 import { useNodeListStore } from '@/stores/nodeListStore'
 
@@ -126,14 +125,6 @@ watch(() => props.node?.id, (id) => {
 </script>
 
 <style lang="scss" scoped>
-.card {
-  background: var(--p-content-background);
-  border: 1px solid var(--p-content-border-color);
-  border-radius: 5px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.08);
-  padding: 15px;
-  margin-bottom: 15px;
-}
 .service {
   min-width: 103px;
   margin-left: 8px;

--- a/ui/src/components/Nodes/NodeCategoriesPanel.vue
+++ b/ui/src/components/Nodes/NodeCategoriesPanel.vue
@@ -1,0 +1,66 @@
+<template>
+  <div class="card">
+    <div class="title headline3">Surveillance Category Memberships</div>
+    <OnmsIconButton
+      v-if="adminRole"
+      text
+      aria-label="Edit"
+      data-test="edit-button"
+      :icon="IconEdit"
+      @click="onEditClick"
+    />
+    <div class="onms-row" v-if="props.node?.categories?.length === 0">
+      <div class="onms-col-12">
+        <span class="attribute-value">This node is not a member of any categories.</span>
+      </div>
+    </div>
+    <div class="onms-row" v-for="item in props.node?.categories" :key="item.id">
+      <div class="onms-col-12">
+        <span class="attribute-value">{{ item.name }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { PropType } from 'vue'
+import { OnmsIconButton } from '@opennms/onms-ui'
+import IconEdit from '@opennms/onms-ui/icons/action/Edit.vue'
+import useRole from '@/composables/useRole'
+import { Node } from '@/types'
+
+const props = defineProps({
+  baseHref: {
+    required: true,
+    type: String
+  },
+  node: {
+    required: true,
+    type: Object as PropType<Node>
+  }
+})
+
+const { adminRole } = useRole()
+
+const onEditClick = () => {
+  if (adminRole.value) {
+    const editUrl = `${props.baseHref}/admin/categories.htm?edit&node=${props.node.id}`
+    window.location.assign(editUrl)
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.card {
+  background: var(--p-content-background);
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 5px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.08);
+  padding: 15px;
+  margin-bottom: 15px;
+
+  .title {
+    padding: 5px 10px 0px 10px;
+  }
+}
+</style>

--- a/ui/src/components/Nodes/NodeCategoriesPanel.vue
+++ b/ui/src/components/Nodes/NodeCategoriesPanel.vue
@@ -46,7 +46,7 @@ const { adminRole } = useRole()
 
 const onEditClick = () => {
   if (adminRole.value) {
-    const editUrl = `${props.baseHref}/admin/categories.htm?edit&node=${props.node.id}`
+    const editUrl = `${props.baseHref}admin/categories.htm?edit&node=${props.node.id}`
     window.location.assign(editUrl)
   }
 }

--- a/ui/src/components/Nodes/NodeCategoriesPanel.vue
+++ b/ui/src/components/Nodes/NodeCategoriesPanel.vue
@@ -1,16 +1,14 @@
 <template>
-  <div class="card">
-    <div class="title-row">
-      <div class="title headline3">Surveillance Category Memberships</div>
+  <NodeDetailsPanel title="Surveillance Category Memberships">
+    <template v-if="adminRole" #actions>
       <OnmsIconButton
-        v-if="adminRole"
         aria-label="Edit"
         tooltip="Edit"
         data-test="edit-button"
         :icon="IconEdit"
         @click="onEditClick"
       />
-    </div>
+    </template>
     <div class="onms-row" v-if="props.node?.categories?.length === 0">
       <div class="onms-col-12">
         <span class="attribute-value">This node is not a member of any categories.</span>
@@ -21,13 +19,14 @@
         <span class="attribute-value">{{ item.name }}</span>
       </div>
     </div>
-  </div>
+  </NodeDetailsPanel>
 </template>
 
 <script setup lang="ts">
 import { PropType } from 'vue'
 import { OnmsIconButton } from '@opennms/onms-ui'
 import IconEdit from '@opennms/onms-ui/icons/action/Edit.vue'
+import NodeDetailsPanel from './NodeDetailsPanel.vue'
 import useRole from '@/composables/useRole'
 import { Node } from '@/types'
 
@@ -51,20 +50,3 @@ const onEditClick = () => {
   }
 }
 </script>
-
-<style lang="scss" scoped>
-.card {
-  background: var(--p-content-background);
-  border: 1px solid var(--p-content-border-color);
-  border-radius: 5px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.08);
-  padding: 15px;
-  margin-bottom: 15px;
-
-  .title-row {
-    display: flex;
-    align-items: center;
-    gap: 5px;
-  }
-}
-</style>

--- a/ui/src/components/Nodes/NodeCategoriesPanel.vue
+++ b/ui/src/components/Nodes/NodeCategoriesPanel.vue
@@ -1,14 +1,16 @@
 <template>
   <div class="card">
-    <div class="title headline3">Surveillance Category Memberships</div>
-    <OnmsIconButton
-      v-if="adminRole"
-      text
-      aria-label="Edit"
-      data-test="edit-button"
-      :icon="IconEdit"
-      @click="onEditClick"
-    />
+    <div class="title-row">
+      <div class="title headline3">Surveillance Category Memberships</div>
+      <OnmsIconButton
+        v-if="adminRole"
+        aria-label="Edit"
+        tooltip="Edit"
+        data-test="edit-button"
+        :icon="IconEdit"
+        @click="onEditClick"
+      />
+    </div>
     <div class="onms-row" v-if="props.node?.categories?.length === 0">
       <div class="onms-col-12">
         <span class="attribute-value">This node is not a member of any categories.</span>
@@ -59,8 +61,10 @@ const onEditClick = () => {
   padding: 15px;
   margin-bottom: 15px;
 
-  .title {
-    padding: 5px 10px 0px 10px;
+  .title-row {
+    display: flex;
+    align-items: center;
+    gap: 5px;
   }
 }
 </style>

--- a/ui/src/components/Nodes/NodeDetailsHeader.vue
+++ b/ui/src/components/Nodes/NodeDetailsHeader.vue
@@ -1,0 +1,86 @@
+<template>
+  <div class="card">
+      <div class="node-badge-wrapper">
+        <OnmsMenu :model="menuItems" class="node-details-header" />
+      </div>
+      <div class="node-badge-wrapper">
+        <OnmsTag class="node-chip" :value="`Status: ${nodeStatus}`" :severity="nodeSeverity" />
+      </div>
+      <div class="node-badge-wrapper">
+        <OnmsTag class="node-chip" :value="`Label: ${props.node?.label}`" severity="info" />
+      </div>
+      <div class="node-badge-wrapper">
+        <OnmsTag class="node-chip" :value="`ID: ${props.node?.id}`" severity="info" />
+      </div>
+      <div class="node-badge-wrapper">
+        <OnmsTag class="node-chip" :value="`Monitoring Location: ${props.node?.location}`" severity="info" />
+      </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, PropType } from 'vue'
+import { OnmsMenu, OnmsTag, OnmsTagSeverity } from '@opennms/onms-ui'
+
+import { createLinkItemsList } from './nodeActionLinks'
+import { Node } from '@/types'
+import { getNodeStatusString } from './utils'
+
+const props = defineProps({
+  baseHref: {
+    required: true,
+    type: String
+  },
+  node: {
+    required: true,
+    type: Object as PropType<Node>
+  }
+})
+
+const menuItems = computed((): any[] => {
+  const linkItemsList = createLinkItemsList(props.node)
+
+  const links = linkItemsList
+    .map(li => ({
+      label: li.label,
+      command: () => window.location.assign(`${props.baseHref}${li.link}`)
+    }))
+
+  return [
+    {
+      label: 'Actions',
+      items: links
+    }
+  ]
+})
+
+const nodeStatus = computed(() => {
+  return getNodeStatusString(props.node)
+})
+
+const nodeSeverity = computed(() => {
+  const status = nodeStatus.value
+
+  if (status === 'Deleted') {
+    return 'danger' as OnmsTagSeverity
+  } else if (status === 'Unknown') {
+    return 'danger' as OnmsTagSeverity
+  } else if (status === 'Active') {
+    return 'danger' as OnmsTagSeverity
+  } else {
+    return 'danger' as OnmsTagSeverity
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.card {
+  padding: 1rem;
+  margin-bottom: 1rem;
+
+  .node-badge-wrapper {
+    display: inline-block;
+    margin-right: 0.5rem;
+  }
+}
+</style>

--- a/ui/src/components/Nodes/NodeDetailsHeader.vue
+++ b/ui/src/components/Nodes/NodeDetailsHeader.vue
@@ -1,9 +1,6 @@
 <template>
   <div class="card">
       <div class="node-badge-wrapper">
-        <OnmsMenu :model="menuItems" class="node-details-header" />
-      </div>
-      <div class="node-badge-wrapper">
         <OnmsTag class="node-chip" :value="`Status: ${nodeStatus}`" :severity="nodeSeverity" />
       </div>
       <div class="node-badge-wrapper">
@@ -20,38 +17,16 @@
 
 <script setup lang="ts">
 import { computed, PropType } from 'vue'
-import { OnmsMenu, OnmsTag, OnmsTagSeverity } from '@opennms/onms-ui'
+import { OnmsTag, OnmsTagSeverity } from '@opennms/onms-ui'
 
-import { createLinkItemsList } from './nodeActionLinks'
 import { Node } from '@/types'
 import { getNodeStatusString } from './utils'
 
 const props = defineProps({
-  baseHref: {
-    required: true,
-    type: String
-  },
   node: {
     required: true,
     type: Object as PropType<Node>
   }
-})
-
-const menuItems = computed((): any[] => {
-  const linkItemsList = createLinkItemsList(props.node)
-
-  const links = linkItemsList
-    .map(li => ({
-      label: li.label,
-      command: () => window.location.assign(`${props.baseHref}${li.link}`)
-    }))
-
-  return [
-    {
-      label: 'Actions',
-      items: links
-    }
-  ]
 })
 
 const nodeStatus = computed(() => {

--- a/ui/src/components/Nodes/NodeDetailsHeader.vue
+++ b/ui/src/components/Nodes/NodeDetailsHeader.vue
@@ -33,19 +33,15 @@ const nodeStatus = computed(() => {
   return getNodeStatusString(props.node)
 })
 
-const nodeSeverity = computed(() => {
-  const status = nodeStatus.value
+// getNodeStatusString only ever returns these three, but anything it does not recognise reads
+// as unknown rather than as a problem.
+const SEVERITY_BY_STATUS: Record<string, OnmsTagSeverity> = {
+  Active: 'success',
+  Deleted: 'danger',
+  Unknown: 'info'
+}
 
-  if (status === 'Deleted') {
-    return 'danger' as OnmsTagSeverity
-  } else if (status === 'Unknown') {
-    return 'danger' as OnmsTagSeverity
-  } else if (status === 'Active') {
-    return 'danger' as OnmsTagSeverity
-  } else {
-    return 'danger' as OnmsTagSeverity
-  }
-})
+const nodeSeverity = computed<OnmsTagSeverity>(() => SEVERITY_BY_STATUS[nodeStatus.value] ?? 'info')
 </script>
 
 <style lang="scss" scoped>

--- a/ui/src/components/Nodes/NodeDetailsPanel.vue
+++ b/ui/src/components/Nodes/NodeDetailsPanel.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="card">
+    <div class="title-row">
+      <div class="title headline3">{{ title }}</div>
+      <div v-if="$slots.actions" class="action-buttons-container">
+        <slot name="actions" />
+      </div>
+    </div>
+    <slot />
+  </div>
+</template>
+
+<script setup lang="ts">
+// The card shell shared by the Node Details panels: a title, an optional row of right-aligned
+// action buttons beside it, and the panel body. Scoped to components/Nodes for now; promoting
+// icon-button actions into OnmsCard itself is a separate piece of work.
+defineProps<{
+  title: string
+}>()
+</script>
+
+<style lang="scss" scoped>
+.card {
+  background: var(--p-content-background);
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 5px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.08);
+  padding: 15px;
+  margin-bottom: 15px;
+
+  .title-row {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+  }
+
+  .action-buttons-container {
+    display: flex;
+    flex: 1;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.5rem;
+  }
+}
+</style>

--- a/ui/src/components/Nodes/NodeNotificationsPanel.vue
+++ b/ui/src/components/Nodes/NodeNotificationsPanel.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="card">
+    <div class="title headline3">Notifications</div>
+    <OnmsIconButton
+      text
+      aria-label="Edit"
+      data-test="edit-button"
+      :icon="IconLink"
+      @click="onLinkClick"
+    />
+
+    <div class="onms-row">
+      <div class="onms-col-12">
+        <span class="attribute-value">Stuff goes here.</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { PropType } from 'vue'
+import { OnmsIconButton } from '@opennms/onms-ui'
+import IconLink from '@opennms/onms-ui/icons/action/Link.vue'
+import useRole from '@/composables/useRole'
+import { Node } from '@/types'
+
+const props = defineProps({
+  baseHref: {
+    required: true,
+    type: String
+  },
+  node: {
+    required: true,
+    type: Object as PropType<Node>
+  }
+})
+
+const { adminRole } = useRole()
+
+const onLinkClick = () => {
+  if (adminRole.value) {
+    const linkUrl = `${props.baseHref}/notifications/index.jsp`
+    window.location.assign(linkUrl)
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.card {
+  background: var(--p-content-background);
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 5px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.08);
+  padding: 15px;
+  margin-bottom: 15px;
+
+  .title {
+    padding: 5px 10px 0px 10px;
+  }
+}
+</style>

--- a/ui/src/components/Nodes/NodeNotificationsPanel.vue
+++ b/ui/src/components/Nodes/NodeNotificationsPanel.vue
@@ -53,9 +53,5 @@ const onLinkClick = () => {
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.08);
   padding: 15px;
   margin-bottom: 15px;
-
-  .title {
-    padding: 5px 10px 0px 10px;
-  }
 }
 </style>

--- a/ui/src/components/Nodes/NodeNotificationsPanel.vue
+++ b/ui/src/components/Nodes/NodeNotificationsPanel.vue
@@ -1,7 +1,6 @@
 <template>
-  <div class="card">
-    <div class="title-row">
-      <div class="title headline3">Notifications</div>
+  <NodeDetailsPanel title="Notifications">
+    <template #actions>
       <OnmsIconButton
         aria-label="View Notifications"
         tooltip="View Notifications"
@@ -9,7 +8,7 @@
         :icon="IconViewDetails"
         @click="onLinkClick"
       />
-    </div>
+    </template>
     <div class="onms-row" v-for="link in links" :key="link.dataTest">
       <div class="onms-col-12">
         <a
@@ -18,13 +17,14 @@
         >{{ link.label }}</a>
       </div>
     </div>
-  </div>
+  </NodeDetailsPanel>
 </template>
 
 <script setup lang="ts">
 import { PropType, computed } from 'vue'
 import { OnmsIconButton } from '@opennms/onms-ui'
 import IconViewDetails from '@opennms/onms-ui/icons/action/ViewDetails.vue'
+import NodeDetailsPanel from './NodeDetailsPanel.vue'
 import { useMenuStore } from '@/stores/menuStore'
 import { Node } from '@/types'
 
@@ -82,20 +82,3 @@ const onLinkClick = () => {
   window.location.assign(`${props.baseHref}${NOTIFICATION_INDEX_PATH}`)
 }
 </script>
-
-<style lang="scss" scoped>
-.card {
-  background: var(--p-content-background);
-  border: 1px solid var(--p-content-border-color);
-  border-radius: 5px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.08);
-  padding: 15px;
-  margin-bottom: 15px;
-
-  .title-row {
-    display: flex;
-    align-items: center;
-    gap: 5px;
-  }
-}
-</style>

--- a/ui/src/components/Nodes/NodeNotificationsPanel.vue
+++ b/ui/src/components/Nodes/NodeNotificationsPanel.vue
@@ -1,28 +1,40 @@
 <template>
   <div class="card">
-    <div class="title headline3">Notifications</div>
-    <OnmsIconButton
-      text
-      aria-label="Edit"
-      data-test="edit-button"
-      :icon="IconLink"
-      @click="onLinkClick"
-    />
-
-    <div class="onms-row">
+    <div class="title-row">
+      <div class="title headline3">Notifications</div>
+      <OnmsIconButton
+        aria-label="View Notifications"
+        tooltip="View Notifications"
+        data-test="notifications-link-button"
+        :icon="IconViewDetails"
+        @click="onLinkClick"
+      />
+    </div>
+    <div class="onms-row" v-for="link in links" :key="link.dataTest">
       <div class="onms-col-12">
-        <span class="attribute-value">Stuff goes here.</span>
+        <a
+          :data-test="link.dataTest"
+          :href="link.href"
+        >{{ link.label }}</a>
       </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { PropType } from 'vue'
+import { PropType, computed } from 'vue'
 import { OnmsIconButton } from '@opennms/onms-ui'
-import IconLink from '@opennms/onms-ui/icons/action/Link.vue'
-import useRole from '@/composables/useRole'
+import IconViewDetails from '@opennms/onms-ui/icons/action/ViewDetails.vue'
+import { useMenuStore } from '@/stores/menuStore'
 import { Node } from '@/types'
+
+// Link to the legacy notification browse page which accept query parameters.
+// Will need to replace with Vue page once it's implemented.
+const NOTIFICATION_BROWSE_PATH = 'notification/browse'
+
+// Link to the legacy notification main page.
+// Will need to replace with Vue page once it's implemented.
+const NOTIFICATION_INDEX_PATH = 'notification/index.jsp'
 
 const props = defineProps({
   baseHref: {
@@ -35,13 +47,39 @@ const props = defineProps({
   }
 })
 
-const { adminRole } = useRole()
+const menuStore = useMenuStore()
+
+const username = computed<string>(() => menuStore.mainMenu.username)
+
+const userFilter = computed<string>(() => `&filter=${encodeURIComponent(`user=${username.value}`)}`)
+
+const nodeFilter = computed<string>(() => `&filter=${encodeURIComponent(`node=${props.node.id}`)}`)
+
+const browseLink = (ackType: 'ack' | 'unack') =>
+  `${props.baseHref}${NOTIFICATION_BROWSE_PATH}?acktype=${ackType}${nodeFilter.value}${userFilter.value}`
+
+// Don't display links if the username is not yet available.
+const links = computed(() => {
+  if (!username.value) {
+    return []
+  }
+
+  return [
+    {
+      dataTest: 'outstanding-notifications-link',
+      label: 'Your outstanding notifications for this node',
+      href: browseLink('unack')
+    },
+    {
+      dataTest: 'acknowledged-notifications-link',
+      label: 'Your acknowledged notifications for this node',
+      href: browseLink('ack')
+    }
+  ]
+})
 
 const onLinkClick = () => {
-  if (adminRole.value) {
-    const linkUrl = `${props.baseHref}/notifications/index.jsp`
-    window.location.assign(linkUrl)
-  }
+  window.location.assign(`${props.baseHref}${NOTIFICATION_INDEX_PATH}`)
 }
 </script>
 
@@ -53,5 +91,11 @@ const onLinkClick = () => {
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.08);
   padding: 15px;
   margin-bottom: 15px;
+
+  .title-row {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+  }
 }
 </style>

--- a/ui/src/components/Nodes/NodeSnmpAttributes.vue
+++ b/ui/src/components/Nodes/NodeSnmpAttributes.vue
@@ -1,0 +1,71 @@
+<template>
+  <div class="card">
+    <div class="title headline3">SNMP Attributes</div>
+    <div class="onms-row" v-for="item in items" :key="item.label">
+      <div class="onms-col-3">
+        <span class="attribute-label">{{ item.label }}:</span>
+      </div>
+      <div class="onms-col-9">
+        <span class="attribute-value">{{ item.value }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, PropType } from 'vue'
+import { Node } from '@/types'
+
+const props = defineProps({
+  node: {
+    required: true,
+    type: Object as PropType<Node>
+  }
+})
+
+const items = computed(() => [
+  {
+    label: 'Name',
+    value: props.node?.sysName || 'N/A'
+  },
+  {
+    label: 'Sys Object ID',
+    value: props.node?.sysObjectId || 'N/A'
+  },
+  {
+    label: 'Sys Location',
+    value: props.node?.sysLocation || 'N/A'
+  },
+  {
+    label: 'Contact',
+    value: props.node?.sysContact || 'N/A'
+  },
+  {
+    label: 'Description',
+    value: props.node?.sysDescription || 'N/A'
+  }
+])
+</script>
+
+<style lang="scss" scoped>
+
+.card {
+  background: var(--p-content-background);
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 5px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.08);
+  padding: 15px;
+  margin-bottom: 15px;
+
+  .title {
+    padding: 5px 10px 0px 10px;
+  }
+
+  .attribute-label {
+    font-weight: bold;
+  }
+
+  // .attribute-value {
+  // }
+}
+</style>

--- a/ui/src/components/Nodes/NodeSnmpAttributes.vue
+++ b/ui/src/components/Nodes/NodeSnmpAttributes.vue
@@ -57,15 +57,8 @@ const items = computed(() => [
   padding: 15px;
   margin-bottom: 15px;
 
-  .title {
-    padding: 5px 10px 0px 10px;
-  }
-
   .attribute-label {
     font-weight: bold;
   }
-
-  // .attribute-value {
-  // }
 }
 </style>

--- a/ui/src/components/Nodes/NodeSnmpAttributes.vue
+++ b/ui/src/components/Nodes/NodeSnmpAttributes.vue
@@ -1,6 +1,5 @@
 <template>
-  <div class="card">
-    <div class="title headline3">SNMP Attributes</div>
+  <NodeDetailsPanel title="SNMP Attributes">
     <div class="onms-row" v-for="item in items" :key="item.label">
       <div class="onms-col-3">
         <span class="attribute-label">{{ item.label }}:</span>
@@ -9,11 +8,12 @@
         <span class="attribute-value">{{ item.value }}</span>
       </div>
     </div>
-  </div>
+  </NodeDetailsPanel>
 </template>
 
 <script setup lang="ts">
 import { computed, PropType } from 'vue'
+import NodeDetailsPanel from './NodeDetailsPanel.vue'
 import { Node } from '@/types'
 
 const props = defineProps({
@@ -48,17 +48,7 @@ const items = computed(() => [
 </script>
 
 <style lang="scss" scoped>
-
-.card {
-  background: var(--p-content-background);
-  border: 1px solid var(--p-content-border-color);
-  border-radius: 5px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.08);
-  padding: 15px;
-  margin-bottom: 15px;
-
-  .attribute-label {
-    font-weight: bold;
-  }
+.attribute-label {
+  font-weight: bold;
 }
 </style>

--- a/ui/src/components/Nodes/NodesTable.vue
+++ b/ui/src/components/Nodes/NodesTable.vue
@@ -239,6 +239,7 @@
                 <NodeActionsDropdown
                   :baseHref="mainMenu.baseHref"
                   :node="data"
+                  :snmpPrimaryIpAddress="snmpPrimaryIpAddressFor(data.id)"
                   :triggerNodeInfo="onNodeInfo"
                   class="triple-icon"
                 />
@@ -342,6 +343,7 @@ import ColumnSelectionDrawer from './ColumnSelectionDrawer.vue'
 import FlowTooltipCell from './FlowTooltipCell.vue'
 import ManagementIPTooltipCell from './ManagementIPTooltipCell.vue'
 import NodeActionsDropdown from './NodeActionsDropdown.vue'
+import { getSnmpPrimaryIpAddress } from './nodeActionLinks'
 import NodeAdvancedFiltersDrawer from './NodeAdvancedFiltersDrawer.vue'
 import NodeDetailsDialog from './NodeDetailsDialog.vue'
 import NodeDownloadDropdown from './NodeDownloadDropdown.vue'
@@ -464,6 +466,11 @@ const onNodeInfo = (node: Node) => {
   dialogNode.value = node
   dialogVisible.value = true
 }
+
+// The node payload carries no interfaces, so the Update SNMP action's address comes from the
+// interfaces already fetched for the list.
+const snmpPrimaryIpAddressFor = (nodeId: string) =>
+  getSnmpPrimaryIpAddress(nodeStore.nodeToIpInterfaceMap.get(nodeId) ?? [])
 
 const computeNodeLink = (nodeId: number | string) => {
   return `${mainMenu.value.baseHref}${mainMenu.value.baseNodeUrl}${nodeId}`

--- a/ui/src/components/Nodes/NodesTable.vue
+++ b/ui/src/components/Nodes/NodesTable.vue
@@ -307,20 +307,7 @@
 </template>
 
 <script setup lang="ts">
-import useSnackbar from '@/composables/useSnackbar'
-import { useMenuStore } from '@/stores/menuStore'
-import { useNodeStore } from '@/stores/nodeStore'
-import { useNodeListStore } from '@/stores/nodeListStore'
-import {
-  ExtendedSearchValue,
-  FilterTypeEnum,
-  Node,
-  NodeColumnSelectionItem,
-  QueryParameters,
-  UpdateModelFunction
-} from '@/types'
-import { MainMenu } from '@/types/mainMenu'
-import { IAutocompleteItemType } from '@/types'
+import { computed, nextTick, ref, watch } from 'vue'
 import {
   OnmsButton,
   OnmsChip,
@@ -333,31 +320,43 @@ import {
   type OnmsTableSortEvent
 } from '@opennms/onms-ui'
 import FilterAlt from '@opennms/onms-ui/icons/action/FilterAlt.vue'
-import ViewDetails from '@opennms/onms-ui/icons/action/ViewDetails.vue'
 import InfoIcon from '@opennms/onms-ui/icons/action/Info.vue'
-import RowExpandedIcon from '@opennms/onms-ui/icons/navigation/ExpandMore.vue'
+import ViewDetails from '@opennms/onms-ui/icons/action/ViewDetails.vue'
 import RowCollapsedIcon from '@opennms/onms-ui/icons/navigation/ChevronRight.vue'
-import { SORT } from '@/types'
-import { computed, nextTick, ref, watch } from 'vue'
+import RowExpandedIcon from '@opennms/onms-ui/icons/navigation/ExpandMore.vue'
+import useSnackbar from '@/composables/useSnackbar'
+import { useMenuStore } from '@/stores/menuStore'
+import { useNodeListStore } from '@/stores/nodeListStore'
+import { useNodeStore } from '@/stores/nodeStore'
+import {
+  ExtendedSearchValue,
+  FilterTypeEnum,
+  IAutocompleteItemType,
+  Node,
+  NodeColumnSelectionItem,
+  QueryParameters,
+  SORT,
+  UpdateModelFunction
+} from '@/types'
+import { MainMenu } from '@/types/mainMenu'
+import {
+  countInterfaceRowsForNode,
+  getInterfaceListMode
+} from './hooks/useInterfaceListing'
+import { useNodeExport } from './hooks/useNodeExport'
+import { useNodeQuery } from './hooks/useNodeQuery'
+import { getAssetColumnLabel } from './hooks/queryStringParser'
+import { getSnmpPrimaryIpAddress } from './nodeActionLinks'
+import { buildSnmpNarrowing } from './utils'
 import ColumnSelectionDrawer from './ColumnSelectionDrawer.vue'
 import FlowTooltipCell from './FlowTooltipCell.vue'
 import ManagementIPTooltipCell from './ManagementIPTooltipCell.vue'
 import NodeActionsDropdown from './NodeActionsDropdown.vue'
-import { getSnmpPrimaryIpAddress } from './nodeActionLinks'
 import NodeAdvancedFiltersDrawer from './NodeAdvancedFiltersDrawer.vue'
 import NodeDetailsDialog from './NodeDetailsDialog.vue'
 import NodeDownloadDropdown from './NodeDownloadDropdown.vue'
 import NodeInterfacesPanel from './NodeInterfacesPanel.vue'
 import NodeTooltipCell from './NodeTooltipCell.vue'
-import { useNodeExport } from './hooks/useNodeExport'
-import { useNodeQuery } from './hooks/useNodeQuery'
-import {
-  countInterfaceRowsForNode,
-  getInterfaceListMode,
-  normalizeMacSearch,
-  type InterfaceListMode
-} from './hooks/useInterfaceListing'
-import { getAssetColumnLabel } from './hooks/queryStringParser'
 import EmptyList from '../Common/EmptyList.vue'
 import FormField from '../Common/FormField.vue'
 
@@ -567,42 +566,6 @@ const toggleRowExpanded = (node: Node) => {
     updated[node.id] = true
   }
   expandedRows.value = updated
-}
-
-// Characters that make a value unsafe to splice raw into the FIQL attribute-narrowing term below:
-// - '%' / '_' are SQL-LIKE wildcards to the server's FIQL '==*value*' match (literal), while
-//   useInterfaceListing.ts's client-side matchesSnmpParm() treats them as SQL-LIKE wildcards — the
-//   server narrowing would no longer be a superset of the client match.
-// - ',' / ';' are FIQL set operators (OR / AND). sanitizeSearchTerm neutralizes them in other FIQL
-//   builders by replacing them with spaces, but doing that here has the same superset problem as
-//   '%'/'_': the narrowing sent to the server would search for something other than the exact
-//   value, so it could exclude rows the client-side match still considers a hit.
-// - '(' / ')' are FIQL grouping delimiters. Left in raw, they can produce an unbalanced FIQL
-//   expression that fails to parse server-side — surfacing client-side as "No interfaces".
-// If the value contains any of these, omit the attribute narrowing entirely; the node.id scoping
-// alone still limits the fetch to the current page, and exact contains/equals semantics are
-// re-applied client-side anyway (see buildSnmpNarrowing below).
-const UNSAFE_NARROWING_CHARS = /[%_,;()]/
-
-// Build the FIQL narrowing expression passed to nodeStore.getSnmpInterfacesForNodes so we only
-// fetch the SNMP interfaces relevant to the active maclike/snmpParm mode (see
-// getNodeSnmpInterfaceQuery).
-const buildSnmpNarrowing = (mode: InterfaceListMode): string | undefined => {
-  if (mode.mode === 'maclike') {
-    // normalizeMacSearch strips every non-hex character, so the result can never contain any of
-    // UNSAFE_NARROWING_CHARS above — no further guard needed here.
-    return `physAddr==*${normalizeMacSearch(mode.mac)}*`
-  }
-
-  if (mode.mode === 'snmpParm') {
-    if (UNSAFE_NARROWING_CHARS.test(mode.value)) {
-      return undefined
-    }
-
-    return `${mode.attr}==*${mode.value}*`
-  }
-
-  return undefined
 }
 
 const hasTopologySearch = computed(() => {

--- a/ui/src/components/Nodes/OutagesTable.vue
+++ b/ui/src/components/Nodes/OutagesTable.vue
@@ -1,4 +1,5 @@
 <template>
+  <div class="onms-col-12 title headline3">Recent Outages</div>
   <OnmsTable
     lazy
     :value="nodeStore.outages"
@@ -10,9 +11,36 @@
     data-test="outages-table"
     @page="onPage"
   >
-    <OnmsColumn field="ipAddress" header="IP Address" />
-    <OnmsColumn field="hostname" header="Host Name" />
-    <OnmsColumn field="serviceName" header="Service Name" />
+    <OnmsColumn field="outageId" header="ID">
+      <template #body="{ data }">
+        {{ data.id }}
+      </template>
+    </OnmsColumn>
+    <OnmsColumn field="ipAddress" header="IP Address">
+      <template #body="{ data }">
+        {{ data.ipAddress || 'N/A' }}
+      </template>
+    </OnmsColumn>
+    <OnmsColumn field="serviceName" header="Service Name">
+      <template #body="{ data }">
+        {{ data.serviceName || 'N/A' }}
+      </template>
+    </OnmsColumn>
+    <OnmsColumn field="ifLostService" header="Lost">
+      <template #body="{ data }">
+        {{ data.ifLostService || 'N/A' }}
+      </template>
+    </OnmsColumn>
+    <OnmsColumn field="ifRegainedService" header="Regained">
+      <template #body="{ data }">
+        {{ data.ifRegainedService || 'N/A' }}
+      </template>
+    </OnmsColumn>
+    <OnmsColumn field="hostname" header="Host Name">
+      <template #body="{ data }">
+        {{ data.hostname || 'N/A' }}
+      </template>
+    </OnmsColumn>
     <template #empty>
       <EmptyList :content="emptyListContent" data-test="empty-list" />
     </template>

--- a/ui/src/components/Nodes/OutagesTable.vue
+++ b/ui/src/components/Nodes/OutagesTable.vue
@@ -73,7 +73,6 @@ import NodeDetailsPanel from './NodeDetailsPanel.vue'
 import NodeDownloadDropdown from './NodeDownloadDropdown.vue'
 import useSnackbar from '@/composables/useSnackbar'
 import { useMenuStore } from '@/stores/menuStore'
-import { useNodeListStore } from '@/stores/nodeListStore'
 import { useNodeStore } from '@/stores/nodeStore'
 import { useRecordDownload } from './hooks/useRecordDownload'
 import { Outage } from '@/types'
@@ -89,7 +88,6 @@ const INTERFACE_PATH = 'element/interface.jsp'
 const SERVICE_PATH = 'element/service.jsp'
 
 const menuStore = useMenuStore()
-const nodeListStore = useNodeListStore()
 const nodeStore = useNodeStore()
 const route = useRoute()
 
@@ -128,21 +126,18 @@ const interfaceLink = (outage: Outage) =>
 const serviceLink = (outage: Outage) =>
   `${baseHref.value}${SERVICE_PATH}${nodeAndInterfaceQuery(outage)}&service=${outage.serviceId}`
 
-// An outage carries only its serviceId, so the display name comes from the service types the
-// app loaded at startup. They arrive asynchronously, hence a computed read rather than a
-// snapshot: the name fills in once they land.
-const serviceName = (outage: Outage) => nodeListStore.getServiceTypeById(outage.serviceId)?.name
+// Every outage carries its service inline, so the name needs no lookup: OnmsMonitoredService
+// requires a serviceType, and the outage row nests it.
+const serviceName = (outage: Outage) => outage.monitoredService?.serviceType?.name
 
 // Still down: the service was lost and has not come back, so the lost time is called out.
 const isUnresolved = (outage: Outage) => !!outage.ifLostService && !outage.ifRegainedService
 
-const onDownload = async (format: 'csv' | 'json') => {
-  // The paginator's current page: its limit/offset are already tracked in queryParameters, so
-  // raising rows-per-page is how a user downloads more than the default page.
-  const outages = await nodeStore.getNodeOutagesForExport({
-    id: nodeId.value,
-    queryParameters: queryParameters.value
-  })
+// The download is the page the paginator is showing, which the store already holds -- no
+// second request, and no way for the file to disagree with the table. Raising rows-per-page is
+// how a user takes more than the default page.
+const onDownload = (format: 'csv' | 'json') => {
+  const outages = nodeStore.outages
 
   if (!outages || outages.length === 0) {
     showSnackBar({
@@ -156,12 +151,12 @@ const onDownload = async (format: 'csv' | 'json') => {
   downloadRecords(outages, 'Outages', format)
 }
 
-const onCsvDownload = async () => {
-  return onDownload('csv')
+const onCsvDownload = () => {
+  onDownload('csv')
 }
 
-const onJsonDownload = async () => {
-  return onDownload('json')
+const onJsonDownload = () => {
+  onDownload('json')
 }
 
 const fetchOutages = () => {

--- a/ui/src/components/Nodes/OutagesTable.vue
+++ b/ui/src/components/Nodes/OutagesTable.vue
@@ -64,7 +64,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { OnmsColumn, OnmsIconButton, OnmsTable, OnmsTag, type OnmsTablePageEvent } from '@opennms/onms-ui'
 import IconViewDetails from '@opennms/onms-ui/icons/action/ViewDetails.vue'
@@ -164,15 +164,27 @@ const onJsonDownload = async () => {
   return onDownload('json')
 }
 
+const fetchOutages = () => {
+  nodeStore.getNodeOutages({ id: nodeId.value, queryParameters: queryParameters.value })
+}
+
 const onPage = (event: OnmsTablePageEvent) => {
   first.value = event.first
   pageSize.value = event.rows
   queryParameters.value = { ...queryParameters.value, offset: event.first, limit: event.rows }
-  nodeStore.getNodeOutages({ id: route.params.id as string, queryParameters: queryParameters.value })
+  fetchOutages()
 }
 
-onMounted(() => {
-  nodeStore.getNodeOutages({ id: route.params.id as string, queryParameters: queryParameters.value })
+onMounted(fetchOutages)
+
+// The details page keeps one instance of this panel across node ids, so the id has to be
+// followed rather than read once: otherwise the table, its "View Outages for this Node" link
+// and its downloads would disagree about which node they are for. Back to the first page,
+// since the page the user was on says nothing about the new node.
+watch(nodeId, () => {
+  first.value = 0
+  queryParameters.value = { ...queryParameters.value, offset: 0 }
+  fetchOutages()
 })
 
 defineExpose({ onPage })

--- a/ui/src/components/Nodes/OutagesTable.vue
+++ b/ui/src/components/Nodes/OutagesTable.vue
@@ -1,57 +1,74 @@
 <template>
-  <div class="onms-col-12 title headline3">Recent Outages</div>
-  <OnmsTable
-    lazy
-    :value="nodeStore.outages"
-    paginator
-    :rows="pageSize"
-    :first="first"
-    :totalRecords="nodeStore.outagesTotalCount"
-    :rowsPerPageOptions="[5, 10, 20, 50]"
-    data-test="outages-table"
-    @page="onPage"
-  >
-    <OnmsColumn field="outageId" header="ID">
-      <template #body="{ data }">
-        {{ data.id }}
-      </template>
-    </OnmsColumn>
-    <OnmsColumn field="ipAddress" header="IP Address">
-      <template #body="{ data }">
-        {{ data.ipAddress || 'N/A' }}
-      </template>
-    </OnmsColumn>
-    <OnmsColumn field="serviceName" header="Service Name">
-      <template #body="{ data }">
-        {{ data.serviceName || 'N/A' }}
-      </template>
-    </OnmsColumn>
-    <OnmsColumn field="ifLostService" header="Lost">
-      <template #body="{ data }">
-        {{ data.ifLostService || 'N/A' }}
-      </template>
-    </OnmsColumn>
-    <OnmsColumn field="ifRegainedService" header="Regained">
-      <template #body="{ data }">
-        {{ data.ifRegainedService || 'N/A' }}
-      </template>
-    </OnmsColumn>
-    <OnmsColumn field="hostname" header="Host Name">
-      <template #body="{ data }">
-        {{ data.hostname || 'N/A' }}
-      </template>
-    </OnmsColumn>
-    <template #empty>
-      <EmptyList :content="emptyListContent" data-test="empty-list" />
+  <NodeDetailsPanel title="Recent Outages">
+    <template #actions>
+      <OnmsIconButton
+        aria-label="View Outages for this Node"
+        tooltip="View Outages for this Node"
+        data-test="view-outages-button"
+        :icon="IconViewDetails"
+        @click="onViewOutagesClick"
+      />
+      <NodeDownloadDropdown
+        :onCsvDownload="onCsvDownload"
+        :onJsonDownload="onJsonDownload"
+      />
     </template>
-  </OnmsTable>
+    <OnmsTable
+      lazy
+      :value="nodeStore.outages"
+      paginator
+      :rows="pageSize"
+      :first="first"
+      :totalRecords="nodeStore.outagesTotalCount"
+      :rowsPerPageOptions="[5, 10, 20, 50]"
+      data-test="outages-table"
+      @page="onPage"
+    >
+      <OnmsColumn field="outageId" header="ID">
+        <template #body="{ data }">
+          {{ data.id }}
+        </template>
+      </OnmsColumn>
+      <OnmsColumn field="ipAddress" header="IP Address">
+        <template #body="{ data }">
+          {{ data.ipAddress || 'N/A' }}
+        </template>
+      </OnmsColumn>
+      <OnmsColumn field="serviceName" header="Service Name">
+        <template #body="{ data }">
+          {{ data.serviceName || 'N/A' }}
+        </template>
+      </OnmsColumn>
+      <OnmsColumn field="ifLostService" header="Lost">
+        <template #body="{ data }">
+          {{ data.ifLostService || 'N/A' }}
+        </template>
+      </OnmsColumn>
+      <OnmsColumn field="ifRegainedService" header="Regained">
+        <template #body="{ data }">
+          {{ data.ifRegainedService || 'N/A' }}
+        </template>
+      </OnmsColumn>
+      <OnmsColumn field="hostname" header="Host Name">
+        <template #body="{ data }">
+          {{ data.hostname || 'N/A' }}
+        </template>
+      </OnmsColumn>
+      <template #empty>
+        <EmptyList :content="emptyListContent" data-test="empty-list" />
+      </template>
+    </OnmsTable>
+  </NodeDetailsPanel>
 </template>
 
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
 import { useRoute } from 'vue-router'
-import { OnmsColumn, OnmsTable, type OnmsTablePageEvent } from '@opennms/onms-ui'
+import { OnmsColumn, OnmsIconButton, OnmsTable, type OnmsTablePageEvent } from '@opennms/onms-ui'
+import IconViewDetails from '@opennms/onms-ui/icons/action/ViewDetails.vue'
 import EmptyList from '@/components/Common/EmptyList.vue'
+import NodeDetailsPanel from './NodeDetailsPanel.vue'
+import NodeDownloadDropdown from './NodeDownloadDropdown.vue'
 import { useNodeStore } from '@/stores/nodeStore'
 
 const nodeStore = useNodeStore()
@@ -65,6 +82,20 @@ const queryParameters = ref({
   limit: 10,
   offset: 0
 })
+
+// Placeholders for the next set of work: the outages equivalents of the Recent Events panel's
+// "Events for this Node" link and CSV/JSON downloads.
+const onViewOutagesClick = () => {
+  // TODO: link to the outages list filtered to this node
+}
+
+const onCsvDownload = () => {
+  // TODO: download this node's outages as CSV
+}
+
+const onJsonDownload = () => {
+  // TODO: download this node's outages as JSON
+}
 
 const onPage = (event: OnmsTablePageEvent) => {
   first.value = event.first

--- a/ui/src/components/Nodes/OutagesTable.vue
+++ b/ui/src/components/Nodes/OutagesTable.vue
@@ -24,34 +24,36 @@
       data-test="outages-table"
       @page="onPage"
     >
-      <OnmsColumn field="outageId" header="ID">
+      <OnmsColumn field="id" header="ID">
         <template #body="{ data }">
-          {{ data.id }}
+          <a :href="outageDetailLink(data)">{{ data.id }}</a>
         </template>
       </OnmsColumn>
       <OnmsColumn field="ipAddress" header="IP Address">
         <template #body="{ data }">
-          {{ data.ipAddress || 'N/A' }}
+          <a v-if="data.ipAddress" :href="interfaceLink(data)">{{ data.ipAddress }}</a>
+          <span v-else>N/A</span>
         </template>
       </OnmsColumn>
       <OnmsColumn field="serviceName" header="Service Name">
         <template #body="{ data }">
-          {{ data.serviceName || 'N/A' }}
+          <a v-if="serviceName(data) && data.ipAddress" :href="serviceLink(data)">{{ serviceName(data) }}</a>
+          <span v-else>{{ serviceName(data) || 'N/A' }}</span>
         </template>
       </OnmsColumn>
       <OnmsColumn field="ifLostService" header="Lost">
         <template #body="{ data }">
-          {{ data.ifLostService || 'N/A' }}
+          <OnmsTag v-if="isUnresolved(data)" severity="danger">
+            <span v-date>{{ data.ifLostService }}</span>
+          </OnmsTag>
+          <span v-else-if="data.ifLostService" v-date>{{ data.ifLostService }}</span>
+          <span v-else>N/A</span>
         </template>
       </OnmsColumn>
       <OnmsColumn field="ifRegainedService" header="Regained">
         <template #body="{ data }">
-          {{ data.ifRegainedService || 'N/A' }}
-        </template>
-      </OnmsColumn>
-      <OnmsColumn field="hostname" header="Host Name">
-        <template #body="{ data }">
-          {{ data.hostname || 'N/A' }}
+          <span v-if="data.ifRegainedService" v-date>{{ data.ifRegainedService }}</span>
+          <span v-else>N/A</span>
         </template>
       </OnmsColumn>
       <template #empty>
@@ -62,39 +64,104 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useRoute } from 'vue-router'
-import { OnmsColumn, OnmsIconButton, OnmsTable, type OnmsTablePageEvent } from '@opennms/onms-ui'
+import { OnmsColumn, OnmsIconButton, OnmsTable, OnmsTag, type OnmsTablePageEvent } from '@opennms/onms-ui'
 import IconViewDetails from '@opennms/onms-ui/icons/action/ViewDetails.vue'
 import EmptyList from '@/components/Common/EmptyList.vue'
 import NodeDetailsPanel from './NodeDetailsPanel.vue'
 import NodeDownloadDropdown from './NodeDownloadDropdown.vue'
+import useSnackbar from '@/composables/useSnackbar'
+import { useMenuStore } from '@/stores/menuStore'
+import { useNodeListStore } from '@/stores/nodeListStore'
 import { useNodeStore } from '@/stores/nodeStore'
+import { useRecordDownload } from './hooks/useRecordDownload'
+import { Outage } from '@/types'
 
+// The legacy outage pages, which accept node/interface/service parameters.
+// Will need to replace with the Vue pages once they are implemented.
+const OUTAGE_LIST_PATH = 'outage/list.htm'
+
+// outtype=both makes the legacy list show current AND resolved outages, matching this panel.
+const OUTAGE_LIST_TYPE = 'both'
+const OUTAGE_DETAIL_PATH = 'outage/detail.htm'
+const INTERFACE_PATH = 'element/interface.jsp'
+const SERVICE_PATH = 'element/service.jsp'
+
+const menuStore = useMenuStore()
+const nodeListStore = useNodeListStore()
 const nodeStore = useNodeStore()
 const route = useRoute()
 
-const pageSize = ref(10)
+const { showSnackBar } = useSnackbar()
+const { downloadRecords } = useRecordDownload()
+
+const nodeId = computed(() => route.params.id as string)
+const baseHref = computed(() => menuStore.mainMenu.baseHref)
+
+const DEFAULT_PAGE_SIZE = 5
+
+const pageSize = ref(DEFAULT_PAGE_SIZE)
 const first = ref(0)
 const emptyListContent = { msg: 'No results found.' }
 
 const queryParameters = ref({
-  limit: 10,
+  limit: DEFAULT_PAGE_SIZE,
   offset: 0
 })
 
-// Placeholders for the next set of work: the outages equivalents of the Recent Events panel's
-// "Events for this Node" link and CSV/JSON downloads.
 const onViewOutagesClick = () => {
-  // TODO: link to the outages list filtered to this node
+  window.location.assign(
+    `${baseHref.value}${OUTAGE_LIST_PATH}?filter=node%3D${nodeId.value}&outtype=${OUTAGE_LIST_TYPE}`)
 }
 
-const onCsvDownload = () => {
-  // TODO: download this node's outages as CSV
+const outageDetailLink = (outage: Outage) => `${baseHref.value}${OUTAGE_DETAIL_PATH}?id=${outage.id}`
+
+// Both pages take the interface by address rather than by id, so the address is encoded (an
+// IPv6 address is full of reserved characters).
+const nodeAndInterfaceQuery = (outage: Outage) =>
+  `?node=${nodeId.value}&intf=${encodeURIComponent(outage.ipAddress)}`
+
+const interfaceLink = (outage: Outage) =>
+  `${baseHref.value}${INTERFACE_PATH}${nodeAndInterfaceQuery(outage)}`
+
+const serviceLink = (outage: Outage) =>
+  `${baseHref.value}${SERVICE_PATH}${nodeAndInterfaceQuery(outage)}&service=${outage.serviceId}`
+
+// An outage carries only its serviceId, so the display name comes from the service types the
+// app loaded at startup. They arrive asynchronously, hence a computed read rather than a
+// snapshot: the name fills in once they land.
+const serviceName = (outage: Outage) => nodeListStore.getServiceTypeById(outage.serviceId)?.name
+
+// Still down: the service was lost and has not come back, so the lost time is called out.
+const isUnresolved = (outage: Outage) => !!outage.ifLostService && !outage.ifRegainedService
+
+const onDownload = async (format: 'csv' | 'json') => {
+  // The paginator's current page: its limit/offset are already tracked in queryParameters, so
+  // raising rows-per-page is how a user downloads more than the default page.
+  const outages = await nodeStore.getNodeOutagesForExport({
+    id: nodeId.value,
+    queryParameters: queryParameters.value
+  })
+
+  if (!outages || outages.length === 0) {
+    showSnackBar({
+      msg: `No outages found for '${format}' download for this node`,
+      error: true
+    })
+
+    return
+  }
+
+  downloadRecords(outages, 'Outages', format)
 }
 
-const onJsonDownload = () => {
-  // TODO: download this node's outages as JSON
+const onCsvDownload = async () => {
+  return onDownload('csv')
+}
+
+const onJsonDownload = async () => {
+  return onDownload('json')
 }
 
 const onPage = (event: OnmsTablePageEvent) => {

--- a/ui/src/components/Nodes/SnmpInterfacesTable.vue
+++ b/ui/src/components/Nodes/SnmpInterfacesTable.vue
@@ -71,8 +71,7 @@ onMounted(fetchInterfaces)
 // about the new node.
 watch(nodeId, () => {
   first.value = 0
-  pageSize.value = DEFAULT_PAGE_SIZE
-  queryParameters.value = { ...queryParameters.value, offset: 0, limit: DEFAULT_PAGE_SIZE }
+  queryParameters.value = { ...queryParameters.value, offset: 0 }
   fetchInterfaces()
 })
 

--- a/ui/src/components/Nodes/SnmpInterfacesTable.vue
+++ b/ui/src/components/Nodes/SnmpInterfacesTable.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { OnmsColumn, OnmsTable, type OnmsTablePageEvent } from '@opennms/onms-ui'
 import EmptyList from '@/components/Common/EmptyList.vue'
@@ -39,24 +39,41 @@ import { useNodeStore } from '@/stores/nodeStore'
 const nodeStore = useNodeStore()
 const route = useRoute()
 
-const pageSize = ref(5)
+const nodeId = computed(() => route.params.id as string)
+
+const DEFAULT_PAGE_SIZE = 5
+
+const pageSize = ref(DEFAULT_PAGE_SIZE)
 const first = ref(0)
 const emptyListContent = { msg: 'No results found.' }
 
 const queryParameters = ref({
-  limit: 5,
+  limit: DEFAULT_PAGE_SIZE,
   offset: 0
 })
+
+const fetchInterfaces = () => {
+  nodeStore.getNodeSnmpInterfaces({ id: nodeId.value, queryParameters: queryParameters.value })
+}
 
 const onPage = (event: OnmsTablePageEvent) => {
   first.value = event.first
   pageSize.value = event.rows
   queryParameters.value = { ...queryParameters.value, offset: event.first, limit: event.rows }
-  nodeStore.getNodeSnmpInterfaces({ id: route.params.id as string, queryParameters: queryParameters.value })
+  fetchInterfaces()
 }
 
-onMounted(() => {
-  nodeStore.getNodeSnmpInterfaces({ id: route.params.id as string, queryParameters: queryParameters.value })
+onMounted(fetchInterfaces)
+
+// The details page keeps one instance of this table across node ids, so the id has to be
+// followed rather than read once, or the tab keeps showing the SNMP interfaces of the node the user
+// navigated away from. Back to the first page, since the page the user was on says nothing
+// about the new node.
+watch(nodeId, () => {
+  first.value = 0
+  pageSize.value = DEFAULT_PAGE_SIZE
+  queryParameters.value = { ...queryParameters.value, offset: 0, limit: DEFAULT_PAGE_SIZE }
+  fetchInterfaces()
 })
 
 defineExpose({ onPage })

--- a/ui/src/components/Nodes/hooks/useInterfaceListing.ts
+++ b/ui/src/components/Nodes/hooks/useInterfaceListing.ts
@@ -331,7 +331,7 @@ const buildSnmpInterfaceRow = (
  * Cisco-style dotted MAC like 'aabb.ccdd' never matched anything there. Stripping every non-hex
  * character means our maclike/snmpParm matching treats 'aabb.ccdd', 'aabb:ccdd', and 'aabbccdd' as
  * the same search, which is an improvement, not a port of the old behavior. Shared by the
- * client-side maclike match here, NodesTable.vue's buildSnmpNarrowing, and useNodeQuery.ts's
+ * client-side maclike match here, utils.ts's buildSnmpNarrowing, and useNodeQuery.ts's
  * buildMaclikeQuery so all three treat a given input identically.
  */
 export const normalizeMacSearch = (mac: string): string => mac.replace(/[^0-9a-fA-F]/g, '').toLowerCase()

--- a/ui/src/components/Nodes/hooks/useNodeQuery.ts
+++ b/ui/src/components/Nodes/hooks/useNodeQuery.ts
@@ -656,7 +656,7 @@ const buildMaclikeQuery = (macAddress?: string) => {
   // The backend maclike behavior does a case-insensitive ANYWHERE match, so a partial MAC is fine.
   // normalizeMacSearch strips every non-hex character, not just legacy's '[:-]' -- see its doc
   // comment in useInterfaceListing.ts for why that's a deliberate improvement, not parity. Shared
-  // with useInterfaceListing.ts's client-side maclike match and NodesTable.vue's buildSnmpNarrowing
+  // with useInterfaceListing.ts's client-side maclike match and utils.ts's buildSnmpNarrowing
   // so all three normalize a MAC-like value identically.
   const stripped = normalizeMacSearch(macAddress)
 

--- a/ui/src/components/Nodes/hooks/useRecordDownload.ts
+++ b/ui/src/components/Nodes/hooks/useRecordDownload.ts
@@ -20,21 +20,34 @@
 /// License.
 ///
 
-import { ServiceType } from '@/types'
 import { useNodeExport } from './useNodeExport'
 
 export type RecordDownloadFormat = 'csv' | 'json'
 
 /**
- * The CSV columns are whatever fields the records actually carry, in the order the API returns
- * them. Taken from the data rather than from a type, since the API sends fields the types do not
- * all declare (Event.serviceType among them).
+ * Flatten a record into dotted leaf paths: `monitoredService.serviceType.name` rather than a
+ * JSON blob in one cell. Arrays stay whole -- their length varies per row, so they cannot be
+ * columns -- and are emitted as JSON.
  */
-const getCsvColumns = (records: Record<string, unknown>[]) => {
+const toCsvLeaves = (value: unknown, prefix = ''): Array<[string, unknown]> => {
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    return Object.entries(value as Record<string, unknown>)
+      .flatMap(([key, child]) => toCsvLeaves(child, prefix ? `${prefix}.${key}` : key))
+  }
+
+  return [[prefix, value]]
+}
+
+/**
+ * The CSV columns are whatever leaves the records actually carry, in the order the API returns
+ * them. Taken from the data rather than from a type, since the API sends fields the types do
+ * not all declare.
+ */
+const getCsvColumns = (rows: Array<Map<string, unknown>>) => {
   const columns: string[] = []
 
-  for (const record of records) {
-    for (const field of Object.keys(record)) {
+  for (const row of rows) {
+    for (const field of row.keys()) {
       if (!columns.includes(field)) {
         columns.push(field)
       }
@@ -45,34 +58,32 @@ const getCsvColumns = (records: Record<string, unknown>[]) => {
 }
 
 /**
- * serviceType arrives as an object; its name is the part worth a CSV cell. Anything else
- * non-primitive keeps its JSON form rather than stringifying to '[object Object]'.
+ * Quote a field only when it needs it, doubling any embedded quote, per RFC 4180. Event log
+ * messages carry markup and commas, so unquoted values would break the row apart.
+ *
+ * A leading = + - @ tab or CR is also neutralised with a single quote: this data comes from
+ * traps and syslog, and a spreadsheet would otherwise run it as a formula. Numbers are left
+ * alone -- they cannot be formulas, and guarding them would corrupt a legitimate negative.
+ * Same treatment the notices table and the resource-graph export already apply.
  */
-const flattenCsvValue = (field: string, value: unknown) => {
+const toCsvValue = (value: unknown) => {
   if (value === null || value === undefined) {
     return ''
   }
 
-  if (field === 'serviceType') {
-    return (value as ServiceType).name ?? ''
-  }
+  const raw = typeof value === 'object' ? JSON.stringify(value) : String(value)
+  const guarded = typeof value !== 'number' && /^[=+\-@\t\r]/.test(raw) ? `'${raw}` : raw
 
-  return typeof value === 'object' ? JSON.stringify(value) : String(value)
+  return /[",\r\n]/.test(guarded) ? `"${guarded.replace(/"/g, '""')}"` : guarded
 }
 
-/**
- * Quote a field only when it needs it, doubling any embedded quote, per RFC 4180. Event log
- * messages carry markup and commas, so unquoted values would break the row apart.
- */
-const toCsvValue = (value: string) =>
-  /[",\r\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value
-
-const buildCsv = (records: Record<string, unknown>[]) => {
-  const columns = getCsvColumns(records)
+const buildCsv = (records: unknown[]) => {
+  const rows = records.map(record => new Map(toCsvLeaves(record)))
+  const columns = getCsvColumns(rows)
 
   return [
     columns.join(','),
-    ...records.map(record => columns.map(field => toCsvValue(flattenCsvValue(field, record[field]))).join(','))
+    ...rows.map(row => columns.map(field => toCsvValue(row.get(field))).join(','))
   ].join('\n')
 }
 
@@ -86,12 +97,8 @@ export const useRecordDownload = () => {
   const { generateBlob, generateDownload } = useNodeExport()
 
   const downloadRecords = (records: unknown[], baseName: string, format: RecordDownloadFormat) => {
-    // Read the records as plain field bags: the export covers whatever the API sent, including
-    // the fields the record types do not declare.
-    const rows = records as Record<string, unknown>[]
-
     const contentType = format === 'json' ? 'application/json' : 'text/csv'
-    const data = format === 'json' ? buildJson(records) : buildCsv(rows)
+    const data = format === 'json' ? buildJson(records) : buildCsv(records)
 
     generateDownload(generateBlob(data, contentType), `${baseName}.${format}`)
   }

--- a/ui/src/components/Nodes/hooks/useRecordDownload.ts
+++ b/ui/src/components/Nodes/hooks/useRecordDownload.ts
@@ -1,0 +1,102 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { ServiceType } from '@/types'
+import { useNodeExport } from './useNodeExport'
+
+export type RecordDownloadFormat = 'csv' | 'json'
+
+/**
+ * The CSV columns are whatever fields the records actually carry, in the order the API returns
+ * them. Taken from the data rather than from a type, since the API sends fields the types do not
+ * all declare (Event.serviceType among them).
+ */
+const getCsvColumns = (records: Record<string, unknown>[]) => {
+  const columns: string[] = []
+
+  for (const record of records) {
+    for (const field of Object.keys(record)) {
+      if (!columns.includes(field)) {
+        columns.push(field)
+      }
+    }
+  }
+
+  return columns
+}
+
+/**
+ * serviceType arrives as an object; its name is the part worth a CSV cell. Anything else
+ * non-primitive keeps its JSON form rather than stringifying to '[object Object]'.
+ */
+const flattenCsvValue = (field: string, value: unknown) => {
+  if (value === null || value === undefined) {
+    return ''
+  }
+
+  if (field === 'serviceType') {
+    return (value as ServiceType).name ?? ''
+  }
+
+  return typeof value === 'object' ? JSON.stringify(value) : String(value)
+}
+
+/**
+ * Quote a field only when it needs it, doubling any embedded quote, per RFC 4180. Event log
+ * messages carry markup and commas, so unquoted values would break the row apart.
+ */
+const toCsvValue = (value: string) =>
+  /[",\r\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value
+
+const buildCsv = (records: Record<string, unknown>[]) => {
+  const columns = getCsvColumns(records)
+
+  return [
+    columns.join(','),
+    ...records.map(record => columns.map(field => toCsvValue(flattenCsvValue(field, record[field]))).join(','))
+  ].join('\n')
+}
+
+const buildJson = (records: unknown[]) => JSON.stringify(records, null, 2)
+
+/**
+ * Download a set of API records as a CSV or JSON file, covering every field they carry rather
+ * than only the columns a table displays. Shared by the Node Details panels.
+ */
+export const useRecordDownload = () => {
+  const { generateBlob, generateDownload } = useNodeExport()
+
+  const downloadRecords = (records: unknown[], baseName: string, format: RecordDownloadFormat) => {
+    // Read the records as plain field bags: the export covers whatever the API sent, including
+    // the fields the record types do not declare.
+    const rows = records as Record<string, unknown>[]
+
+    const contentType = format === 'json' ? 'application/json' : 'text/csv'
+    const data = format === 'json' ? buildJson(records) : buildCsv(rows)
+
+    generateDownload(generateBlob(data, contentType), `${baseName}.${format}`)
+  }
+
+  return {
+    downloadRecords
+  }
+}

--- a/ui/src/components/Nodes/nodeActionLinks.ts
+++ b/ui/src/components/Nodes/nodeActionLinks.ts
@@ -1,0 +1,91 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { Node } from '@/types'
+
+export const linkItems = [
+  { name: 'events', label: 'Events' },
+  { name: 'alarms', label: 'Alarms' },
+  { name: 'view-outages', label: 'Outages' },
+  { name: 'assets', label: 'Assets' },
+  { name: 'metadata', label: 'Metadata' },
+  { name: 'hardware', label: 'Hardware Inventory' },
+  { name: 'availability', label: 'Availability' },
+  { name: 'siteStatus', label: 'Site Status' },
+  { name: 'graphs', label: 'Resource Graphs' },
+  { name: 'rescan', label: 'Node Rescan' },
+  { name: 'admin', label: 'Admin / Node Management' },
+  { name: 'node-link-details', label: 'Node Link Details' },
+  { name: 'updateSnmp', label: 'Update SNMP Information' },
+  { name: 'schedule-outage', label: 'Schedule an Outage' },
+  { name: 'topology', label: 'View Topology Map' }
+]
+
+export const mapLink = (name: string, node: Node) => {
+  switch (name) {
+    case 'events':
+      return `event/list?filter=node%3D${node.id}`
+    case 'alarms':
+      return `alarm/list.htm?filter=node%3D${node.id}`
+    case 'view-outages':
+      return `outage/list.htm?filter=node%3D${node.id}`
+    case 'assets':
+      return `asset/modify.jsp?node=${node.id}`
+    case 'metadata':
+      return `element/node-metadata.jsp?node=${node.id}`
+    case 'hardware':
+      return `hardware/list.jsp?node=${node.id}`
+    case 'availability':
+      return `element/availability.jsp?node=${node.id}`
+    case 'siteStatus': {
+      if (node.assetRecord?.building && node.assetRecord.building.length > 0) {
+        const encodedBuilding = encodeURIComponent(node.assetRecord.building)
+        return `siteStatusView.htm?statusSite=${encodedBuilding}`
+      }
+      return ''
+    }
+    case 'graphs':
+      return `graph/chooseresource.jsp?node=${node.id}&reports=all`
+    case 'rescan':
+      return `element/rescan.jsp?node=${node.id}`
+    case 'admin':
+      return `admin/nodemanagement/index.jsp?node=${node.id}`
+    case 'node-link-details':
+      return `element/linkednode.jsp?node=${node.id}`
+    case 'updateSnmp':
+      // TODO: Get IP Address
+      return `admin/updateSnmp.jsp?node=${node.id}&ipaddr=0.0.0.0`
+    case 'schedule-outage':
+      return `admin/sched-outages/editoutage.jsp?newName=${node.label}&addNew=true&nodeID=${node.id}`
+    case 'topology':
+      return `topology?provider=Enhanced+Linkd&szl=1&focus-vertices=${node.id}`
+    default: return ''
+  }
+}
+
+export const createLinkItemsList = (node: Node) => {
+  return linkItems.map(li => ({
+    label: li.label,
+    link: mapLink(li.name, node)
+  }))
+    .filter(li => li.link)
+}

--- a/ui/src/components/Nodes/nodeActionLinks.ts
+++ b/ui/src/components/Nodes/nodeActionLinks.ts
@@ -75,7 +75,9 @@ export const mapLink = (name: string, node: Node) => {
       // TODO: Get IP Address
       return `admin/updateSnmp.jsp?node=${node.id}&ipaddr=0.0.0.0`
     case 'schedule-outage':
-      return `admin/sched-outages/editoutage.jsp?newName=${node.label}&addNew=true&nodeID=${node.id}`
+      // The label goes into a query parameter, so it has to be encoded: an & or # in it would
+      // otherwise swallow the parameters that follow.
+      return `admin/sched-outages/editoutage.jsp?newName=${encodeURIComponent(node.label)}&addNew=true&nodeID=${node.id}`
     case 'topology':
       return `topology?provider=Enhanced+Linkd&szl=1&focus-vertices=${node.id}`
     // The legacy node page links to this as "View Node Link Detailed Info".

--- a/ui/src/components/Nodes/nodeActionLinks.ts
+++ b/ui/src/components/Nodes/nodeActionLinks.ts
@@ -20,7 +20,7 @@
 /// License.
 ///
 
-import { Node } from '@/types'
+import { IpInterface, Node } from '@/types'
 
 // The node action links, shared by every place the actions menu is rendered: the Node Details
 // title row and each row of the node list.
@@ -42,7 +42,22 @@ export const linkItems = [
   { name: 'node-link', label: 'Node Link Details' }
 ]
 
-export const mapLink = (name: string, node: Node) => {
+/**
+ * The address the Update SNMP action targets: the node's SNMP-primary interface, matching the
+ * legacy node page's `model.snmpPrimaryIntf`. Undefined when the node has none, in which case
+ * the action is not offered at all.
+ */
+export const getSnmpPrimaryIpAddress = (ipInterfaces: IpInterface[]): string | undefined =>
+  ipInterfaces.find(ipInterface => ipInterface.snmpPrimary === 'P')?.ipAddress
+
+// Data a link needs that the node payload does not carry. /api/v2/nodes sends no interfaces
+// (OnmsNode.getPrimaryInterface is @Transient @JsonIgnore), so the caller supplies the
+// SNMP-primary address from the interface data it has.
+export interface NodeActionLinkContext {
+  snmpPrimaryIpAddress?: string
+}
+
+export const mapLink = (name: string, node: Node, context: NodeActionLinkContext = {}) => {
   switch (name) {
     case 'events':
       return `event/list?filter=node%3D${node.id}`
@@ -71,9 +86,16 @@ export const mapLink = (name: string, node: Node) => {
       return `element/rescan.jsp?node=${node.id}`
     case 'admin':
       return `admin/nodemanagement/index.jsp?node=${node.id}`
-    case 'updateSnmp':
-      // TODO: Get IP Address
-      return `admin/updateSnmp.jsp?node=${node.id}&ipaddr=0.0.0.0`
+    case 'updateSnmp': {
+      // The legacy node page shows this only for a node with an SNMP-primary interface, and
+      // points it at that address. Without one there is nothing safe to link to: the form
+      // would rewrite SNMP configuration for whatever address it was handed.
+      if (!context.snmpPrimaryIpAddress) {
+        return ''
+      }
+
+      return `admin/updateSnmp.jsp?node=${node.id}&ipaddr=${encodeURIComponent(context.snmpPrimaryIpAddress)}`
+    }
     case 'schedule-outage':
       // The label goes into a query parameter, so it has to be encoded: an & or # in it would
       // otherwise swallow the parameters that follow.
@@ -87,10 +109,10 @@ export const mapLink = (name: string, node: Node) => {
   }
 }
 
-export const createLinkItemsList = (node: Node) => {
+export const createLinkItemsList = (node: Node, context: NodeActionLinkContext = {}) => {
   return linkItems.map(li => ({
     label: li.label,
-    link: mapLink(li.name, node)
+    link: mapLink(li.name, node, context)
   }))
     .filter(li => li.link)
 }

--- a/ui/src/components/Nodes/nodeActionLinks.ts
+++ b/ui/src/components/Nodes/nodeActionLinks.ts
@@ -22,6 +22,8 @@
 
 import { Node } from '@/types'
 
+// The node action links, shared by every place the actions menu is rendered: the Node Details
+// title row and each row of the node list.
 export const linkItems = [
   { name: 'events', label: 'Events' },
   { name: 'alarms', label: 'Alarms' },
@@ -34,10 +36,10 @@ export const linkItems = [
   { name: 'graphs', label: 'Resource Graphs' },
   { name: 'rescan', label: 'Node Rescan' },
   { name: 'admin', label: 'Admin / Node Management' },
-  { name: 'node-link-details', label: 'Node Link Details' },
   { name: 'updateSnmp', label: 'Update SNMP Information' },
   { name: 'schedule-outage', label: 'Schedule an Outage' },
-  { name: 'topology', label: 'View Topology Map' }
+  { name: 'topology', label: 'View Topology Map' },
+  { name: 'node-link', label: 'Node Link Details' }
 ]
 
 export const mapLink = (name: string, node: Node) => {
@@ -69,8 +71,6 @@ export const mapLink = (name: string, node: Node) => {
       return `element/rescan.jsp?node=${node.id}`
     case 'admin':
       return `admin/nodemanagement/index.jsp?node=${node.id}`
-    case 'node-link-details':
-      return `element/linkednode.jsp?node=${node.id}`
     case 'updateSnmp':
       // TODO: Get IP Address
       return `admin/updateSnmp.jsp?node=${node.id}&ipaddr=0.0.0.0`
@@ -78,6 +78,9 @@ export const mapLink = (name: string, node: Node) => {
       return `admin/sched-outages/editoutage.jsp?newName=${node.label}&addNew=true&nodeID=${node.id}`
     case 'topology':
       return `topology?provider=Enhanced+Linkd&szl=1&focus-vertices=${node.id}`
+    // The legacy node page links to this as "View Node Link Detailed Info".
+    case 'node-link':
+      return `element/linkednode.jsp?node=${node.id}`
     default: return ''
   }
 }

--- a/ui/src/components/Nodes/utils.ts
+++ b/ui/src/components/Nodes/utils.ts
@@ -68,3 +68,22 @@ export const defaultColumns: NodeColumnSelectionItem[] = [
   { id: 'sysDescription', label: 'Sys Description', selected: false, order: 8 },
   { id: 'flows', label: 'Flows', selected: false, order: 9 }
 ]
+
+export const getNodeStatusString = (node: Node) => {
+  const status = (node?.type ?? ' ').toUpperCase()
+
+  if (status.length === 0) {
+    return 'Unknown'
+  }
+
+  const firstChar = status.charAt(0)
+
+  switch (firstChar) {
+    case 'A':
+      return 'Active'
+    case 'D':
+      return 'Deleted'
+    default:
+      return 'Unknown'
+  }
+}

--- a/ui/src/components/Nodes/utils.ts
+++ b/ui/src/components/Nodes/utils.ts
@@ -25,6 +25,7 @@ import {
   NodeColumnSelectionItem
 } from '@/types'
 import { isNumber } from '@/lib/utils'
+import { normalizeMacSearch, type InterfaceListMode } from './hooks/useInterfaceListing'
 
 /**
  * Construct an array of Feather Table CSS classes for the given configured node table columns.
@@ -86,4 +87,40 @@ export const getNodeStatusString = (node: Node) => {
     default:
       return 'Unknown'
   }
+}
+
+// Characters that make a value unsafe to splice raw into the FIQL attribute-narrowing term below:
+// - '%' / '_' are SQL-LIKE wildcards to the server's FIQL '==*value*' match (literal), while
+//   useInterfaceListing.ts's client-side matchesSnmpParm() treats them as SQL-LIKE wildcards — the
+//   server narrowing would no longer be a superset of the client match.
+// - ',' / ';' are FIQL set operators (OR / AND). sanitizeSearchTerm neutralizes them in other FIQL
+//   builders by replacing them with spaces, but doing that here has the same superset problem as
+//   '%'/'_': the narrowing sent to the server would search for something other than the exact
+//   value, so it could exclude rows the client-side match still considers a hit.
+// - '(' / ')' are FIQL grouping delimiters. Left in raw, they can produce an unbalanced FIQL
+//   expression that fails to parse server-side — surfacing client-side as "No interfaces".
+// If the value contains any of these, omit the attribute narrowing entirely; the node.id scoping
+// alone still limits the fetch to the current page, and exact contains/equals semantics are
+// re-applied client-side anyway (see buildSnmpNarrowing below).
+const UNSAFE_NARROWING_CHARS = /[%_,;()]/
+
+// Build the FIQL narrowing expression passed to nodeStore.getSnmpInterfacesForNodes so we only
+// fetch the SNMP interfaces relevant to the active maclike/snmpParm mode (see
+// getNodeSnmpInterfaceQuery).
+export const buildSnmpNarrowing = (mode: InterfaceListMode): string | undefined => {
+  if (mode.mode === 'maclike') {
+    // normalizeMacSearch strips every non-hex character, so the result can never contain any of
+    // UNSAFE_NARROWING_CHARS above — no further guard needed here.
+    return `physAddr==*${normalizeMacSearch(mode.mac)}*`
+  }
+
+  if (mode.mode === 'snmpParm') {
+    if (UNSAFE_NARROWING_CHARS.test(mode.value)) {
+      return undefined
+    }
+
+    return `${mode.attr}==*${mode.value}*`
+  }
+
+  return undefined
 }

--- a/ui/src/containers/NodeDetails.vue
+++ b/ui/src/containers/NodeDetails.vue
@@ -1,29 +1,53 @@
 <template>
-  <div class="onms-row">
-    <div class="onms-col-12">
-      <BreadCrumbs :items="items" />
+  <div class="onms-node-details">
+    <div class="onms-row">
+      <div class="onms-col-12">
+        <BreadCrumbs :items="items" />
+      </div>
     </div>
-  </div>
-  <div class="onms-row" style="flex-wrap: inherit; padding: 4px;">
-    <div class="onms-col-6">
-      <NodeAvailabilityGraph />
-      <InterfacesTabs />
+    <div class="header">
+      <div class="heading">
+        <h2>Node Details for {{ nodeStore.node?.label }}</h2>
+      </div>
     </div>
-    <div class="onms-col-6">
-      <EventsTable />
-      <OutagesTable />
+    <div class="onms-row">
+      <div class="onms-col-12">
+        <NodeDetailsHeader :node="nodeStore.node" :base-href="baseHref" />
+      </div>
+    </div>
+    <div class="onms-row" style="flex-wrap: inherit; padding: 4px;">
+      <div class="onms-col-6">
+        <NodeSnmpAttributes :node="nodeStore.node" />
+      </div>
+      <div class="onms-col-6">
+        <NodeCategoriesPanel :node="nodeStore.node" :base-href="baseHref" />
+        <NodeNotificationsPanel :node="nodeStore.node" :base-href="baseHref" />
+      </div>
+    </div>
+    <div class="onms-row" style="flex-wrap: inherit; padding: 4px;">
+      <div class="onms-col-6">
+        <NodeAvailabilityGraph :node="nodeStore.node" :base-href="baseHref" />
+        <InterfacesTabs />
+      </div>
+      <div class="onms-col-6">
+        <EventsTable />
+        <OutagesTable />
+      </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed, onMounted, watch } from 'vue'
-
+import BreadCrumbs from '@/components/Layout/BreadCrumbs.vue'
 import EventsTable from '@/components/Nodes/EventsTable.vue'
-import OutagesTable from '@/components/Nodes/OutagesTable.vue'
 import InterfacesTabs from '@/components/Nodes/InterfacesTabs.vue'
 import NodeAvailabilityGraph from '@/components/Nodes/NodeAvailabilityGraph.vue'
-import BreadCrumbs from '@/components/Layout/BreadCrumbs.vue'
+import NodeCategoriesPanel from '@/components/Nodes/NodeCategoriesPanel.vue'
+import NodeDetailsHeader from '@/components/Nodes/NodeDetailsHeader.vue'
+import NodeNotificationsPanel from '@/components/Nodes/NodeNotificationsPanel.vue'
+import OutagesTable from '@/components/Nodes/OutagesTable.vue'
+import NodeSnmpAttributes from '@/components/Nodes/NodeSnmpAttributes.vue'
 import { useMenuStore } from '@/stores/menuStore'
 import { useNodeStore } from '@/stores/nodeStore'
 import { BreadCrumb, Node } from '@/types'
@@ -37,6 +61,7 @@ const props = defineProps({
   }
 })
 
+const baseHref = computed<string>(() => menuStore.mainMenu.baseHref)
 const homeUrl = computed<string>(() => menuStore.mainMenu.homeUrl)
 
 const items = computed<BreadCrumb[]>(() => [
@@ -55,3 +80,17 @@ onMounted(fetchNode)
 
 watch(() => props.id, fetchNode)
 </script>
+
+<style lang="scss" scoped>
+.onms-node-details {
+  padding: 1.5em;
+
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.25em;
+    padding: 0;
+  }
+}
+</style>

--- a/ui/src/containers/NodeDetails.vue
+++ b/ui/src/containers/NodeDetails.vue
@@ -17,7 +17,7 @@
     </div>
     <div class="onms-row">
       <div class="onms-col-12">
-        <NodeDetailsHeader :node="nodeStore.node" :base-href="baseHref" />
+        <NodeDetailsHeader :node="nodeStore.node" />
       </div>
     </div>
     <div class="onms-row" style="flex-wrap: inherit; padding: 4px;">

--- a/ui/src/containers/NodeDetails.vue
+++ b/ui/src/containers/NodeDetails.vue
@@ -7,12 +7,13 @@
     </div>
     <div class="header">
       <div class="heading">
-        <h2>Node Details for {{ nodeStore.node?.label }}</h2>
+        <h2>Node Details for {{ nodeTitle }}</h2>
       </div>
       <NodeActionsDropdown
         v-if="nodeLoaded"
         :baseHref="baseHref"
         :node="nodeStore.node"
+        :snmpPrimaryIpAddress="snmpPrimaryIpAddress"
       />
     </div>
     <template v-if="nodeLoaded">
@@ -60,10 +61,12 @@ import NodeDetailsHeader from '@/components/Nodes/NodeDetailsHeader.vue'
 import NodeNotificationsPanel from '@/components/Nodes/NodeNotificationsPanel.vue'
 import OutagesTable from '@/components/Nodes/OutagesTable.vue'
 import NodeSnmpAttributes from '@/components/Nodes/NodeSnmpAttributes.vue'
+import { useEventStore } from '@/stores/eventStore'
 import { useMenuStore } from '@/stores/menuStore'
 import { useNodeStore } from '@/stores/nodeStore'
 import { BreadCrumb, Node } from '@/types'
 
+const eventStore = useEventStore()
 const menuStore = useMenuStore()
 const nodeStore = useNodeStore()
 
@@ -79,6 +82,20 @@ const baseHref = computed<string>(() => menuStore.mainMenu.baseHref)
 // truthy and answers undefined for every field. The events, outages and interface tables fetch
 // by node id themselves and do not need it.
 const nodeLoaded = computed<boolean>(() => nodeStore.nodeLoaded)
+
+// A node that failed to load has no label to show -- a nonexistent id 404s -- while one still
+// in flight has nothing to say yet, so only the failure is spelled out.
+// Fetched alongside the node: the node payload carries no interfaces, and the IP Interfaces
+// table holds only whatever page it is showing.
+const snmpPrimaryIpAddress = computed<string | undefined>(() => nodeStore.snmpPrimaryIpAddress)
+
+const nodeTitle = computed<string>(() => {
+  if (nodeStore.nodeLoadFailed) {
+    return 'N/A'
+  }
+
+  return nodeStore.node?.label ?? ''
+})
 const homeUrl = computed<string>(() => menuStore.mainMenu.homeUrl)
 
 const items = computed<BreadCrumb[]>(() => [
@@ -87,15 +104,28 @@ const items = computed<BreadCrumb[]>(() => [
   { label: 'Node Details', to: '#', position: 'last' }
 ])
 
-const fetchNode = () => {
-  if (props.id) {
-    nodeStore.getNodeById({ id: props.id } as Node)
+const fetchNode = async () => {
+  if (!props.id) {
+    return
+  }
+
+  nodeStore.getNodeSnmpPrimaryInterface(props.id)
+
+  await nodeStore.getNodeById({ id: props.id } as Node)
+
+  // The events table fetches by node id itself and only replaces its rows on success, so a
+  // node that could not be fetched would otherwise keep the previous node's events on screen.
+  // Events are the event store's to clear, so the page asks rather than reaching across.
+  if (nodeStore.nodeLoadFailed) {
+    eventStore.clearEvents()
   }
 }
 
 onMounted(fetchNode)
 
 watch(() => props.id, fetchNode)
+
+defineExpose({ fetchNode })
 </script>
 
 <style lang="scss" scoped>

--- a/ui/src/containers/NodeDetails.vue
+++ b/ui/src/containers/NodeDetails.vue
@@ -10,28 +10,34 @@
         <h2>Node Details for {{ nodeStore.node?.label }}</h2>
       </div>
       <NodeActionsDropdown
-        v-if="nodeStore.node"
+        v-if="nodeLoaded"
         :baseHref="baseHref"
         :node="nodeStore.node"
       />
     </div>
-    <div class="onms-row">
-      <div class="onms-col-12">
-        <NodeDetailsHeader :node="nodeStore.node" />
+    <template v-if="nodeLoaded">
+      <div class="onms-row">
+        <div class="onms-col-12">
+          <NodeDetailsHeader :node="nodeStore.node" />
+        </div>
       </div>
-    </div>
+      <div class="onms-row" style="flex-wrap: inherit; padding: 4px;">
+        <div class="onms-col-6">
+          <NodeSnmpAttributes :node="nodeStore.node" />
+        </div>
+        <div class="onms-col-6">
+          <NodeCategoriesPanel :node="nodeStore.node" :base-href="baseHref" />
+          <NodeNotificationsPanel :node="nodeStore.node" :base-href="baseHref" />
+        </div>
+      </div>
+    </template>
     <div class="onms-row" style="flex-wrap: inherit; padding: 4px;">
       <div class="onms-col-6">
-        <NodeSnmpAttributes :node="nodeStore.node" />
-      </div>
-      <div class="onms-col-6">
-        <NodeCategoriesPanel :node="nodeStore.node" :base-href="baseHref" />
-        <NodeNotificationsPanel :node="nodeStore.node" :base-href="baseHref" />
-      </div>
-    </div>
-    <div class="onms-row" style="flex-wrap: inherit; padding: 4px;">
-      <div class="onms-col-6">
-        <NodeAvailabilityGraph :node="nodeStore.node" :base-href="baseHref" />
+        <NodeAvailabilityGraph
+          v-if="nodeLoaded"
+          :node="nodeStore.node"
+          :base-href="baseHref"
+        />
         <InterfacesTabs />
       </div>
       <div class="onms-col-6">
@@ -68,6 +74,11 @@ const props = defineProps({
 })
 
 const baseHref = computed<string>(() => menuStore.mainMenu.baseHref)
+
+// Panels that read the node wait for a real one: the store's node starts as {}, which is
+// truthy and answers undefined for every field. The events, outages and interface tables fetch
+// by node id themselves and do not need it.
+const nodeLoaded = computed<boolean>(() => nodeStore.nodeLoaded)
 const homeUrl = computed<string>(() => menuStore.mainMenu.homeUrl)
 
 const items = computed<BreadCrumb[]>(() => [

--- a/ui/src/containers/NodeDetails.vue
+++ b/ui/src/containers/NodeDetails.vue
@@ -9,6 +9,11 @@
       <div class="heading">
         <h2>Node Details for {{ nodeStore.node?.label }}</h2>
       </div>
+      <NodeActionsDropdown
+        v-if="nodeStore.node"
+        :baseHref="baseHref"
+        :node="nodeStore.node"
+      />
     </div>
     <div class="onms-row">
       <div class="onms-col-12">
@@ -40,6 +45,7 @@
 <script setup lang="ts">
 import { computed, onMounted, watch } from 'vue'
 import BreadCrumbs from '@/components/Layout/BreadCrumbs.vue'
+import NodeActionsDropdown from '@/components/Nodes/NodeActionsDropdown.vue'
 import EventsTable from '@/components/Nodes/EventsTable.vue'
 import InterfacesTabs from '@/components/Nodes/InterfacesTabs.vue'
 import NodeAvailabilityGraph from '@/components/Nodes/NodeAvailabilityGraph.vue'

--- a/ui/src/stores/eventStore.ts
+++ b/ui/src/stores/eventStore.ts
@@ -38,9 +38,21 @@ export const useEventStore = defineStore('eventStore', () => {
     }
   }
 
+  /**
+   * Fetch events matching the given query WITHOUT publishing them into `events`/`totalCount`,
+   * and hand them back to the caller. Keeps a download from disturbing the page the events
+   * table is currently showing, whatever query the download runs.
+   */
+  const getEventsForExport = async (queryParameters?: QueryParameters): Promise<Event[]> => {
+    const resp = await API.getEvents(queryParameters)
+
+    return resp ? resp.event : []
+  }
+
   return {
     events,
     totalCount,
-    getEvents
+    getEvents,
+    getEventsForExport
   }
 })

--- a/ui/src/stores/eventStore.ts
+++ b/ui/src/stores/eventStore.ts
@@ -29,8 +29,19 @@ export const useEventStore = defineStore('eventStore', () => {
   const events = ref([] as Event[])
   const totalCount = ref(0)
 
+  // Monotonic id sequencing getEvents requests, mirroring the node store's fetches: the events
+  // table fires one per node id as the user moves between nodes and again per page, so a slow
+  // response from a superseded request must not land under the current paginator state.
+  let eventsRequestId = 0
+
   const getEvents = async (queryParameters?: QueryParameters) => {
+    const requestId = ++eventsRequestId
+
     const resp = await API.getEvents(queryParameters)
+
+    if (requestId !== eventsRequestId) {
+      return
+    }
 
     if (resp) {
       events.value = resp.event

--- a/ui/src/stores/eventStore.ts
+++ b/ui/src/stores/eventStore.ts
@@ -39,20 +39,19 @@ export const useEventStore = defineStore('eventStore', () => {
   }
 
   /**
-   * Fetch events matching the given query WITHOUT publishing them into `events`/`totalCount`,
-   * and hand them back to the caller. Keeps a download from disturbing the page the events
-   * table is currently showing, whatever query the download runs.
+   * Drop the events on hand. The Node Details page calls this when its node fails to load:
+   * the events table fetches by node id itself and only replaces its rows on success, so the
+   * previous node's events would otherwise stay on screen.
    */
-  const getEventsForExport = async (queryParameters?: QueryParameters): Promise<Event[]> => {
-    const resp = await API.getEvents(queryParameters)
-
-    return resp ? resp.event : []
+  const clearEvents = () => {
+    events.value = []
+    totalCount.value = 0
   }
 
   return {
     events,
     totalCount,
     getEvents,
-    getEventsForExport
+    clearEvents
   }
 })

--- a/ui/src/stores/mapStore.ts
+++ b/ui/src/stores/mapStore.ts
@@ -125,8 +125,8 @@ export const useMapStore = defineStore('mapStore', () => {
     if (resp) {
       const nodes = resp.node.filter(
         node =>
-          !(node.assetRecord.latitude == null || node.assetRecord.latitude.length === 0) &&
-          !(node.assetRecord.longitude == null || node.assetRecord.longitude.length === 0)
+          !(node.assetRecord.latitude === undefined || node.assetRecord.latitude === null) &&
+          !(node.assetRecord.longitude === undefined || node.assetRecord.longitude === null)
       )
 
       nodesWithCoordinates.value = [...nodes]

--- a/ui/src/stores/nodeListStore.ts
+++ b/ui/src/stores/nodeListStore.ts
@@ -102,6 +102,10 @@ export const useNodeListStore = defineStore('nodeListStore', () => {
     serviceTypesLoaded.value = true
   }
 
+  const getServiceTypeByName = (name: string): ServiceType | undefined => {
+    return allServiceTypes.value.find(serviceType => serviceType.name.toLocaleLowerCase() === name.toLocaleLowerCase())
+  }
+
   const isAnyFilterSelected = () => {
     return (
       queryFilter.value.searchTerm?.length > 0 ||
@@ -532,6 +536,7 @@ export const useNodeListStore = defineStore('nodeListStore', () => {
     getCategories: fetchCategories,
     getMonitoringLocations: fetchMonitoringLocations,
     getServiceTypes: fetchServiceTypes,
+    getServiceTypeByName,
     getNodePreferences,
     isAnyFilterSelected,
     resetColumnSelectionToDefault,

--- a/ui/src/stores/nodeListStore.ts
+++ b/ui/src/stores/nodeListStore.ts
@@ -106,6 +106,12 @@ export const useNodeListStore = defineStore('nodeListStore', () => {
     return allServiceTypes.value.find(serviceType => serviceType.name.toLocaleLowerCase() === name.toLocaleLowerCase())
   }
 
+  // Outage records carry only a serviceId, so callers resolve the display name from here. A
+  // linear scan over the handful of service types an installation has is not worth indexing.
+  const getServiceTypeById = (id: number): ServiceType | undefined => {
+    return allServiceTypes.value.find(serviceType => serviceType.id === id)
+  }
+
   const isAnyFilterSelected = () => {
     return (
       queryFilter.value.searchTerm?.length > 0 ||
@@ -537,6 +543,7 @@ export const useNodeListStore = defineStore('nodeListStore', () => {
     getMonitoringLocations: fetchMonitoringLocations,
     getServiceTypes: fetchServiceTypes,
     getServiceTypeByName,
+    getServiceTypeById,
     getNodePreferences,
     isAnyFilterSelected,
     resetColumnSelectionToDefault,

--- a/ui/src/stores/nodeListStore.ts
+++ b/ui/src/stores/nodeListStore.ts
@@ -106,12 +106,6 @@ export const useNodeListStore = defineStore('nodeListStore', () => {
     return allServiceTypes.value.find(serviceType => serviceType.name.toLocaleLowerCase() === name.toLocaleLowerCase())
   }
 
-  // Outage records carry only a serviceId, so callers resolve the display name from here. A
-  // linear scan over the handful of service types an installation has is not worth indexing.
-  const getServiceTypeById = (id: number): ServiceType | undefined => {
-    return allServiceTypes.value.find(serviceType => serviceType.id === id)
-  }
-
   const isAnyFilterSelected = () => {
     return (
       queryFilter.value.searchTerm?.length > 0 ||
@@ -543,7 +537,6 @@ export const useNodeListStore = defineStore('nodeListStore', () => {
     getMonitoringLocations: fetchMonitoringLocations,
     getServiceTypes: fetchServiceTypes,
     getServiceTypeByName,
-    getServiceTypeById,
     getNodePreferences,
     isAnyFilterSelected,
     resetColumnSelectionToDefault,

--- a/ui/src/stores/nodeStore.ts
+++ b/ui/src/stores/nodeStore.ts
@@ -36,6 +36,14 @@ export const useNodeStore = defineStore('nodeStore', () => {
   // consumers cannot tell an unfetched node from a fetched one -- `node` starts as {}, which is
   // truthy and answers undefined for every field.
   const nodeLoaded = ref(false)
+
+  // Whether the last attempt to fetch a node failed, as distinct from not having finished:
+  // a page mid-fetch has nothing to say yet, a failed one has nothing to show at all.
+  const nodeLoadFailed = ref(false)
+
+  // Address of the node's SNMP-primary interface, which the node payload does not carry
+  // (OnmsNode.getPrimaryInterface is @Transient @JsonIgnore). Undefined when the node has none.
+  const snmpPrimaryIpAddress = ref<string | undefined>(undefined)
   const snmpInterfaces = ref([] as SnmpInterface[])
   const snmpInterfacesTotalCount = ref(0)
   const ipInterfaces = ref([] as IpInterface[])
@@ -71,12 +79,48 @@ export const useNodeStore = defineStore('nodeStore', () => {
     // user navigated away from.
     node.value = {} as Node
     nodeLoaded.value = false
+    nodeLoadFailed.value = false
 
     const resp = await API.getNodeById(n.id)
 
     if (resp) {
       node.value = resp
       nodeLoaded.value = true
+
+      return
+    }
+
+    nodeLoadFailed.value = true
+
+    // Every panel fetches by node id on its own and only replaces its rows on a successful
+    // response, so without this the previous node's data stays on screen under an id that has
+    // no node. Events live in their own store and are cleared by the page.
+    ipInterfaces.value = []
+    ipInterfacesTotalCount.value = 0
+    snmpInterfaces.value = []
+    snmpInterfacesTotalCount.value = 0
+    outages.value = []
+    outagesTotalCount.value = 0
+    availability.value = {} as NodeAvailability
+    snmpPrimaryIpAddress.value = undefined
+  }
+
+  /**
+   * Fetch the address of the node's SNMP-primary interface, which the "Update SNMP Information"
+   * action needs. Asked for directly rather than read off `ipInterfaces`: that holds whatever
+   * page the IP Interfaces table is showing, which need not include the primary.
+   */
+  const getNodeSnmpPrimaryInterface = async (id: string) => {
+    snmpPrimaryIpAddress.value = undefined
+
+    const resp = await API.getNodeIpInterfaces(id, {
+      limit: 1,
+      offset: 0,
+      _s: 'snmpPrimary==P'
+    })
+
+    if (resp) {
+      snmpPrimaryIpAddress.value = resp.ipInterface[0]?.ipAddress
     }
   }
 
@@ -210,17 +254,6 @@ export const useNodeStore = defineStore('nodeStore', () => {
     }
   }
 
-  /**
-   * Fetch a node's outages WITHOUT publishing them into `outages`/`outagesTotalCount`, and hand
-   * them back to the caller. Keeps a download from disturbing the page the outages table is
-   * currently showing, whatever query the download runs.
-   */
-  const getNodeOutagesForExport = async (payload: { id: string; queryParameters?: QueryParameters }): Promise<Outage[]> => {
-    const resp = await API.getNodeOutages(payload.id, payload.queryParameters)
-
-    return resp ? resp.outage : []
-  }
-
   const setNodeQueryParameters = async (params: QueryParameters) => {
     nodeQueryParameters.value = {
       ...params
@@ -232,6 +265,8 @@ export const useNodeStore = defineStore('nodeStore', () => {
     totalCount,
     node,
     nodeLoaded,
+    nodeLoadFailed,
+    snmpPrimaryIpAddress,
     snmpInterfaces,
     snmpInterfacesTotalCount,
     ipInterfaces,
@@ -250,7 +285,7 @@ export const useNodeStore = defineStore('nodeStore', () => {
     getNodeIpInterfaces,
     getNodeAvailabilityPercentage,
     getNodeOutages,
-    getNodeOutagesForExport,
+    getNodeSnmpPrimaryInterface,
     setNodeQueryParameters
   }
 })

--- a/ui/src/stores/nodeStore.ts
+++ b/ui/src/stores/nodeStore.ts
@@ -73,7 +73,24 @@ export const useNodeStore = defineStore('nodeStore', () => {
     }
   }
 
+  // Every fetch below is sequenced the same way, mirroring getIpInterfacesForNodes: the details
+  // page fires one per node id as the user moves between nodes, and the paginated ones fire
+  // again per page, so responses can come back in any order. A response applies only if no
+  // newer call has started since its request was issued.
+  let nodeSnmpInterfacesRequestId = 0
+  let nodeIpInterfacesRequestId = 0
+  let outagesRequestId = 0
+  let availabilityRequestId = 0
+
+  // Monotonic id sequencing getNodeById requests, mirroring getIpInterfacesForNodes below: the
+  // details page fires one per node id as the user moves between nodes, and the responses can
+  // come back in any order. Without this a slow response for the node the user left would
+  // overwrite the one they are on -- and a slow FAILURE would wipe every panel's data.
+  let nodeRequestId = 0
+
   const getNodeById = async (n: Node) => {
+    const requestId = ++nodeRequestId
+
     // Clear first: until this resolves there is no node to show, and the previous one belongs
     // to a different page. A failed request leaves nothing loaded rather than the node the
     // user navigated away from.
@@ -82,6 +99,10 @@ export const useNodeStore = defineStore('nodeStore', () => {
     nodeLoadFailed.value = false
 
     const resp = await API.getNodeById(n.id)
+
+    if (requestId !== nodeRequestId) {
+      return
+    }
 
     if (resp) {
       node.value = resp
@@ -105,12 +126,16 @@ export const useNodeStore = defineStore('nodeStore', () => {
     snmpPrimaryIpAddress.value = undefined
   }
 
+  let snmpPrimaryRequestId = 0
+
   /**
    * Fetch the address of the node's SNMP-primary interface, which the "Update SNMP Information"
    * action needs. Asked for directly rather than read off `ipInterfaces`: that holds whatever
    * page the IP Interfaces table is showing, which need not include the primary.
    */
   const getNodeSnmpPrimaryInterface = async (id: string) => {
+    const requestId = ++snmpPrimaryRequestId
+
     snmpPrimaryIpAddress.value = undefined
 
     const resp = await API.getNodeIpInterfaces(id, {
@@ -119,13 +144,26 @@ export const useNodeStore = defineStore('nodeStore', () => {
       _s: 'snmpPrimary==P'
     })
 
+    // Sequenced like getNodeById above. A stale address here is worse than a missing one: the
+    // Update SNMP action would point at an address that is not this node's, and the form
+    // rewrites SNMP configuration for whatever address it is handed.
+    if (requestId !== snmpPrimaryRequestId) {
+      return
+    }
+
     if (resp) {
       snmpPrimaryIpAddress.value = resp.ipInterface[0]?.ipAddress
     }
   }
 
   const getNodeSnmpInterfaces = async (payload: { id: string; queryParameters?: QueryParameters }) => {
+    const requestId = ++nodeSnmpInterfacesRequestId
+
     const resp = await API.getNodeSnmpInterfaces(payload.id, payload.queryParameters)
+
+    if (requestId !== nodeSnmpInterfacesRequestId) {
+      return
+    }
 
     if (resp) {
       snmpInterfaces.value = resp.snmpInterface
@@ -134,7 +172,13 @@ export const useNodeStore = defineStore('nodeStore', () => {
   }
 
   const getNodeIpInterfaces = async (payload: { id: string; queryParameters?: QueryParameters }) => {
+    const requestId = ++nodeIpInterfacesRequestId
+
     const resp = await API.getNodeIpInterfaces(payload.id, payload.queryParameters)
+
+    if (requestId !== nodeIpInterfacesRequestId) {
+      return
+    }
 
     if (resp) {
       ipInterfaces.value = resp.ipInterface
@@ -238,7 +282,13 @@ export const useNodeStore = defineStore('nodeStore', () => {
   }
 
   const getNodeAvailabilityPercentage = async (id: string) => {
+    const requestId = ++availabilityRequestId
+
     const av = await API.getNodeAvailabilityPercentage(id)
+
+    if (requestId !== availabilityRequestId) {
+      return
+    }
 
     if (av) {
       availability.value = av
@@ -246,7 +296,13 @@ export const useNodeStore = defineStore('nodeStore', () => {
   }
 
   const getNodeOutages = async (payload: { id: string; queryParameters?: QueryParameters }) => {
+    const requestId = ++outagesRequestId
+
     const resp = await API.getNodeOutages(payload.id, payload.queryParameters)
+
+    if (requestId !== outagesRequestId) {
+      return
+    }
 
     if (resp) {
       outages.value = resp.outage

--- a/ui/src/stores/nodeStore.ts
+++ b/ui/src/stores/nodeStore.ts
@@ -31,6 +31,11 @@ export const useNodeStore = defineStore('nodeStore', () => {
   const nodes = ref([] as Node[])
   const totalCount = ref(0)
   const node = ref({} as Node)
+
+  // Whether `node` holds a real node. The store is global and outlives any one page, so
+  // consumers cannot tell an unfetched node from a fetched one -- `node` starts as {}, which is
+  // truthy and answers undefined for every field.
+  const nodeLoaded = ref(false)
   const snmpInterfaces = ref([] as SnmpInterface[])
   const snmpInterfacesTotalCount = ref(0)
   const ipInterfaces = ref([] as IpInterface[])
@@ -61,10 +66,17 @@ export const useNodeStore = defineStore('nodeStore', () => {
   }
 
   const getNodeById = async (n: Node) => {
+    // Clear first: until this resolves there is no node to show, and the previous one belongs
+    // to a different page. A failed request leaves nothing loaded rather than the node the
+    // user navigated away from.
+    node.value = {} as Node
+    nodeLoaded.value = false
+
     const resp = await API.getNodeById(n.id)
 
     if (resp) {
       node.value = resp
+      nodeLoaded.value = true
     }
   }
 
@@ -219,6 +231,7 @@ export const useNodeStore = defineStore('nodeStore', () => {
     nodes,
     totalCount,
     node,
+    nodeLoaded,
     snmpInterfaces,
     snmpInterfacesTotalCount,
     ipInterfaces,

--- a/ui/src/stores/nodeStore.ts
+++ b/ui/src/stores/nodeStore.ts
@@ -198,6 +198,17 @@ export const useNodeStore = defineStore('nodeStore', () => {
     }
   }
 
+  /**
+   * Fetch a node's outages WITHOUT publishing them into `outages`/`outagesTotalCount`, and hand
+   * them back to the caller. Keeps a download from disturbing the page the outages table is
+   * currently showing, whatever query the download runs.
+   */
+  const getNodeOutagesForExport = async (payload: { id: string; queryParameters?: QueryParameters }): Promise<Outage[]> => {
+    const resp = await API.getNodeOutages(payload.id, payload.queryParameters)
+
+    return resp ? resp.outage : []
+  }
+
   const setNodeQueryParameters = async (params: QueryParameters) => {
     nodeQueryParameters.value = {
       ...params
@@ -226,6 +237,7 @@ export const useNodeStore = defineStore('nodeStore', () => {
     getNodeIpInterfaces,
     getNodeAvailabilityPercentage,
     getNodeOutages,
+    getNodeOutagesForExport,
     setNodeQueryParameters
   }
 })

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -137,18 +137,74 @@ export interface MonitoringSystemMainResponse {
   type: string
 }
 
+export interface NodeAssetRecord {
+  address1?: string | null
+  address2?: string | null
+  additionalhardware?: string | null
+  admin?: string | null
+  assetNumber?: string | null
+  autoenable?: string | null
+  building?: string | null
+  category?: string | null
+  circuitId?: string | null
+  city?: string | null
+  comment?: string | null
+  connection?: string | null
+  cpu?: string | null
+  dateInstalled?: string | null
+  department?: string | null
+  description?: string | null
+  displayCategory?: string | null
+  division?: string | null
+  enable?: string | null
+  floor?: string | null
+  hdd1?: string | null
+  hdd2?: string | null
+  hdd3?: string | null
+  hdd4?: string | null
+  hdd5?: string | null
+  hdd6?: string | null
+  inputpower?: string | null
+  latitude?: number | null
+  lease?: string | null
+  leaseExpires?: string | null
+  longitude?: number | null
+  maintcontract?: string | null
+  maintContractExpires?: string | null
+  manufacturer?: string | null
+  modelNumber?: string | null
+  notifyCategory?: string | null
+  numpowersupplies?: string | null
+  operatingSystem?: string | null
+  password?: string | null
+  pollerCategory?: string | null
+  port?: string | null
+  rack?: string | null
+  rackunitheight?: string | null
+  ram?: string | null
+  region?: string | null
+  room?: string | null
+  serialNumber?: string | null
+  slot?: string | null
+  snmpcommunity?: string | null
+  state?: string | null
+  storagectrl?: string | null
+  supportPhone?: string | null
+  thresholdCategory?: string | null
+  username?: string | null
+  vendor?: string | null
+  vendorAssetNumber?: string | null
+  vendorFax?: string | null
+  vendorPhone?: string | null
+  zip?: string | null
+}
+
 export interface Node {
   location: string
   type: string
   label: string
   id: string
-  assetRecord: {
-    longitude: string
-    latitude: string
-    category: string
-    description: string
-    maintcontract: string
-  }
+  assetRecord: NodeAssetRecord
   categories: Category[]
   createTime: number
   foreignId: string
@@ -280,16 +336,33 @@ export interface IpInterface {
   snmpPrimary: string
   hostName: string
 }
+export interface MonitoredService {
+  id: number
+  lastGood?: Date | null
+  lastFail?: Date | null
+  qualifier?: string
+  status?: string
+  source?: string
+  notify?: string
+  serviceType?: ServiceType
+  ipInterface?: IpInterface
+}
 
 export interface Outage {
-  nodeId: number
-  ipAddress: string
-  serviceIs: number
-  nodeLabel: string
-  location: string
   hostname: string
+  id: number
+  ifLostService: Date | null
+  ifRegainedService: Date | null
+  ipAddress: string
+  locationName: string
+  monitoredService?: MonitoredService
+  nodeId: number
+  nodeLabel: string
+  perspective?: MonitoringLocation
+  serviceId: number
   serviceName: string
-  outageId: number
+  suppressTime?: Date | null
+  suppressedBy?: string | null
 }
 
 export interface IfService {

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -348,8 +348,9 @@ export interface MonitoredService {
   ipInterface?: IpInterface
 }
 
+// Mirrors what /api/v2/outages actually returns. It sends no hostname and no serviceName --
+// OnmsOutage has neither -- so the service name is resolved from serviceId by the caller.
 export interface Outage {
-  hostname: string
   id: number
   ifLostService: Date | null
   ifRegainedService: Date | null
@@ -360,7 +361,6 @@ export interface Outage {
   nodeLabel: string
   perspective?: MonitoringLocation
   serviceId: number
-  serviceName: string
   suppressTime?: Date | null
   suppressedBy?: string | null
 }

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -350,6 +350,9 @@ export interface MonitoredService {
 
 // Mirrors what /api/v2/outages actually returns. It sends no hostname and no serviceName --
 // OnmsOutage has neither -- so the service name is resolved from serviceId by the caller.
+// perspective is the monitoring location NAME, not the location: OnmsOutage.getPerspective
+// returns an OnmsMonitoringLocation, but MonitoringLocationJsonSerializer writes it out as
+// just getLocationName() (and the XML adapter does the same).
 export interface Outage {
   id: number
   ifLostService: Date | null
@@ -359,7 +362,7 @@ export interface Outage {
   monitoredService?: MonitoredService
   nodeId: number
   nodeLabel: string
-  perspective?: MonitoringLocation
+  perspective?: string
   serviceId: number
   suppressTime?: Date | null
   suppressedBy?: string | null

--- a/ui/tests/components/Nodes/EventsTable.test.ts
+++ b/ui/tests/components/Nodes/EventsTable.test.ts
@@ -221,61 +221,42 @@ describe('EventsTable.vue', () => {
       }) as any)
     })
 
-    it('requests the default page size for the node, leaving the visible page untouched', async () => {
-      eventStore.getEventsForExport = vi.fn().mockResolvedValue([mockEvent])
+    // The download is the page the paginator is showing, which the store already holds: no
+    // second request, and no way for the file to disagree with the table.
+    it('exports the rows the table is showing without another request', async () => {
       eventStore.events = [mockEvent] as any
       eventStore.totalCount = 1
+      vi.clearAllMocks()
 
       await runDownload('Download CSV...')
 
-      expect(eventStore.getEventsForExport).toHaveBeenCalledWith({
-        limit: 5,
-        offset: 0,
-        _s: `node.id==${mockNodeId}`
-      })
-      expect(eventStore.events).toEqual([mockEvent])
-      expect(eventStore.totalCount).toBe(1)
-    })
-
-    // The download is the page the paginator is showing, so raising rows-per-page is how a user
-    // downloads more; the whole set comes from the Events page instead.
-    it('follows the paginator when the user changes page or rows-per-page', async () => {
-      eventStore.getEventsForExport = vi.fn().mockResolvedValue([mockEvent])
-
-      await wrapper.vm.onPage({ first: 20, rows: 20, page: 1, pageCount: 2 })
-      await flushPromises()
-      await runDownload('Download CSV...')
-
-      expect(eventStore.getEventsForExport).toHaveBeenCalledWith({
-        limit: 20,
-        offset: 20,
-        _s: `node.id==${mockNodeId}`
-      })
+      expect(eventStore.getEvents).not.toHaveBeenCalled()
+      expect(downloadNames).toEqual(['Events.csv'])
+      expect(await blobs[0].text()).toContain(String(mockEvent.id))
     })
 
     it('downloads a CSV of every event field, quoting values that contain commas or quotes', async () => {
-      eventStore.getEventsForExport = vi.fn().mockResolvedValue([
+      eventStore.events = [
         {
           id: 101,
           severity: 'Major',
-          logMessage: '<p>Interface "eth0" down, node 42</p>',
-          serviceType: { id: 3, name: 'ICMP' }
+          logMessage: '<p>Interface "eth0" down, node 42</p>'
         }
-      ])
+      ] as any
 
       await runDownload('Download CSV...')
 
       expect(downloadNames).toEqual(['Events.csv'])
       expect(blobs[0].type).toBe('text/csv')
       expect(await blobs[0].text()).toBe(
-        'id,severity,logMessage,serviceType\n' +
-        '101,Major,"<p>Interface ""eth0"" down, node 42</p>",ICMP'
+        'id,severity,logMessage\n' +
+        '101,Major,"<p>Interface ""eth0"" down, node 42</p>"'
       )
     })
 
     // The table only shows 4 columns, but the export is the whole record.
     it('includes CSV columns for fields the table does not display', async () => {
-      eventStore.getEventsForExport = vi.fn().mockResolvedValue([mockEvent])
+      eventStore.events = [mockEvent] as any
 
       await runDownload('Download CSV...')
 
@@ -285,10 +266,8 @@ describe('EventsTable.vue', () => {
 
     // parameters is the other non-primitive field on an event; String() on it would put
     // '[object Object]' in the cell.
-    it('keeps other non-primitive CSV fields readable as JSON', async () => {
-      eventStore.getEventsForExport = vi.fn().mockResolvedValue([
-        { id: 101, parameters: [{ name: 'p1', value: 'v1' }] }
-      ])
+    it('keeps array CSV fields readable as JSON', async () => {
+      eventStore.events = [{ id: 101, parameters: [{ name: 'p1', value: 'v1' }] }] as any
 
       await runDownload('Download CSV...')
 
@@ -299,7 +278,7 @@ describe('EventsTable.vue', () => {
     })
 
     it('downloads JSON of the full event records', async () => {
-      eventStore.getEventsForExport = vi.fn().mockResolvedValue([mockEvent])
+      eventStore.events = [mockEvent] as any
 
       await runDownload('Download JSON...')
 
@@ -309,7 +288,7 @@ describe('EventsTable.vue', () => {
     })
 
     it('shows an error snackbar and downloads nothing when the node has no events', async () => {
-      eventStore.getEventsForExport = vi.fn().mockResolvedValue([])
+      eventStore.events = [] as any
 
       await runDownload('Download CSV...')
 
@@ -323,23 +302,12 @@ describe('EventsTable.vue', () => {
   describe('Node changes under the same component instance', () => {
     // /node/42 -> /node/99 reuses this instance, so a table that only reads the route id at
     // setup would keep showing node 42 while the panel's other links point at 99.
-    it('refetches for the new node and exports that node', async () => {
-      // Empty, so the download stops at the snackbar: what matters here is the node it asked
-      // for, not the file it would have produced.
-      eventStore.getEventsForExport = vi.fn().mockResolvedValue([])
+    it('refetches for the new node', async () => {
       ;(useRoute() as any).params.id = '99'
       await flushPromises()
 
       expect(eventStore.getEvents).toHaveBeenCalledWith(
         expect.objectContaining({ _s: 'node.id==99', offset: 0, limit: 5 })
-      )
-
-      const items = wrapper.findComponent(NodeDownloadDropdown).vm.items as Array<{ label: string, command: () => void }>
-      await items[0].command()
-      await flushPromises()
-
-      expect(eventStore.getEventsForExport).toHaveBeenCalledWith(
-        expect.objectContaining({ _s: 'node.id==99' })
       )
     })
   })

--- a/ui/tests/components/Nodes/EventsTable.test.ts
+++ b/ui/tests/components/Nodes/EventsTable.test.ts
@@ -21,7 +21,9 @@
 ///
 
 import EventsTable from '@/components/Nodes/EventsTable.vue'
+import NodeDownloadDropdown from '@/components/Nodes/NodeDownloadDropdown.vue'
 import { useEventStore } from '@/stores/eventStore'
+import { useMenuStore } from '@/stores/menuStore'
 import { createTestingPinia } from '@pinia/testing'
 import { flushPromises, mount, VueWrapper } from '@vue/test-utils'
 import PrimeVue from 'primevue/config'
@@ -33,6 +35,9 @@ const mockNodeId = '42'
 vi.mock('vue-router', () => ({
   useRoute: () => ({ params: { id: mockNodeId }})
 }))
+
+const { showSnackBar } = vi.hoisted(() => ({ showSnackBar: vi.fn() }))
+vi.mock('@/composables/useSnackbar', () => ({ default: () => ({ showSnackBar }) }))
 
 const mockEvent = {
   id: 101,
@@ -148,6 +153,163 @@ describe('EventsTable.vue', () => {
 
       const rows = wrapper.findAll('tbody tr')
       expect(rows[0].html()).toContain('<p>A test log message</p>')
+    })
+  })
+
+  describe('Card and title row', () => {
+    it('wraps the panel content in a card with the title and both action buttons on one row', () => {
+      expect(wrapper.find('.card').exists()).toBe(true)
+
+      const titleRow = wrapper.find('.title-row')
+      expect(titleRow.text()).toContain('Recent Events')
+      expect(titleRow.find('[data-test="events-for-node-button"]').exists()).toBe(true)
+      expect(titleRow.find('[data-test="download-button"]').exists()).toBe(true)
+    })
+  })
+
+  describe('Events for this Node link', () => {
+    it('navigates to the legacy event list filtered to this node', async () => {
+      const assign = vi.fn()
+      vi.stubGlobal('location', { assign } as any)
+      useMenuStore().mainMenu = { baseHref: '/opennms/' } as any
+      await nextTick()
+
+      await wrapper.find('[data-test="events-for-node-button"]').trigger('click')
+
+      expect(assign).toHaveBeenCalledWith(`/opennms/event/list?filter=node%3D${mockNodeId}`)
+      vi.unstubAllGlobals()
+    })
+  })
+
+  describe('Download', () => {
+    // Drive the real menu wiring rather than the component internals: the dropdown owns the
+    // CSV/JSON menu items and calls back into the table.
+    const runDownload = async (label: string) => {
+      const items = wrapper.findComponent(NodeDownloadDropdown).vm.items as Array<{ label: string, command: () => void }>
+      await items.find(i => i.label === label)!.command()
+      await flushPromises()
+    }
+
+    let blobs: Blob[]
+    let downloadNames: string[]
+
+    beforeEach(() => {
+      blobs = []
+      downloadNames = []
+
+      vi.stubGlobal('URL', {
+        createObjectURL: (blob: Blob) => {
+          blobs.push(blob)
+          return 'blob:fake'
+        }
+      } as any)
+
+      const realCreateElement = document.createElement.bind(document)
+      vi.spyOn(document, 'createElement').mockImplementation(((tag: string, options?: any) => {
+        const el = realCreateElement(tag, options)
+        if (tag === 'a') {
+          Object.defineProperty(el, 'click', { value: () => downloadNames.push((el as HTMLAnchorElement).download) })
+        }
+        return el
+      }) as any)
+    })
+
+    it('requests the default page size for the node, leaving the visible page untouched', async () => {
+      eventStore.getEventsForExport = vi.fn().mockResolvedValue([mockEvent])
+      eventStore.events = [mockEvent] as any
+      eventStore.totalCount = 1
+
+      await runDownload('Download CSV...')
+
+      expect(eventStore.getEventsForExport).toHaveBeenCalledWith({
+        limit: 5,
+        offset: 0,
+        _s: `node.id==${mockNodeId}`
+      })
+      expect(eventStore.events).toEqual([mockEvent])
+      expect(eventStore.totalCount).toBe(1)
+    })
+
+    // The download is the page the paginator is showing, so raising rows-per-page is how a user
+    // downloads more; the whole set comes from the Events page instead.
+    it('follows the paginator when the user changes page or rows-per-page', async () => {
+      eventStore.getEventsForExport = vi.fn().mockResolvedValue([mockEvent])
+
+      await wrapper.vm.onPage({ first: 20, rows: 20, page: 1, pageCount: 2 })
+      await flushPromises()
+      await runDownload('Download CSV...')
+
+      expect(eventStore.getEventsForExport).toHaveBeenCalledWith({
+        limit: 20,
+        offset: 20,
+        _s: `node.id==${mockNodeId}`
+      })
+    })
+
+    it('downloads a CSV of every event field, quoting values that contain commas or quotes', async () => {
+      eventStore.getEventsForExport = vi.fn().mockResolvedValue([
+        {
+          id: 101,
+          severity: 'Major',
+          logMessage: '<p>Interface "eth0" down, node 42</p>',
+          serviceType: { id: 3, name: 'ICMP' }
+        }
+      ])
+
+      await runDownload('Download CSV...')
+
+      expect(downloadNames).toEqual(['Events.csv'])
+      expect(blobs[0].type).toBe('text/csv')
+      expect(await blobs[0].text()).toBe(
+        'id,severity,logMessage,serviceType\n' +
+        '101,Major,"<p>Interface ""eth0"" down, node 42</p>",ICMP'
+      )
+    })
+
+    // The table only shows 4 columns, but the export is the whole record.
+    it('includes CSV columns for fields the table does not display', async () => {
+      eventStore.getEventsForExport = vi.fn().mockResolvedValue([mockEvent])
+
+      await runDownload('Download CSV...')
+
+      const [header] = (await blobs[0].text()).split('\n')
+      expect(header.split(',')).toEqual(Object.keys(mockEvent))
+    })
+
+    // parameters is the other non-primitive field on an event; String() on it would put
+    // '[object Object]' in the cell.
+    it('keeps other non-primitive CSV fields readable as JSON', async () => {
+      eventStore.getEventsForExport = vi.fn().mockResolvedValue([
+        { id: 101, parameters: [{ name: 'p1', value: 'v1' }] }
+      ])
+
+      await runDownload('Download CSV...')
+
+      expect(await blobs[0].text()).toBe(
+        'id,parameters\n' +
+        '101,"[{""name"":""p1"",""value"":""v1""}]"'
+      )
+    })
+
+    it('downloads JSON of the full event records', async () => {
+      eventStore.getEventsForExport = vi.fn().mockResolvedValue([mockEvent])
+
+      await runDownload('Download JSON...')
+
+      expect(downloadNames).toEqual(['Events.json'])
+      expect(blobs[0].type).toBe('application/json')
+      expect(JSON.parse(await blobs[0].text())).toEqual([mockEvent])
+    })
+
+    it('shows an error snackbar and downloads nothing when the node has no events', async () => {
+      eventStore.getEventsForExport = vi.fn().mockResolvedValue([])
+
+      await runDownload('Download CSV...')
+
+      expect(downloadNames).toEqual([])
+      expect(showSnackBar).toHaveBeenCalledWith(
+        expect.objectContaining({ error: true })
+      )
     })
   })
 

--- a/ui/tests/components/Nodes/EventsTable.test.ts
+++ b/ui/tests/components/Nodes/EventsTable.test.ts
@@ -29,12 +29,18 @@ import { flushPromises, mount, VueWrapper } from '@vue/test-utils'
 import PrimeVue from 'primevue/config'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
+import { useRoute } from 'vue-router'
 
 const mockNodeId = '42'
 
-vi.mock('vue-router', () => ({
-  useRoute: () => ({ params: { id: mockNodeId }})
-}))
+// A reactive route, so a test can change the node id the way navigating to another node does.
+// The details page keeps one component instance across those changes.
+vi.mock('vue-router', async () => {
+  const { reactive } = await import('vue')
+  const route = reactive({ params: { id: '42' }})
+
+  return { useRoute: () => route }
+})
 
 const { showSnackBar } = vi.hoisted(() => ({ showSnackBar: vi.fn() }))
 vi.mock('@/composables/useSnackbar', () => ({ default: () => ({ showSnackBar }) }))
@@ -91,6 +97,7 @@ describe('EventsTable.vue', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks()
+    ;(useRoute() as any).params.id = mockNodeId
     wrapper = mountTable()
     eventStore.events = []
     eventStore.totalCount = 0
@@ -309,6 +316,30 @@ describe('EventsTable.vue', () => {
       expect(downloadNames).toEqual([])
       expect(showSnackBar).toHaveBeenCalledWith(
         expect.objectContaining({ error: true })
+      )
+    })
+  })
+
+  describe('Node changes under the same component instance', () => {
+    // /node/42 -> /node/99 reuses this instance, so a table that only reads the route id at
+    // setup would keep showing node 42 while the panel's other links point at 99.
+    it('refetches for the new node and exports that node', async () => {
+      // Empty, so the download stops at the snackbar: what matters here is the node it asked
+      // for, not the file it would have produced.
+      eventStore.getEventsForExport = vi.fn().mockResolvedValue([])
+      ;(useRoute() as any).params.id = '99'
+      await flushPromises()
+
+      expect(eventStore.getEvents).toHaveBeenCalledWith(
+        expect.objectContaining({ _s: 'node.id==99', offset: 0, limit: 5 })
+      )
+
+      const items = wrapper.findComponent(NodeDownloadDropdown).vm.items as Array<{ label: string, command: () => void }>
+      await items[0].command()
+      await flushPromises()
+
+      expect(eventStore.getEventsForExport).toHaveBeenCalledWith(
+        expect.objectContaining({ _s: 'node.id==99' })
       )
     })
   })

--- a/ui/tests/components/Nodes/IpInterfacesTable.test.ts
+++ b/ui/tests/components/Nodes/IpInterfacesTable.test.ts
@@ -27,12 +27,18 @@ import { flushPromises, mount, VueWrapper } from '@vue/test-utils'
 import PrimeVue from 'primevue/config'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
+import { useRoute } from 'vue-router'
 
 const mockNodeId = '42'
 
-vi.mock('vue-router', () => ({
-  useRoute: () => ({ params: { id: mockNodeId }})
-}))
+// A reactive route, so a test can change the node id the way navigating to another node does.
+// The details page keeps one component instance across those changes.
+vi.mock('vue-router', async () => {
+  const { reactive } = await import('vue')
+  const route = reactive({ params: { id: '42' }})
+
+  return { useRoute: () => route }
+})
 
 describe('IpInterfacesTable.vue', () => {
   let wrapper: VueWrapper<any>
@@ -167,6 +173,25 @@ describe('IpInterfacesTable.vue', () => {
       expect(nodeStore.getNodeIpInterfaces).toHaveBeenCalledWith(
         expect.objectContaining({ id: mockNodeId })
       )
+    })
+  })
+
+  describe('Node changes under the same component instance', () => {
+    // /node/42 -> /node/99 reuses this instance, so a table that only reads the route id at
+    // mount would keep showing the interfaces of the node the user navigated away from.
+    it('refetches for the new node and returns to the first page', async () => {
+      await wrapper.vm.onPage({ first: 10, rows: 5, page: 2, pageCount: 3 } as any)
+      await flushPromises()
+      vi.clearAllMocks()
+
+      ;(useRoute() as any).params.id = '99'
+      await flushPromises()
+
+      expect(nodeStore.getNodeIpInterfaces).toHaveBeenCalledWith({
+        id: '99',
+        queryParameters: { limit: 5, offset: 0, _s: 'isManaged==U,isManaged==P,isManaged==N,isManaged==M' }
+      })
+      ;(useRoute() as any).params.id = '42'
     })
   })
 })

--- a/ui/tests/components/Nodes/IpInterfacesTable.test.ts
+++ b/ui/tests/components/Nodes/IpInterfacesTable.test.ts
@@ -180,7 +180,8 @@ describe('IpInterfacesTable.vue', () => {
     // /node/42 -> /node/99 reuses this instance, so a table that only reads the route id at
     // mount would keep showing the interfaces of the node the user navigated away from.
     it('refetches for the new node and returns to the first page', async () => {
-      await wrapper.vm.onPage({ first: 10, rows: 5, page: 2, pageCount: 3 } as any)
+      // rows-per-page is the user's choice and survives the node change; only the page resets.
+      await wrapper.vm.onPage({ first: 20, rows: 10, page: 2, pageCount: 3 } as any)
       await flushPromises()
       vi.clearAllMocks()
 
@@ -189,7 +190,7 @@ describe('IpInterfacesTable.vue', () => {
 
       expect(nodeStore.getNodeIpInterfaces).toHaveBeenCalledWith({
         id: '99',
-        queryParameters: { limit: 5, offset: 0, _s: 'isManaged==U,isManaged==P,isManaged==N,isManaged==M' }
+        queryParameters: { limit: 10, offset: 0, _s: 'isManaged==U,isManaged==P,isManaged==N,isManaged==M' }
       })
       ;(useRoute() as any).params.id = '42'
     })

--- a/ui/tests/components/Nodes/NodeActionsDropdown.test.ts
+++ b/ui/tests/components/Nodes/NodeActionsDropdown.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 import PrimeVue from 'primevue/config'
 import NodeActionsDropdown from '@/components/Nodes/NodeActionsDropdown.vue'
 
-const node = { id: 42, label: 'srv-42' } as any
+const node = { id: 42, label: 'srv-42', assetRecord: {}} as any
 
 const mountIt = (overrides: any = {}) =>
   mount(NodeActionsDropdown, {

--- a/ui/tests/components/Nodes/NodeActionsDropdown.test.ts
+++ b/ui/tests/components/Nodes/NodeActionsDropdown.test.ts
@@ -19,7 +19,7 @@ describe('NodeActionsDropdown.vue', () => {
     expect(items[0].label).toBe('Info...')
     expect(items.map(i => i.label)).toContain('Events')
     expect(items.map(i => i.label)).toContain('View Topology Map')
-    expect(items).toHaveLength(15) // Info + 14 links
+    expect(items).toHaveLength(14) // Info + 13 links; Update SNMP needs an address
   })
 
   // Driven by the shared nodeActionLinks list, which filters a Site Status link the node
@@ -28,7 +28,7 @@ describe('NodeActionsDropdown.vue', () => {
     const wrapper = mountIt({ node: { ...node, assetRecord: { building: 'HQ 1' }}})
     const items = (wrapper.vm as any).items as Array<{ label: string }>
     expect(items.map(i => i.label)).toContain('Site Status')
-    expect(items).toHaveLength(16) // Info + 15 links
+    expect(items).toHaveLength(15) // Info + 14 links; Update SNMP needs an address
   })
 
   it('omits Site Status for a node with no building', () => {
@@ -44,6 +44,21 @@ describe('NodeActionsDropdown.vue', () => {
     const items = (wrapper.vm as any).items as Array<{ label: string, command: () => void }>
     items.find(i => i.label === 'Site Status')!.command()
     expect(assign).toHaveBeenCalledWith('/opennms/siteStatusView.htm?statusSite=HQ%201')
+    vi.unstubAllGlobals()
+  })
+
+  it('offers Update SNMP Information only when given the SNMP-primary address', () => {
+    const without = (mountIt().vm as any).items as Array<{ label: string }>
+    expect(without.map(i => i.label)).not.toContain('Update SNMP Information')
+
+    const wrapper = mountIt({ snmpPrimaryIpAddress: '10.0.0.44' })
+    const items = (wrapper.vm as any).items as Array<{ label: string, command: () => void }>
+    expect(items.map(i => i.label)).toContain('Update SNMP Information')
+
+    const assign = vi.fn()
+    vi.stubGlobal('location', { assign } as any)
+    items.find(i => i.label === 'Update SNMP Information')!.command()
+    expect(assign).toHaveBeenCalledWith('/opennms/admin/updateSnmp.jsp?node=42&ipaddr=10.0.0.44')
     vi.unstubAllGlobals()
   })
 
@@ -73,7 +88,7 @@ describe('NodeActionsDropdown.vue', () => {
     const items = (wrapper.vm as any).items as Array<{ label: string }>
     expect(items.map(i => i.label)).not.toContain('Info...')
     expect(items[0].label).toBe('Events')
-    expect(items).toHaveLength(14)
+    expect(items).toHaveLength(13)
   })
 
   it('Info... command calls triggerNodeInfo with the node', () => {

--- a/ui/tests/components/Nodes/NodeActionsDropdown.test.ts
+++ b/ui/tests/components/Nodes/NodeActionsDropdown.test.ts
@@ -22,18 +22,43 @@ describe('NodeActionsDropdown.vue', () => {
     expect(items).toHaveLength(15) // Info + 14 links
   })
 
-  it('offers Node Link Detailed Info last', () => {
-    const wrapper = mountIt()
+  // Driven by the shared nodeActionLinks list, which filters a Site Status link the node
+  // cannot supply a building for.
+  it('offers Site Status for a node with a building', () => {
+    const wrapper = mountIt({ node: { ...node, assetRecord: { building: 'HQ 1' }}})
     const items = (wrapper.vm as any).items as Array<{ label: string }>
-    expect(items[items.length - 1].label).toBe('Node Link Detailed Info')
+    expect(items.map(i => i.label)).toContain('Site Status')
+    expect(items).toHaveLength(16) // Info + 15 links
   })
 
-  it('Node Link Detailed Info navigates to the linked node page', () => {
+  it('omits Site Status for a node with no building', () => {
+    const wrapper = mountIt()
+    const items = (wrapper.vm as any).items as Array<{ label: string }>
+    expect(items.map(i => i.label)).not.toContain('Site Status')
+  })
+
+  it('Site Status navigates to the site status view', () => {
+    const assign = vi.fn()
+    vi.stubGlobal('location', { assign } as any)
+    const wrapper = mountIt({ node: { ...node, assetRecord: { building: 'HQ 1' }}})
+    const items = (wrapper.vm as any).items as Array<{ label: string, command: () => void }>
+    items.find(i => i.label === 'Site Status')!.command()
+    expect(assign).toHaveBeenCalledWith('/opennms/siteStatusView.htm?statusSite=HQ%201')
+    vi.unstubAllGlobals()
+  })
+
+  it('offers Node Link Details last', () => {
+    const wrapper = mountIt()
+    const items = (wrapper.vm as any).items as Array<{ label: string }>
+    expect(items[items.length - 1].label).toBe('Node Link Details')
+  })
+
+  it('Node Link Details navigates to the linked node page', () => {
     const assign = vi.fn()
     vi.stubGlobal('location', { assign } as any)
     const wrapper = mountIt()
     const items = (wrapper.vm as any).items as Array<{ label: string, command: () => void }>
-    items.find(i => i.label === 'Node Link Detailed Info')!.command()
+    items.find(i => i.label === 'Node Link Details')!.command()
     expect(assign).toHaveBeenCalledWith('/opennms/element/linkednode.jsp?node=42')
     vi.unstubAllGlobals()
   })

--- a/ui/tests/components/Nodes/NodeActionsDropdown.test.ts
+++ b/ui/tests/components/Nodes/NodeActionsDropdown.test.ts
@@ -19,7 +19,36 @@ describe('NodeActionsDropdown.vue', () => {
     expect(items[0].label).toBe('Info...')
     expect(items.map(i => i.label)).toContain('Events')
     expect(items.map(i => i.label)).toContain('View Topology Map')
-    expect(items).toHaveLength(14) // Info + 13 links
+    expect(items).toHaveLength(15) // Info + 14 links
+  })
+
+  it('offers Node Link Detailed Info last', () => {
+    const wrapper = mountIt()
+    const items = (wrapper.vm as any).items as Array<{ label: string }>
+    expect(items[items.length - 1].label).toBe('Node Link Detailed Info')
+  })
+
+  it('Node Link Detailed Info navigates to the linked node page', () => {
+    const assign = vi.fn()
+    vi.stubGlobal('location', { assign } as any)
+    const wrapper = mountIt()
+    const items = (wrapper.vm as any).items as Array<{ label: string, command: () => void }>
+    items.find(i => i.label === 'Node Link Detailed Info')!.command()
+    expect(assign).toHaveBeenCalledWith('/opennms/element/linkednode.jsp?node=42')
+    vi.unstubAllGlobals()
+  })
+
+  // The Node Details page has no use for an Info... dialog describing the node it is already
+  // showing, so it mounts the menu without a handler.
+  it('omits Info... when no triggerNodeInfo is given', () => {
+    const wrapper = mount(NodeActionsDropdown, {
+      props: { baseHref: '/opennms/', node },
+      global: { plugins: [PrimeVue] }
+    })
+    const items = (wrapper.vm as any).items as Array<{ label: string }>
+    expect(items.map(i => i.label)).not.toContain('Info...')
+    expect(items[0].label).toBe('Events')
+    expect(items).toHaveLength(14)
   })
 
   it('Info... command calls triggerNodeInfo with the node', () => {

--- a/ui/tests/components/Nodes/NodeAvailabilityGraph.test.ts
+++ b/ui/tests/components/Nodes/NodeAvailabilityGraph.test.ts
@@ -27,6 +27,7 @@
 
 import NodeAvailabilityGraph from '@/components/Nodes/NodeAvailabilityGraph.vue'
 import { useNodeStore } from '@/stores/nodeStore'
+import { useNodeListStore } from '@/stores/nodeListStore'
 import { NodeAvailability } from '@/types'
 import { createTestingPinia } from '@pinia/testing'
 import { mount, VueWrapper } from '@vue/test-utils'
@@ -76,6 +77,33 @@ describe('NodeAvailabilityGraph.vue', () => {
     wrapper.unmount()
   })
 
+  // The details page keeps one component instance across node ids and the node store is never
+  // reset, so a panel that only fetches when props.node.id CHANGES never fetches at all on a
+  // return visit to the same node.
+  it('fetches availability on mount', () => {
+    const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: true })
+    const w = mount(NodeAvailabilityGraph, {
+      props: { baseHref: '/opennms/', node: { id: '101' } as any },
+      global: { plugins: [pinia, PrimeVue] }
+    })
+    const store = useNodeStore()
+
+    expect(store.getNodeAvailabilityPercentage).toHaveBeenCalledWith('101')
+    w.unmount()
+  })
+
+  it('does not fetch availability before the node is known', () => {
+    const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: true })
+    const w = mount(NodeAvailabilityGraph, {
+      props: { baseHref: '/opennms/', node: {} as any },
+      global: { plugins: [pinia, PrimeVue] }
+    })
+    const store = useNodeStore()
+
+    expect(store.getNodeAvailabilityPercentage).not.toHaveBeenCalled()
+    w.unmount()
+  })
+
   it('renders without errors', () => {
     expect(wrapper.exists()).toBe(true)
   })
@@ -97,6 +125,30 @@ describe('NodeAvailabilityGraph.vue', () => {
     await w.vm.$nextTick()
     // 98.76 rounded to 2 decimal places = 98.76
     expect(w.text()).toContain('98.76%')
+    w.unmount()
+  })
+
+  // A scope-qualified IPv6 address (fe80::1%eth0) leaves a bare % in the path, which is an
+  // invalid escape: the request is rejected and the strip silently fails to render.
+  it('url-encodes the interface address in the timeline image path', async () => {
+    const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: true })
+    const w = mount(NodeAvailabilityGraph, {
+      props: { baseHref: '/opennms/', node: { id: '101' } as any },
+      global: { plugins: [pinia, PrimeVue] }
+    })
+    const store = useNodeStore()
+    // stubActions also stubs the setup store's plain functions, so the service lookup the link
+    // depends on has to be supplied here.
+    const listStore = useNodeListStore()
+    listStore.getServiceTypeByName = vi.fn(() => ({ id: 10, name: 'ICMP' }))
+    store.availability = {
+      ...seedAvailability,
+      ipinterfaces: [{ ...seedAvailability.ipinterfaces[0], address: 'fe80::1%eth0' }]
+    }
+    await w.vm.$nextTick()
+
+    const src = w.findAll('img').map(i => i.attributes('src')).find(s => s?.includes('timeline/image'))
+    expect(src).toContain('/fe80%3A%3A1%25eth0/')
     w.unmount()
   })
 

--- a/ui/tests/components/Nodes/NodeCategoriesPanel.test.ts
+++ b/ui/tests/components/Nodes/NodeCategoriesPanel.test.ts
@@ -6,16 +6,21 @@ import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 import PrimeVue from 'primevue/config'
 
-const mountPanel = (node: any = { id: '1', categories: [] }) => {
+// One pinia for the whole file, with roles set BEFORE mounting. useRole caches the auth store
+// the first time it reads a role (module-level `computed(() => useAuthStore())`), so a fresh
+// createTestingPinia per mount would leave later tests reading the first test's roles.
+const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
+
+const mountPanel = (node: any = { id: '1', categories: [] }, roles: string[] = ['ROLE_ADMIN']) => {
+  const authStore = useAuthStore(pinia)
+  authStore.whoAmI = { id: 'admin', fullName: 'Administrator', internal: true, roles }
+
   const wrapper = mount(NodeCategoriesPanel, {
     props: { node, baseHref: '/opennms/' },
     global: {
-      plugins: [createTestingPinia({ createSpy: vi.fn, stubActions: false }), PrimeVue]
+      plugins: [pinia, PrimeVue]
     }
   })
-
-  const authStore = useAuthStore()
-  authStore.whoAmI = { id: 'admin', fullName: 'Administrator', internal: true, roles: ['ROLE_ADMIN'] }
 
   return { wrapper, authStore }
 }
@@ -31,5 +36,22 @@ describe('NodeCategoriesPanel.vue', () => {
 
     expect(assign).toHaveBeenCalledWith('/opennms/admin/categories.htm?edit&node=1')
     vi.unstubAllGlobals()
+  })
+  it('puts the title-row button in a right-aligned container', async () => {
+    const { wrapper } = mountPanel()
+    await wrapper.vm.$nextTick()
+
+    const buttons = wrapper.find('.title-row .action-buttons-container')
+    expect(buttons.exists()).toBe(true)
+    expect(buttons.find('[data-test="edit-button"]').exists()).toBe(true)
+  })
+
+  // Without the edit button there is nothing to align, so the container goes too.
+  it('renders no actions container for a user without the admin role', async () => {
+    const { wrapper } = mountPanel({ id: '1', categories: [] }, ['ROLE_USER'])
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-test="edit-button"]').exists()).toBe(false)
+    expect(wrapper.find('.action-buttons-container').exists()).toBe(false)
   })
 })

--- a/ui/tests/components/Nodes/NodeCategoriesPanel.test.ts
+++ b/ui/tests/components/Nodes/NodeCategoriesPanel.test.ts
@@ -1,0 +1,35 @@
+// ui/tests/components/Nodes/NodeCategoriesPanel.test.ts
+import NodeCategoriesPanel from '@/components/Nodes/NodeCategoriesPanel.vue'
+import { useAuthStore } from '@/stores/authStore'
+import { createTestingPinia } from '@pinia/testing'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import PrimeVue from 'primevue/config'
+
+const mountPanel = (node: any = { id: '1', categories: [] }) => {
+  const wrapper = mount(NodeCategoriesPanel, {
+    props: { node, baseHref: '/opennms/' },
+    global: {
+      plugins: [createTestingPinia({ createSpy: vi.fn, stubActions: false }), PrimeVue]
+    }
+  })
+
+  const authStore = useAuthStore()
+  authStore.whoAmI = { id: 'admin', fullName: 'Administrator', internal: true, roles: ['ROLE_ADMIN'] }
+
+  return { wrapper, authStore }
+}
+
+describe('NodeCategoriesPanel.vue', () => {
+  it('navigates to the category edit page for the node', async () => {
+    const assign = vi.fn()
+    vi.stubGlobal('location', { assign } as any)
+
+    const { wrapper } = mountPanel()
+    await wrapper.vm.$nextTick()
+    await wrapper.find('[data-test="edit-button"]').trigger('click')
+
+    expect(assign).toHaveBeenCalledWith('/opennms/admin/categories.htm?edit&node=1')
+    vi.unstubAllGlobals()
+  })
+})

--- a/ui/tests/components/Nodes/NodeDetailsHeader.test.ts
+++ b/ui/tests/components/Nodes/NodeDetailsHeader.test.ts
@@ -1,6 +1,6 @@
 // ui/tests/components/Nodes/NodeDetailsHeader.test.ts
 import NodeDetailsHeader from '@/components/Nodes/NodeDetailsHeader.vue'
-import { OnmsMenu } from '@opennms/onms-ui'
+import { OnmsMenu, OnmsTag } from '@opennms/onms-ui'
 import { mount } from '@vue/test-utils'
 import PrimeVue from 'primevue/config'
 import { describe, expect, it } from 'vitest'
@@ -21,6 +21,45 @@ describe('NodeDetailsHeader.vue', () => {
     expect(text).toContain('Label: srv-42')
     expect(text).toContain('ID: 42')
     expect(text).toContain('Monitoring Location: Default')
+  })
+
+  // getNodeStatusString derives these three from node.type; the tag colours them.
+  describe('status severity', () => {
+    const statusTag = (type?: string) => {
+      const wrapper = mount(NodeDetailsHeader, {
+        props: { node: { ...node, type }},
+        global: { plugins: [PrimeVue] }
+      })
+
+      return wrapper.findAllComponents(OnmsTag)[0]
+    }
+
+    it('shows an active node in success', () => {
+      const tag = statusTag('A')
+
+      expect(tag.props('value')).toBe('Status: Active')
+      expect(tag.props('severity')).toBe('success')
+    })
+
+    it('shows a deleted node in danger', () => {
+      const tag = statusTag('D')
+
+      expect(tag.props('value')).toBe('Status: Deleted')
+      expect(tag.props('severity')).toBe('danger')
+    })
+
+    it('shows an unknown status in info', () => {
+      const tag = statusTag('X')
+
+      expect(tag.props('value')).toBe('Status: Unknown')
+      expect(tag.props('severity')).toBe('info')
+    })
+
+    it('falls back to info for a node with no type at all', () => {
+      const tag = statusTag(undefined)
+
+      expect(tag.props('severity')).toBe('info')
+    })
   })
 
   // The actions menu lives on the Node Details title row now; this header carried a second

--- a/ui/tests/components/Nodes/NodeDetailsHeader.test.ts
+++ b/ui/tests/components/Nodes/NodeDetailsHeader.test.ts
@@ -1,0 +1,34 @@
+// ui/tests/components/Nodes/NodeDetailsHeader.test.ts
+import NodeDetailsHeader from '@/components/Nodes/NodeDetailsHeader.vue'
+import { OnmsMenu } from '@opennms/onms-ui'
+import { mount } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import { describe, expect, it } from 'vitest'
+
+const node = { id: 42, label: 'srv-42', location: 'Default', assetRecord: {}} as any
+
+const mountHeader = () =>
+  mount(NodeDetailsHeader, {
+    props: { node },
+    global: { plugins: [PrimeVue] }
+  })
+
+describe('NodeDetailsHeader.vue', () => {
+  it('renders the node status, label, id and location badges', () => {
+    const text = mountHeader().text()
+
+    expect(text).toContain('Status:')
+    expect(text).toContain('Label: srv-42')
+    expect(text).toContain('ID: 42')
+    expect(text).toContain('Monitoring Location: Default')
+  })
+
+  // The actions menu lives on the Node Details title row now; this header carried a second
+  // copy of the same link list.
+  it('no longer renders its own actions menu', () => {
+    const wrapper = mountHeader()
+
+    expect(wrapper.findComponent(OnmsMenu).exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('Actions')
+  })
+})

--- a/ui/tests/components/Nodes/NodeDetailsPanel.test.ts
+++ b/ui/tests/components/Nodes/NodeDetailsPanel.test.ts
@@ -1,0 +1,36 @@
+// ui/tests/components/Nodes/NodeDetailsPanel.test.ts
+import NodeDetailsPanel from '@/components/Nodes/NodeDetailsPanel.vue'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+const mountPanel = (slots: Record<string, string> = {}) =>
+  mount(NodeDetailsPanel, { props: { title: 'Recent Outages' }, slots })
+
+describe('NodeDetailsPanel.vue', () => {
+  it('renders the title in the card title row', () => {
+    const wrapper = mountPanel()
+
+    expect(wrapper.find('.card .title-row .title').text()).toBe('Recent Outages')
+  })
+
+  it('renders the default slot as the card body', () => {
+    const wrapper = mountPanel({ default: '<p data-test="body">panel body</p>' })
+
+    expect(wrapper.find('.card [data-test="body"]').text()).toBe('panel body')
+  })
+
+  it('renders actions in a right-aligned container on the title row', () => {
+    const wrapper = mountPanel({ actions: '<button data-test="action">Go</button>' })
+
+    const buttons = wrapper.find('.title-row .action-buttons-container')
+    expect(buttons.exists()).toBe(true)
+    expect(buttons.find('[data-test="action"]').exists()).toBe(true)
+  })
+
+  // A panel with no actions must not leave an empty flex container on the title row.
+  it('omits the actions container when no actions are given', () => {
+    const wrapper = mountPanel()
+
+    expect(wrapper.find('.action-buttons-container').exists()).toBe(false)
+  })
+})

--- a/ui/tests/components/Nodes/NodeNotificationsPanel.test.ts
+++ b/ui/tests/components/Nodes/NodeNotificationsPanel.test.ts
@@ -1,0 +1,104 @@
+// ui/tests/components/Nodes/NodeNotificationsPanel.test.ts
+import NodeNotificationsPanel from '@/components/Nodes/NodeNotificationsPanel.vue'
+import { useMenuStore } from '@/stores/menuStore'
+import { createTestingPinia } from '@pinia/testing'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { useAuthStore } from '@/stores/authStore'
+import PrimeVue from 'primevue/config'
+
+const mountPanel = (username = 'admin', node: any = { id: '1' }, roles: string[] = ['ROLE_ADMIN']) => {
+  const wrapper = mount(NodeNotificationsPanel, {
+    props: { node, baseHref: '/opennms/' },
+    global: {
+      plugins: [createTestingPinia({ createSpy: vi.fn, stubActions: false }), PrimeVue]
+    }
+  })
+
+  const menuStore = useMenuStore()
+  menuStore.mainMenu = { baseHref: '/opennms/', username } as any
+
+  const authStore = useAuthStore()
+  authStore.whoAmI = { id: 'admin', fullName: 'Administrator', internal: true, roles }
+
+  return { wrapper, menuStore, authStore }
+}
+
+describe('NodeNotificationsPanel.vue', () => {
+  it('links to the current user outstanding notifications for this node', async () => {
+    const { wrapper } = mountPanel()
+    await wrapper.vm.$nextTick()
+
+    const link = wrapper.find('[data-test="outstanding-notifications-link"]')
+    expect(link.text()).toBe('Your outstanding notifications for this node')
+    expect(link.attributes('href'))
+      .toBe('/opennms/notification/browse?acktype=unack&filter=node%3D1&filter=user%3Dadmin')
+  })
+
+  it('links to the current user acknowledged notifications for this node', async () => {
+    const { wrapper } = mountPanel()
+    await wrapper.vm.$nextTick()
+
+    const link = wrapper.find('[data-test="acknowledged-notifications-link"]')
+    expect(link.text()).toBe('Your acknowledged notifications for this node')
+    expect(link.attributes('href'))
+      .toBe('/opennms/notification/browse?acktype=ack&filter=node%3D1&filter=user%3Dadmin')
+  })
+
+  it('url-encodes a username containing reserved characters', async () => {
+    const { wrapper } = mountPanel('some user&x')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-test="outstanding-notifications-link"]').attributes('href'))
+      .toBe('/opennms/notification/browse?acktype=unack&filter=node%3D1&filter=user%3Dsome%20user%26x')
+  })
+
+  it('renders no notification links until the username is known', async () => {
+    const { wrapper } = mountPanel('')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-test="outstanding-notifications-link"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="acknowledged-notifications-link"]').exists()).toBe(false)
+  })
+
+  it('navigates to the legacy notifications index page', async () => {
+    const assign = vi.fn()
+    vi.stubGlobal('location', { assign } as any)
+
+    const { wrapper } = mountPanel()
+    await wrapper.vm.$nextTick()
+    await wrapper.find('[data-test="notifications-link-button"]').trigger('click')
+
+    expect(assign).toHaveBeenCalledWith('/opennms/notification/index.jsp')
+    vi.unstubAllGlobals()
+  })
+
+  // The panel mounts before menuStore.getMainMenu() resolves, so the links have to appear on
+  // their own once mainMenu lands -- i.e. `username`/`links` must stay reactive reads of the
+  // store, not values snapshotted during setup.
+  it('shows the links once the main menu populates the username', async () => {
+    const { wrapper, menuStore } = mountPanel('')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-test="outstanding-notifications-link"]').exists()).toBe(false)
+
+    menuStore.mainMenu = { baseHref: '/opennms/', username: 'admin' } as any
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-test="outstanding-notifications-link"]').attributes('href'))
+      .toBe('/opennms/notification/browse?acktype=unack&filter=node%3D1&filter=user%3Dadmin')
+  })
+
+  // The legacy card header link was open to any logged-in user, not just admins.
+  it('navigates to the notifications index for a user without the admin role', async () => {
+    const assign = vi.fn()
+    vi.stubGlobal('location', { assign } as any)
+
+    const { wrapper } = mountPanel('admin', { id: '1' }, ['ROLE_USER'])
+    await wrapper.vm.$nextTick()
+    await wrapper.find('[data-test="notifications-link-button"]').trigger('click')
+
+    expect(assign).toHaveBeenCalledWith('/opennms/notification/index.jsp')
+    vi.unstubAllGlobals()
+  })
+})

--- a/ui/tests/components/Nodes/NodeNotificationsPanel.test.ts
+++ b/ui/tests/components/Nodes/NodeNotificationsPanel.test.ts
@@ -7,19 +7,24 @@ import { describe, expect, it, vi } from 'vitest'
 import { useAuthStore } from '@/stores/authStore'
 import PrimeVue from 'primevue/config'
 
+// One pinia for the whole file, with store state set BEFORE mounting. useRole caches the auth
+// store the first time it reads a role (module-level `computed(() => useAuthStore())`), so a
+// fresh createTestingPinia per mount would leave later tests reading the first test's roles.
+const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
+
 const mountPanel = (username = 'admin', node: any = { id: '1' }, roles: string[] = ['ROLE_ADMIN']) => {
+  const menuStore = useMenuStore(pinia)
+  menuStore.mainMenu = { baseHref: '/opennms/', username } as any
+
+  const authStore = useAuthStore(pinia)
+  authStore.whoAmI = { id: 'admin', fullName: 'Administrator', internal: true, roles }
+
   const wrapper = mount(NodeNotificationsPanel, {
     props: { node, baseHref: '/opennms/' },
     global: {
-      plugins: [createTestingPinia({ createSpy: vi.fn, stubActions: false }), PrimeVue]
+      plugins: [pinia, PrimeVue]
     }
   })
-
-  const menuStore = useMenuStore()
-  menuStore.mainMenu = { baseHref: '/opennms/', username } as any
-
-  const authStore = useAuthStore()
-  authStore.whoAmI = { id: 'admin', fullName: 'Administrator', internal: true, roles }
 
   return { wrapper, menuStore, authStore }
 }
@@ -100,5 +105,13 @@ describe('NodeNotificationsPanel.vue', () => {
 
     expect(assign).toHaveBeenCalledWith('/opennms/notification/index.jsp')
     vi.unstubAllGlobals()
+  })
+  it('puts the title-row button in a right-aligned container', async () => {
+    const { wrapper } = mountPanel()
+    await wrapper.vm.$nextTick()
+
+    const buttons = wrapper.find('.title-row .action-buttons-container')
+    expect(buttons.exists()).toBe(true)
+    expect(buttons.find('[data-test="notifications-link-button"]').exists()).toBe(true)
   })
 })

--- a/ui/tests/components/Nodes/NodesTable.test.ts
+++ b/ui/tests/components/Nodes/NodesTable.test.ts
@@ -94,7 +94,11 @@ const stubs = {
   ColumnSelectionDrawer: { name: 'ColumnSelectionDrawer', template: '<div></div>' },
   NodeDetailsDialog: { name: 'NodeDetailsDialog', template: '<div></div>', props: ['visible', 'node', 'computeNodeLink', 'computeNodeIpInterfaceLink'] },
   NodeDownloadDropdown: { name: 'NodeDownloadDropdown', template: '<div></div>', props: ['onCsvDownload', 'onJsonDownload'] },
-  NodeActionsDropdown: { name: 'NodeActionsDropdown', template: '<div></div>', props: ['baseHref', 'node', 'triggerNodeInfo'] },
+  NodeActionsDropdown: {
+    name: 'NodeActionsDropdown',
+    template: '<div></div>',
+    props: ['baseHref', 'node', 'triggerNodeInfo', 'snmpPrimaryIpAddress']
+  },
   NodeTooltipCell: { name: 'NodeTooltipCell', template: '<span></span>', props: ['text'] },
   ManagementIPTooltipCell: { name: 'ManagementIPTooltipCell', template: '<span></span>', props: ['computeNodeIpInterfaceLink', 'node', 'nodeToIpInterfaceMap'] },
   FlowTooltipCell: { name: 'FlowTooltipCell', template: '<span></span>', props: ['node'] },
@@ -176,6 +180,25 @@ describe('NodesTable.vue', () => {
     await nextTick()
 
     expect(wrapper.findAllComponents({ name: 'NodeActionsDropdown' }).length).toBe(2)
+  })
+
+  // Same as the Node Details page: the Update SNMP action needs the SNMP-primary address, and
+  // the node list already holds every node's interfaces.
+  it('hands each row actions menu that node SNMP-primary address', async () => {
+    const wrapper = mountTable()
+    const ns = useNodeStore()
+    ns.nodes = [{ id: '1', label: 'node-1' }] as any
+    ns.totalCount = 1
+    ns.nodeToIpInterfaceMap = new Map([
+      ['1', [
+        { id: 'ip1', ipAddress: '10.0.0.1', snmpPrimary: 'N' },
+        { id: 'ip2', ipAddress: '10.0.0.44', snmpPrimary: 'P' }
+      ]]
+    ]) as any
+    await nextTick()
+
+    expect(wrapper.findComponent({ name: 'NodeActionsDropdown' }).props('snmpPrimaryIpAddress'))
+      .toBe('10.0.0.44')
   })
 
   it('onSort updates query order and refetches — descending', () => {

--- a/ui/tests/components/Nodes/NodesTable.test.ts
+++ b/ui/tests/components/Nodes/NodesTable.test.ts
@@ -166,6 +166,18 @@ describe('NodesTable.vue', () => {
     expect(headers.some(h => /Node Label/i.test(h))).toBe(true)
   })
 
+  // The actions menu owns the per-node link list, so every node row must carry one for the
+  // node list to offer the same actions as the Node Details page.
+  it('renders a node actions menu for each node row', async () => {
+    const wrapper = mountTable()
+    const ns = useNodeStore()
+    ns.nodes = [{ id: 1, label: 'node-1' }, { id: 2, label: 'node-2' }] as any
+    ns.totalCount = 2
+    await nextTick()
+
+    expect(wrapper.findAllComponents({ name: 'NodeActionsDropdown' }).length).toBe(2)
+  })
+
   it('onSort updates query order and refetches — descending', () => {
     const wrapper = mountTable()
     const ns = useNodeStore()

--- a/ui/tests/components/Nodes/OutagesTable.test.ts
+++ b/ui/tests/components/Nodes/OutagesTable.test.ts
@@ -31,12 +31,18 @@ import { flushPromises, mount, VueWrapper } from '@vue/test-utils'
 import PrimeVue from 'primevue/config'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
+import { useRoute } from 'vue-router'
 
 const mockNodeId = '42'
 
-vi.mock('vue-router', () => ({
-  useRoute: () => ({ params: { id: mockNodeId }})
-}))
+// A reactive route, so a test can change the node id the way navigating to another node does.
+// The details page keeps one component instance across those changes.
+vi.mock('vue-router', async () => {
+  const { reactive } = await import('vue')
+  const route = reactive({ params: { id: '42' }})
+
+  return { useRoute: () => route }
+})
 
 const { showSnackBar } = vi.hoisted(() => ({ showSnackBar: vi.fn() }))
 vi.mock('@/composables/useSnackbar', () => ({ default: () => ({ showSnackBar }) }))
@@ -84,6 +90,7 @@ describe('OutagesTable.vue', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks()
+    ;(useRoute() as any).params.id = mockNodeId
     wrapper = mountTable()
     nodeStore.outages = []
     nodeStore.outagesTotalCount = 0
@@ -329,6 +336,29 @@ describe('OutagesTable.vue', () => {
 
       expect(downloadNames).toEqual([])
       expect(showSnackBar).toHaveBeenCalledWith(expect.objectContaining({ error: true }))
+    })
+  })
+
+  describe('Node changes under the same component instance', () => {
+    it('refetches for the new node and exports that node', async () => {
+      // Empty, so the download stops at the snackbar: what matters here is the node it asked
+      // for, not the file it would have produced.
+      nodeStore.getNodeOutagesForExport = vi.fn().mockResolvedValue([])
+      ;(useRoute() as any).params.id = '99'
+      await flushPromises()
+
+      expect(nodeStore.getNodeOutages).toHaveBeenCalledWith({
+        id: '99',
+        queryParameters: { limit: 5, offset: 0 }
+      })
+
+      const items = wrapper.findComponent(NodeDownloadDropdown).vm.items as Array<{ label: string, command: () => void }>
+      await items[0].command()
+      await flushPromises()
+
+      expect(nodeStore.getNodeOutagesForExport).toHaveBeenCalledWith(
+        expect.objectContaining({ id: '99' })
+      )
     })
   })
 

--- a/ui/tests/components/Nodes/OutagesTable.test.ts
+++ b/ui/tests/components/Nodes/OutagesTable.test.ts
@@ -22,7 +22,10 @@
 
 import OutagesTable from '@/components/Nodes/OutagesTable.vue'
 import NodeDownloadDropdown from '@/components/Nodes/NodeDownloadDropdown.vue'
+import { OnmsTag } from '@opennms/onms-ui'
 import { useNodeStore } from '@/stores/nodeStore'
+import { useNodeListStore } from '@/stores/nodeListStore'
+import { useMenuStore } from '@/stores/menuStore'
 import { createTestingPinia } from '@pinia/testing'
 import { flushPromises, mount, VueWrapper } from '@vue/test-utils'
 import PrimeVue from 'primevue/config'
@@ -35,9 +38,23 @@ vi.mock('vue-router', () => ({
   useRoute: () => ({ params: { id: mockNodeId }})
 }))
 
+const { showSnackBar } = vi.hoisted(() => ({ showSnackBar: vi.fn() }))
+vi.mock('@/composables/useSnackbar', () => ({ default: () => ({ showSnackBar }) }))
+
+const mockOutage = {
+  id: 2435,
+  ipAddress: '10.0.0.44',
+  serviceId: 3,
+  ifLostService: 1700000000000,
+  ifRegainedService: 1700009999000,
+  hostname: 'host1.example.com',
+  nodeId: 42
+}
+
 describe('OutagesTable.vue', () => {
   let wrapper: VueWrapper<any>
   let nodeStore: ReturnType<typeof useNodeStore>
+  let nodeListStore: ReturnType<typeof useNodeListStore>
 
   // The store action must be mocked BEFORE mounting — the component fetches in
   // onMounted, and an unmocked action would fire a real network request.
@@ -45,10 +62,22 @@ describe('OutagesTable.vue', () => {
     const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
     nodeStore = useNodeStore(pinia)
     nodeStore.getNodeOutages = vi.fn().mockResolvedValue(undefined)
+    nodeListStore = useNodeListStore(pinia)
+    nodeListStore.allServiceTypes = [{ id: 3, name: 'ICMP' }, { id: 8, name: 'HTTPS' }]
+    useMenuStore(pinia).mainMenu = { baseHref: '/opennms/' } as any
 
     return mount(OutagesTable, {
       global: {
-        plugins: [pinia, PrimeVue]
+        plugins: [pinia, PrimeVue],
+        directives: {
+          // Marks the value instead of formatting it, so a test can tell the directive was
+          // applied without depending on the app's date format or time zone.
+          date: {
+            mounted(el: Element) {
+              el.innerHTML = `formatted:${el.innerHTML}`
+            }
+          }
+        }
       }
     })
   }
@@ -71,31 +100,27 @@ describe('OutagesTable.vue', () => {
       expect(wrapper.find('[data-test="outages-table"]').exists()).toBe(true)
     })
 
-    it('renders all 3 column headers', () => {
+    it('renders the column headers, without Host Name', () => {
       const headers = wrapper.findAll('th')
       const headerTexts = headers.map(h => h.text())
+      expect(headerTexts).toContain('ID')
       expect(headerTexts).toContain('IP Address')
-      expect(headerTexts).toContain('Host Name')
       expect(headerTexts).toContain('Service Name')
+      expect(headerTexts).toContain('Lost')
+      expect(headerTexts).toContain('Regained')
+      expect(headerTexts).not.toContain('Host Name')
     })
 
-    it('renders rows for each outage', async () => {
-      nodeStore.outages = [
-        {
-          outageId: 1,
-          ipAddress: '192.168.1.1',
-          hostname: 'host1.example.com',
-          serviceName: 'ICMP'
-        }
-      ] as any
+    it('renders rows for each outage, and no longer the host name', async () => {
+      nodeStore.outages = [mockOutage] as any
       nodeStore.outagesTotalCount = 1
       await nextTick()
 
       const rows = wrapper.findAll('tbody tr')
       expect(rows.length).toBe(1)
-      expect(rows[0].text()).toContain('192.168.1.1')
-      expect(rows[0].text()).toContain('host1.example.com')
+      expect(rows[0].text()).toContain('10.0.0.44')
       expect(rows[0].text()).toContain('ICMP')
+      expect(rows[0].text()).not.toContain('host1.example.com')
     })
   })
 
@@ -109,16 +134,201 @@ describe('OutagesTable.vue', () => {
       expect(titleRow.find('[data-test="download-button"]').exists()).toBe(true)
     })
 
-    // Not wired up yet (next set of work); the placeholders must at least be inert rather
-    // than throwing when clicked.
-    it('offers CSV and JSON downloads that do nothing yet', async () => {
-      const items = wrapper.findComponent(NodeDownloadDropdown).vm.items as Array<{ label: string, command: () => void }>
-      expect(items.map(i => i.label)).toEqual(['Download CSV...', 'Download JSON...'])
+    it('navigates to the legacy outage list filtered to this node', async () => {
+      const assign = vi.fn()
+      vi.stubGlobal('location', { assign } as any)
 
-      for (const item of items) {
-        expect(() => item.command()).not.toThrow()
-      }
       await wrapper.find('[data-test="view-outages-button"]').trigger('click')
+
+      expect(assign).toHaveBeenCalledWith(`/opennms/outage/list.htm?filter=node%3D${mockNodeId}&outtype=both`)
+      vi.unstubAllGlobals()
+    })
+  })
+
+  describe('Cell links', () => {
+    const cellLinks = async () => {
+      nodeStore.outages = [mockOutage] as any
+      nodeStore.outagesTotalCount = 1
+      await nextTick()
+
+      return wrapper.findAll('tbody tr td a')
+    }
+
+    it('links the ID to the outage detail page', async () => {
+      const links = await cellLinks()
+
+      expect(links[0].text()).toBe('2435')
+      expect(links[0].attributes('href')).toBe('/opennms/outage/detail.htm?id=2435')
+    })
+
+    it('links the IP address to the interface page for this node', async () => {
+      const links = await cellLinks()
+
+      expect(links[1].text()).toBe('10.0.0.44')
+      expect(links[1].attributes('href')).toBe(`/opennms/element/interface.jsp?node=${mockNodeId}&intf=10.0.0.44`)
+    })
+
+    it('resolves the service name from the id and links it to the service page', async () => {
+      const links = await cellLinks()
+
+      expect(links[2].text()).toBe('ICMP')
+      expect(links[2].attributes('href'))
+        .toBe(`/opennms/element/service.jsp?node=${mockNodeId}&intf=10.0.0.44&service=3`)
+    })
+
+    it('shows N/A without a link when the outage has no IP address or known service', async () => {
+      nodeStore.outages = [{ id: 1, serviceId: 99 }] as any
+      nodeStore.outagesTotalCount = 1
+      await nextTick()
+
+      const cells = wrapper.findAll('tbody tr td')
+      expect(cells[1].text()).toBe('N/A')
+      expect(cells[1].find('a').exists()).toBe(false)
+      expect(cells[2].text()).toBe('N/A')
+      expect(cells[2].find('a').exists()).toBe(false)
+    })
+
+    it('shows a known service name without a link when the outage has no IP address', async () => {
+      nodeStore.outages = [{ id: 1, serviceId: 3 }] as any
+      nodeStore.outagesTotalCount = 1
+      await nextTick()
+
+      const cells = wrapper.findAll('tbody tr td')
+      expect(cells[2].text()).toBe('ICMP')
+      expect(cells[2].find('a').exists()).toBe(false)
+    })
+  })
+
+  describe('Date columns', () => {
+    // An ongoing outage has no regained time; it kept showing N/A before the dates were
+    // formatted and should keep doing so.
+    it('shows N/A for a missing lost or regained time', async () => {
+      nodeStore.outages = [{ id: 1 }] as any
+      nodeStore.outagesTotalCount = 1
+      await nextTick()
+
+      const cells = wrapper.findAll('tbody tr td')
+      expect(cells[3].text()).toBe('N/A')
+      expect(cells[4].text()).toBe('N/A')
+    })
+
+    // An outage with no regained time is still down, so its lost time is called out.
+    it('tags the lost time as danger while the outage is unresolved', async () => {
+      nodeStore.outages = [{ id: 1, ifLostService: 1700000000000 }] as any
+      nodeStore.outagesTotalCount = 1
+      await nextTick()
+
+      const tag = wrapper.findComponent(OnmsTag)
+      expect(tag.exists()).toBe(true)
+      expect(tag.props('severity')).toBe('danger')
+      expect(tag.text()).toBe('formatted:1700000000000')
+    })
+
+    it('leaves the lost time untagged once the outage has been regained', async () => {
+      nodeStore.outages = [mockOutage] as any
+      nodeStore.outagesTotalCount = 1
+      await nextTick()
+
+      expect(wrapper.findComponent(OnmsTag).exists()).toBe(false)
+    })
+
+    it('renders the lost and regained times through the date directive', async () => {
+      nodeStore.outages = [mockOutage] as any
+      nodeStore.outagesTotalCount = 1
+      await nextTick()
+
+      const cells = wrapper.findAll('tbody tr td')
+      expect(cells[3].text()).toBe('formatted:1700000000000')
+      expect(cells[4].text()).toBe('formatted:1700009999000')
+    })
+  })
+
+  describe('Download', () => {
+    const runDownload = async (label: string) => {
+      const items = wrapper.findComponent(NodeDownloadDropdown).vm.items as Array<{ label: string, command: () => void }>
+      await items.find(i => i.label === label)!.command()
+      await flushPromises()
+    }
+
+    let blobs: Blob[]
+    let downloadNames: string[]
+
+    beforeEach(() => {
+      blobs = []
+      downloadNames = []
+
+      vi.stubGlobal('URL', {
+        createObjectURL: (blob: Blob) => {
+          blobs.push(blob)
+          return 'blob:fake'
+        }
+      } as any)
+
+      const realCreateElement = document.createElement.bind(document)
+      vi.spyOn(document, 'createElement').mockImplementation(((tag: string, options?: any) => {
+        const el = realCreateElement(tag, options)
+        if (tag === 'a') {
+          Object.defineProperty(el, 'click', { value: () => downloadNames.push((el as HTMLAnchorElement).download) })
+        }
+        return el
+      }) as any)
+    })
+
+    it('requests the displayed page of outages for the node, leaving it untouched', async () => {
+      nodeStore.getNodeOutagesForExport = vi.fn().mockResolvedValue([mockOutage])
+      nodeStore.outages = [mockOutage] as any
+      nodeStore.outagesTotalCount = 1
+
+      await runDownload('Download CSV...')
+
+      expect(nodeStore.getNodeOutagesForExport).toHaveBeenCalledWith({
+        id: mockNodeId,
+        queryParameters: { limit: 5, offset: 0 }
+      })
+      expect(nodeStore.outages).toEqual([mockOutage])
+      expect(nodeStore.outagesTotalCount).toBe(1)
+    })
+
+    it('follows the paginator when the user changes page or rows-per-page', async () => {
+      nodeStore.getNodeOutagesForExport = vi.fn().mockResolvedValue([mockOutage])
+
+      await wrapper.vm.onPage({ first: 20, rows: 20, page: 1, pageCount: 2 })
+      await flushPromises()
+      await runDownload('Download CSV...')
+
+      expect(nodeStore.getNodeOutagesForExport).toHaveBeenCalledWith({
+        id: mockNodeId,
+        queryParameters: { limit: 20, offset: 20 }
+      })
+    })
+
+    it('downloads a CSV of every outage field', async () => {
+      nodeStore.getNodeOutagesForExport = vi.fn().mockResolvedValue([{ id: 2435, ipAddress: '10.0.0.44' }])
+
+      await runDownload('Download CSV...')
+
+      expect(downloadNames).toEqual(['Outages.csv'])
+      expect(blobs[0].type).toBe('text/csv')
+      expect(await blobs[0].text()).toBe('id,ipAddress\n2435,10.0.0.44')
+    })
+
+    it('downloads JSON of the full outage records', async () => {
+      nodeStore.getNodeOutagesForExport = vi.fn().mockResolvedValue([mockOutage])
+
+      await runDownload('Download JSON...')
+
+      expect(downloadNames).toEqual(['Outages.json'])
+      expect(blobs[0].type).toBe('application/json')
+      expect(JSON.parse(await blobs[0].text())).toEqual([mockOutage])
+    })
+
+    it('shows an error snackbar and downloads nothing when the node has no outages', async () => {
+      nodeStore.getNodeOutagesForExport = vi.fn().mockResolvedValue([])
+
+      await runDownload('Download CSV...')
+
+      expect(downloadNames).toEqual([])
+      expect(showSnackBar).toHaveBeenCalledWith(expect.objectContaining({ error: true }))
     })
   })
 
@@ -134,7 +344,7 @@ describe('OutagesTable.vue', () => {
   })
 
   describe('onMounted fetch', () => {
-    it('calls getNodeOutages on mount with node id, offset 0 and limit 10', async () => {
+    it('calls getNodeOutages on mount with node id, offset 0 and limit 5', async () => {
       vi.clearAllMocks()
       const localWrapper = mountTable()
       await flushPromises()
@@ -143,7 +353,7 @@ describe('OutagesTable.vue', () => {
       expect(nodeStore.getNodeOutages).toHaveBeenCalledWith(
         expect.objectContaining({
           id: mockNodeId,
-          queryParameters: expect.objectContaining({ offset: 0, limit: 10 })
+          queryParameters: expect.objectContaining({ offset: 0, limit: 5 })
         })
       )
 

--- a/ui/tests/components/Nodes/OutagesTable.test.ts
+++ b/ui/tests/components/Nodes/OutagesTable.test.ts
@@ -24,7 +24,6 @@ import OutagesTable from '@/components/Nodes/OutagesTable.vue'
 import NodeDownloadDropdown from '@/components/Nodes/NodeDownloadDropdown.vue'
 import { OnmsTag } from '@opennms/onms-ui'
 import { useNodeStore } from '@/stores/nodeStore'
-import { useNodeListStore } from '@/stores/nodeListStore'
 import { useMenuStore } from '@/stores/menuStore'
 import { createTestingPinia } from '@pinia/testing'
 import { flushPromises, mount, VueWrapper } from '@vue/test-utils'
@@ -51,6 +50,7 @@ const mockOutage = {
   id: 2435,
   ipAddress: '10.0.0.44',
   serviceId: 3,
+  monitoredService: { id: 99, serviceType: { id: 3, name: 'ICMP' }},
   ifLostService: 1700000000000,
   ifRegainedService: 1700009999000,
   hostname: 'host1.example.com',
@@ -60,7 +60,6 @@ const mockOutage = {
 describe('OutagesTable.vue', () => {
   let wrapper: VueWrapper<any>
   let nodeStore: ReturnType<typeof useNodeStore>
-  let nodeListStore: ReturnType<typeof useNodeListStore>
 
   // The store action must be mocked BEFORE mounting — the component fetches in
   // onMounted, and an unmocked action would fire a real network request.
@@ -68,8 +67,6 @@ describe('OutagesTable.vue', () => {
     const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false })
     nodeStore = useNodeStore(pinia)
     nodeStore.getNodeOutages = vi.fn().mockResolvedValue(undefined)
-    nodeListStore = useNodeListStore(pinia)
-    nodeListStore.allServiceTypes = [{ id: 3, name: 'ICMP' }, { id: 8, name: 'HTTPS' }]
     useMenuStore(pinia).mainMenu = { baseHref: '/opennms/' } as any
 
     return mount(OutagesTable, {
@@ -175,7 +172,9 @@ describe('OutagesTable.vue', () => {
       expect(links[1].attributes('href')).toBe(`/opennms/element/interface.jsp?node=${mockNodeId}&intf=10.0.0.44`)
     })
 
-    it('resolves the service name from the id and links it to the service page', async () => {
+    // The row carries monitoredService.serviceType.name, so the name needs no lookup against
+    // the service types the app loads at startup -- and cannot read N/A while that is in flight.
+    it('takes the service name from the row and links it to the service page', async () => {
       const links = await cellLinks()
 
       expect(links[2].text()).toBe('ICMP')
@@ -196,7 +195,7 @@ describe('OutagesTable.vue', () => {
     })
 
     it('shows a known service name without a link when the outage has no IP address', async () => {
-      nodeStore.outages = [{ id: 1, serviceId: 3 }] as any
+      nodeStore.outages = [{ id: 1, serviceId: 3, monitoredService: { serviceType: { name: 'ICMP' }}}] as any
       nodeStore.outagesTotalCount = 1
       await nextTick()
 
@@ -281,36 +280,22 @@ describe('OutagesTable.vue', () => {
       }) as any)
     })
 
-    it('requests the displayed page of outages for the node, leaving it untouched', async () => {
-      nodeStore.getNodeOutagesForExport = vi.fn().mockResolvedValue([mockOutage])
+    // The download is the page the paginator is showing, which the store already holds: no
+    // second request, and no way for the file to disagree with the table.
+    it('exports the rows the table is showing without another request', async () => {
       nodeStore.outages = [mockOutage] as any
       nodeStore.outagesTotalCount = 1
+      vi.clearAllMocks()
 
       await runDownload('Download CSV...')
 
-      expect(nodeStore.getNodeOutagesForExport).toHaveBeenCalledWith({
-        id: mockNodeId,
-        queryParameters: { limit: 5, offset: 0 }
-      })
-      expect(nodeStore.outages).toEqual([mockOutage])
-      expect(nodeStore.outagesTotalCount).toBe(1)
-    })
-
-    it('follows the paginator when the user changes page or rows-per-page', async () => {
-      nodeStore.getNodeOutagesForExport = vi.fn().mockResolvedValue([mockOutage])
-
-      await wrapper.vm.onPage({ first: 20, rows: 20, page: 1, pageCount: 2 })
-      await flushPromises()
-      await runDownload('Download CSV...')
-
-      expect(nodeStore.getNodeOutagesForExport).toHaveBeenCalledWith({
-        id: mockNodeId,
-        queryParameters: { limit: 20, offset: 20 }
-      })
+      expect(nodeStore.getNodeOutages).not.toHaveBeenCalled()
+      expect(downloadNames).toEqual(['Outages.csv'])
+      expect(await blobs[0].text()).toContain(String(mockOutage.id))
     })
 
     it('downloads a CSV of every outage field', async () => {
-      nodeStore.getNodeOutagesForExport = vi.fn().mockResolvedValue([{ id: 2435, ipAddress: '10.0.0.44' }])
+      nodeStore.outages = [{ id: 2435, ipAddress: '10.0.0.44' }] as any
 
       await runDownload('Download CSV...')
 
@@ -319,8 +304,43 @@ describe('OutagesTable.vue', () => {
       expect(await blobs[0].text()).toBe('id,ipAddress\n2435,10.0.0.44')
     })
 
+    // Log messages and service names come from traps and syslog, so a leading = + - @ or tab
+    // would execute as a formula when the file is opened in a spreadsheet.
+    it('neutralises spreadsheet formulas in CSV text cells', async () => {
+      nodeStore.outages = [{ id: 1, ipAddress: '=cmd|calc!A1' }] as any
+
+      await runDownload('Download CSV...')
+
+      expect(await blobs[0].text()).toBe('id,ipAddress\n1,\'=cmd|calc!A1')
+    })
+
+    // A number cannot be a formula, and guarding one would corrupt a legitimate negative.
+    it('leaves negative numbers alone', async () => {
+      nodeStore.outages = [{ id: -5, ipAddress: '10.0.0.44' }] as any
+
+      await runDownload('Download CSV...')
+
+      expect(await blobs[0].text()).toBe('id,ipAddress\n-5,10.0.0.44')
+    })
+
+    // Only serviceType used to be special-cased, so an outage's monitoredService landed in one
+    // cell as a JSON blob.
+    it('expands nested objects into their own CSV columns', async () => {
+      nodeStore.outages = [{
+        id: 1,
+        monitoredService: { id: 99, serviceType: { id: 3, name: 'ICMP' }}
+      }] as any
+
+      await runDownload('Download CSV...')
+
+      expect(await blobs[0].text()).toBe(
+        'id,monitoredService.id,monitoredService.serviceType.id,monitoredService.serviceType.name\n' +
+        '1,99,3,ICMP'
+      )
+    })
+
     it('downloads JSON of the full outage records', async () => {
-      nodeStore.getNodeOutagesForExport = vi.fn().mockResolvedValue([mockOutage])
+      nodeStore.outages = [mockOutage] as any
 
       await runDownload('Download JSON...')
 
@@ -330,7 +350,7 @@ describe('OutagesTable.vue', () => {
     })
 
     it('shows an error snackbar and downloads nothing when the node has no outages', async () => {
-      nodeStore.getNodeOutagesForExport = vi.fn().mockResolvedValue([])
+      nodeStore.outages = [] as any
 
       await runDownload('Download CSV...')
 
@@ -340,10 +360,7 @@ describe('OutagesTable.vue', () => {
   })
 
   describe('Node changes under the same component instance', () => {
-    it('refetches for the new node and exports that node', async () => {
-      // Empty, so the download stops at the snackbar: what matters here is the node it asked
-      // for, not the file it would have produced.
-      nodeStore.getNodeOutagesForExport = vi.fn().mockResolvedValue([])
+    it('refetches for the new node', async () => {
       ;(useRoute() as any).params.id = '99'
       await flushPromises()
 
@@ -351,14 +368,6 @@ describe('OutagesTable.vue', () => {
         id: '99',
         queryParameters: { limit: 5, offset: 0 }
       })
-
-      const items = wrapper.findComponent(NodeDownloadDropdown).vm.items as Array<{ label: string, command: () => void }>
-      await items[0].command()
-      await flushPromises()
-
-      expect(nodeStore.getNodeOutagesForExport).toHaveBeenCalledWith(
-        expect.objectContaining({ id: '99' })
-      )
     })
   })
 

--- a/ui/tests/components/Nodes/OutagesTable.test.ts
+++ b/ui/tests/components/Nodes/OutagesTable.test.ts
@@ -21,6 +21,7 @@
 ///
 
 import OutagesTable from '@/components/Nodes/OutagesTable.vue'
+import NodeDownloadDropdown from '@/components/Nodes/NodeDownloadDropdown.vue'
 import { useNodeStore } from '@/stores/nodeStore'
 import { createTestingPinia } from '@pinia/testing'
 import { flushPromises, mount, VueWrapper } from '@vue/test-utils'
@@ -95,6 +96,29 @@ describe('OutagesTable.vue', () => {
       expect(rows[0].text()).toContain('192.168.1.1')
       expect(rows[0].text()).toContain('host1.example.com')
       expect(rows[0].text()).toContain('ICMP')
+    })
+  })
+
+  describe('Card and title row', () => {
+    it('wraps the panel content in a card with the title and both action buttons on one row', () => {
+      expect(wrapper.find('.card').exists()).toBe(true)
+
+      const titleRow = wrapper.find('.title-row')
+      expect(titleRow.text()).toContain('Recent Outages')
+      expect(titleRow.find('[data-test="view-outages-button"]').exists()).toBe(true)
+      expect(titleRow.find('[data-test="download-button"]').exists()).toBe(true)
+    })
+
+    // Not wired up yet (next set of work); the placeholders must at least be inert rather
+    // than throwing when clicked.
+    it('offers CSV and JSON downloads that do nothing yet', async () => {
+      const items = wrapper.findComponent(NodeDownloadDropdown).vm.items as Array<{ label: string, command: () => void }>
+      expect(items.map(i => i.label)).toEqual(['Download CSV...', 'Download JSON...'])
+
+      for (const item of items) {
+        expect(() => item.command()).not.toThrow()
+      }
+      await wrapper.find('[data-test="view-outages-button"]').trigger('click')
     })
   })
 

--- a/ui/tests/components/Nodes/SnmpInterfacesTable.test.ts
+++ b/ui/tests/components/Nodes/SnmpInterfacesTable.test.ts
@@ -27,12 +27,18 @@ import { flushPromises, mount, VueWrapper } from '@vue/test-utils'
 import PrimeVue from 'primevue/config'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
+import { useRoute } from 'vue-router'
 
 const mockNodeId = '42'
 
-vi.mock('vue-router', () => ({
-  useRoute: () => ({ params: { id: mockNodeId }})
-}))
+// A reactive route, so a test can change the node id the way navigating to another node does.
+// The details page keeps one component instance across those changes.
+vi.mock('vue-router', async () => {
+  const { reactive } = await import('vue')
+  const route = reactive({ params: { id: '42' }})
+
+  return { useRoute: () => route }
+})
 
 describe('SnmpInterfacesTable.vue', () => {
   let wrapper: VueWrapper<any>
@@ -171,6 +177,25 @@ describe('SnmpInterfacesTable.vue', () => {
       expect(nodeStore.getNodeSnmpInterfaces).toHaveBeenCalledWith(
         expect.objectContaining({ id: mockNodeId })
       )
+    })
+  })
+
+  describe('Node changes under the same component instance', () => {
+    // /node/42 -> /node/99 reuses this instance, so a table that only reads the route id at
+    // mount would keep showing the interfaces of the node the user navigated away from.
+    it('refetches for the new node and returns to the first page', async () => {
+      await wrapper.vm.onPage({ first: 10, rows: 5, page: 2, pageCount: 3 } as any)
+      await flushPromises()
+      vi.clearAllMocks()
+
+      ;(useRoute() as any).params.id = '99'
+      await flushPromises()
+
+      expect(nodeStore.getNodeSnmpInterfaces).toHaveBeenCalledWith({
+        id: '99',
+        queryParameters: { limit: 5, offset: 0 }
+      })
+      ;(useRoute() as any).params.id = '42'
     })
   })
 })

--- a/ui/tests/components/Nodes/SnmpInterfacesTable.test.ts
+++ b/ui/tests/components/Nodes/SnmpInterfacesTable.test.ts
@@ -184,7 +184,8 @@ describe('SnmpInterfacesTable.vue', () => {
     // /node/42 -> /node/99 reuses this instance, so a table that only reads the route id at
     // mount would keep showing the interfaces of the node the user navigated away from.
     it('refetches for the new node and returns to the first page', async () => {
-      await wrapper.vm.onPage({ first: 10, rows: 5, page: 2, pageCount: 3 } as any)
+      // rows-per-page is the user's choice and survives the node change; only the page resets.
+      await wrapper.vm.onPage({ first: 20, rows: 10, page: 2, pageCount: 3 } as any)
       await flushPromises()
       vi.clearAllMocks()
 
@@ -193,7 +194,7 @@ describe('SnmpInterfacesTable.vue', () => {
 
       expect(nodeStore.getNodeSnmpInterfaces).toHaveBeenCalledWith({
         id: '99',
-        queryParameters: { limit: 5, offset: 0 }
+        queryParameters: { limit: 10, offset: 0 }
       })
       ;(useRoute() as any).params.id = '42'
     })

--- a/ui/tests/components/Nodes/nodeActionLinks.test.ts
+++ b/ui/tests/components/Nodes/nodeActionLinks.test.ts
@@ -48,6 +48,14 @@ describe('nodeActionLinks', () => {
     expect(mapLink('node-link', node)).toBe('element/linkednode.jsp?node=42')
   })
 
+  // A label with & or # would otherwise corrupt the query string, losing addNew and nodeID.
+  it('url-encodes the node label in the schedule-outage link', () => {
+    const awkward = { ...node, id: 42, label: 'srv & #1' } as unknown as Node
+
+    expect(mapLink('schedule-outage', awkward))
+      .toBe('admin/sched-outages/editoutage.jsp?newName=srv%20%26%20%231&addNew=true&nodeID=42')
+  })
+
   it('createLinkItemsList drops Site Status for a node with no building', () => {
     expect(createLinkItemsList(node).map(li => li.label)).not.toContain('Site Status')
   })

--- a/ui/tests/components/Nodes/nodeActionLinks.test.ts
+++ b/ui/tests/components/Nodes/nodeActionLinks.test.ts
@@ -37,10 +37,9 @@ describe('nodeActionLinks', () => {
     expect(linkItems.map(li => li.name)).toContain('siteStatus')
   })
 
-  // 'node-link-details' pointed at the same page as 'node-link', so only one of the two
-  // survived the merge into this list.
-  it('has no leftover duplicate of the linked-node action', () => {
-    expect(linkItems.map(li => li.name)).not.toContain('node-link-details')
+  // Two entries pointed at the linked-node page before these lists were merged, under
+  // different labels. Only one should reach the menu.
+  it('offers the linked-node page exactly once', () => {
     expect(linkItems.filter(li => mapLink(li.name, node).startsWith('element/linkednode.jsp'))).toHaveLength(1)
   })
 
@@ -54,6 +53,26 @@ describe('nodeActionLinks', () => {
 
     expect(mapLink('schedule-outage', awkward))
       .toBe('admin/sched-outages/editoutage.jsp?newName=srv%20%26%20%231&addNew=true&nodeID=42')
+  })
+
+  // The legacy node page shows Update SNMP only when the node has an SNMP-primary interface,
+  // and points it at that interface's address. A hardcoded 0.0.0.0 would have the form rewrite
+  // SNMP config for an address that is not the node's.
+  it('points Update SNMP Information at the SNMP-primary address', () => {
+    expect(mapLink('updateSnmp', node, { snmpPrimaryIpAddress: '10.0.0.44' }))
+      .toBe('admin/updateSnmp.jsp?node=42&ipaddr=10.0.0.44')
+  })
+
+  it('drops Update SNMP Information when no SNMP-primary address is known', () => {
+    expect(mapLink('updateSnmp', node)).toBe('')
+    expect(createLinkItemsList(node).map(li => li.label)).not.toContain('Update SNMP Information')
+  })
+
+  it('createLinkItemsList keeps Update SNMP Information when the address is known', () => {
+    expect(createLinkItemsList(node, { snmpPrimaryIpAddress: '10.0.0.44' })).toContainEqual({
+      label: 'Update SNMP Information',
+      link: 'admin/updateSnmp.jsp?node=42&ipaddr=10.0.0.44'
+    })
   })
 
   it('createLinkItemsList drops Site Status for a node with no building', () => {

--- a/ui/tests/components/Nodes/nodeActionLinks.test.ts
+++ b/ui/tests/components/Nodes/nodeActionLinks.test.ts
@@ -1,0 +1,63 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { createLinkItemsList, linkItems, mapLink } from '@/components/Nodes/nodeActionLinks'
+import { Node } from '@/types'
+import { describe, expect, it } from 'vitest'
+
+const node = { id: 42, label: 'srv-42', assetRecord: {}} as unknown as Node
+
+describe('nodeActionLinks', () => {
+  // The single source of truth for the node action links, shared by the actions menu wherever
+  // it is rendered.
+  it('offers Node Link Details last', () => {
+    expect(linkItems[linkItems.length - 1]).toEqual({ name: 'node-link', label: 'Node Link Details' })
+  })
+
+  it('still offers Site Status', () => {
+    expect(linkItems.map(li => li.name)).toContain('siteStatus')
+  })
+
+  // 'node-link-details' pointed at the same page as 'node-link', so only one of the two
+  // survived the merge into this list.
+  it('has no leftover duplicate of the linked-node action', () => {
+    expect(linkItems.map(li => li.name)).not.toContain('node-link-details')
+    expect(linkItems.filter(li => mapLink(li.name, node).startsWith('element/linkednode.jsp'))).toHaveLength(1)
+  })
+
+  it('maps node-link to the linked node page', () => {
+    expect(mapLink('node-link', node)).toBe('element/linkednode.jsp?node=42')
+  })
+
+  it('createLinkItemsList drops Site Status for a node with no building', () => {
+    expect(createLinkItemsList(node).map(li => li.label)).not.toContain('Site Status')
+  })
+
+  it('createLinkItemsList keeps Site Status for a node with a building', () => {
+    const withBuilding = { ...node, assetRecord: { building: 'HQ 1' }} as unknown as Node
+
+    expect(createLinkItemsList(withBuilding)).toContainEqual({
+      label: 'Site Status',
+      link: 'siteStatusView.htm?statusSite=HQ%201'
+    })
+  })
+})

--- a/ui/tests/components/Nodes/utils.test.ts
+++ b/ui/tests/components/Nodes/utils.test.ts
@@ -22,7 +22,7 @@
 
 import { describe, expect, test } from 'vitest'
 import { mock } from 'vitest-mock-extended'
-import { getTableCssClasses, hasEgressFlow, hasIngressFlow } from '@/components/Nodes/utils'
+import { buildSnmpNarrowing, getTableCssClasses, hasEgressFlow, hasIngressFlow } from '@/components/Nodes/utils'
 import { Node, NodeColumnSelectionItem } from '@/types'
 
 describe('Nodes utils test', () => {
@@ -80,5 +80,27 @@ describe('Nodes utils test', () => {
 
     expect(hasEgressFlow(neither)).toBeFalsy()
     expect(hasIngressFlow(neither)).toBeFalsy()
+  })
+
+  describe('buildSnmpNarrowing', () => {
+    test('narrows a maclike fetch by the normalized MAC', () => {
+      expect(buildSnmpNarrowing({ mode: 'maclike', mac: 'aa:bb:cc' })).toBe('physAddr==*aabbcc*')
+    })
+
+    test('narrows an snmpParm fetch by the searched attribute', () => {
+      expect(buildSnmpNarrowing({ mode: 'snmpParm', attr: 'ifAlias', value: 'core', matchType: 'contains' }))
+        .toBe('ifAlias==*core*')
+    })
+
+    // The narrowing sent to the server has to stay a superset of the client-side match, so a
+    // value carrying LIKE wildcards or FIQL operators drops the attribute term entirely.
+    test.each(['up%', 'up_link', 'a,b', 'a;b', 'a(b', 'a)b'])('omits narrowing for %s', (value) => {
+      expect(buildSnmpNarrowing({ mode: 'snmpParm', attr: 'ifName', value, matchType: 'contains' }))
+        .toBeUndefined()
+    })
+
+    test('narrows nothing in the default mode', () => {
+      expect(buildSnmpNarrowing({ mode: 'default' })).toBeUndefined()
+    })
   })
 })

--- a/ui/tests/containers/NodeDetails.test.ts
+++ b/ui/tests/containers/NodeDetails.test.ts
@@ -25,7 +25,7 @@ describe('NodeDetails.vue', () => {
     nodeStore.getNodeById = vi.fn().mockResolvedValue(undefined)
 
     const menuStore = useMenuStore()
-    menuStore.mainMenu = { homeUrl: '/home' } as any
+    menuStore.mainMenu = { homeUrl: '/home', baseHref: '/base' } as any
 
     const wrapper = mount(NodeDetails, {
       props: { id },
@@ -34,9 +34,13 @@ describe('NodeDetails.vue', () => {
         stubs: {
           BreadCrumbs: true,
           NodeAvailabilityGraph: true,
-          InterfacesTabs: true,
+          NodeCategoriesPanel: true,
+          NodeDetailsHeader: true,
+          NodeNotificationsPanel: true,
+          NodeSnmpAttributes: true,
           EventsTable: true,
-          OutagesTable: true
+          OutagesTable: true,
+          InterfacesTabs: true
         }
       }
     })
@@ -52,9 +56,14 @@ describe('NodeDetails.vue', () => {
     const { wrapper } = mountComponent()
     await flushPromises()
 
+    expect(wrapper.findComponent({ name: 'BreadCrumbs' }).exists()).toBe(true)
     expect(wrapper.findComponent({ name: 'NodeAvailabilityGraph' }).exists()).toBe(true)
-    expect(wrapper.findComponent({ name: 'InterfacesTabs' }).exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'NodeCategoriesPanel' }).exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'NodeDetailsHeader' }).exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'NodeNotificationsPanel' }).exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'NodeSnmpAttributes' }).exists()).toBe(true)
     expect(wrapper.findComponent({ name: 'EventsTable' }).exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'InterfacesTabs' }).exists()).toBe(true)
     expect(wrapper.findComponent({ name: 'OutagesTable' }).exists()).toBe(true)
   })
 

--- a/ui/tests/containers/NodeDetails.test.ts
+++ b/ui/tests/containers/NodeDetails.test.ts
@@ -1,6 +1,7 @@
 import NodeDetails from '@/containers/NodeDetails.vue'
 import { useNodeStore } from '@/stores/nodeStore'
 import { useMenuStore } from '@/stores/menuStore'
+import { useEventStore } from '@/stores/eventStore'
 import { createTestingPinia } from '@pinia/testing'
 import { flushPromises, mount } from '@vue/test-utils'
 import { setActivePinia } from 'pinia'
@@ -23,6 +24,7 @@ describe('NodeDetails.vue', () => {
 
     const nodeStore = useNodeStore()
     nodeStore.getNodeById = vi.fn().mockResolvedValue(undefined)
+    nodeStore.getNodeSnmpPrimaryInterface = vi.fn().mockResolvedValue(undefined)
 
     if (loaded) {
       nodeStore.node = { id: '42', label: 'srv-42' } as any
@@ -40,7 +42,11 @@ describe('NodeDetails.vue', () => {
           BreadCrumbs: true,
           NodeAvailabilityGraph: true,
           NodeCategoriesPanel: true,
-          NodeActionsDropdown: { name: 'NodeActionsDropdown', template: '<div></div>', props: ['baseHref', 'node'] },
+          NodeActionsDropdown: {
+            name: 'NodeActionsDropdown',
+            template: '<div></div>',
+            props: ['baseHref', 'node', 'snmpPrimaryIpAddress']
+          },
           NodeDetailsHeader: true,
           NodeNotificationsPanel: true,
           NodeSnmpAttributes: true,
@@ -71,6 +77,64 @@ describe('NodeDetails.vue', () => {
     expect(wrapper.findComponent({ name: 'NodeCategoriesPanel' }).exists()).toBe(false)
     expect(wrapper.findComponent({ name: 'NodeNotificationsPanel' }).exists()).toBe(false)
     expect(wrapper.findComponent({ name: 'NodeAvailabilityGraph' }).exists()).toBe(false)
+  })
+
+  // A 404 for a nonexistent node id leaves nothing to name in the heading.
+  it('titles the page N/A when the node could not be fetched', async () => {
+    const { wrapper } = mountComponent()
+    useNodeStore().nodeLoadFailed = true
+    await flushPromises()
+
+    expect(wrapper.find('h2').text()).toBe('Node Details for N/A')
+  })
+
+  it('leaves the title unnamed while the node is still being fetched', async () => {
+    const { wrapper } = mountComponent()
+    await flushPromises()
+
+    expect(wrapper.find('h2').text()).toBe('Node Details for')
+  })
+
+  // The Update SNMP action needs the SNMP-primary address, which the node payload does not
+  // carry and the IP Interfaces table only holds a page of, so the page asks for it directly.
+  it('asks for the node SNMP-primary address and hands it to the actions menu', async () => {
+    const { wrapper, nodeStore } = mountComponent('42', true)
+    await flushPromises()
+
+    expect(nodeStore.getNodeSnmpPrimaryInterface).toHaveBeenCalledWith('42')
+
+    nodeStore.snmpPrimaryIpAddress = '10.0.0.44'
+    await flushPromises()
+
+    expect(wrapper.findComponent({ name: 'NodeActionsDropdown' }).props('snmpPrimaryIpAddress'))
+      .toBe('10.0.0.44')
+  })
+
+  // The events table fetches by node id on its own and only replaces its rows on a successful
+  // response, so a node that 404s would otherwise keep the previous node's events on screen.
+  it('clears the events when the node fails to load', async () => {
+    const { wrapper, nodeStore } = mountComponent()
+    nodeStore.getNodeById = vi.fn().mockImplementation(async () => {
+      nodeStore.nodeLoadFailed = true
+    })
+    const eventStore = useEventStore()
+    eventStore.clearEvents = vi.fn()
+
+    await wrapper.vm.$nextTick()
+    await (wrapper.vm as any).fetchNode()
+
+    expect(eventStore.clearEvents).toHaveBeenCalled()
+  })
+
+  it('leaves the events alone when the node loads', async () => {
+    const { wrapper, nodeStore } = mountComponent('42', true)
+    nodeStore.getNodeById = vi.fn().mockResolvedValue(undefined)
+    const eventStore = useEventStore()
+    eventStore.clearEvents = vi.fn()
+
+    await (wrapper.vm as any).fetchNode()
+
+    expect(eventStore.clearEvents).not.toHaveBeenCalled()
   })
 
   it('renders the four child components', async () => {

--- a/ui/tests/containers/NodeDetails.test.ts
+++ b/ui/tests/containers/NodeDetails.test.ts
@@ -35,6 +35,7 @@ describe('NodeDetails.vue', () => {
           BreadCrumbs: true,
           NodeAvailabilityGraph: true,
           NodeCategoriesPanel: true,
+          NodeActionsDropdown: { name: 'NodeActionsDropdown', template: '<div></div>', props: ['baseHref', 'node'] },
           NodeDetailsHeader: true,
           NodeNotificationsPanel: true,
           NodeSnmpAttributes: true,
@@ -65,6 +66,15 @@ describe('NodeDetails.vue', () => {
     expect(wrapper.findComponent({ name: 'EventsTable' }).exists()).toBe(true)
     expect(wrapper.findComponent({ name: 'InterfacesTabs' }).exists()).toBe(true)
     expect(wrapper.findComponent({ name: 'OutagesTable' }).exists()).toBe(true)
+  })
+
+  it('puts the node actions menu on the title row', async () => {
+    const { wrapper } = mountComponent()
+    await flushPromises()
+
+    const header = wrapper.find('.header')
+    expect(header.text()).toContain('Node Details for')
+    expect(header.findComponent({ name: 'NodeActionsDropdown' }).exists()).toBe(true)
   })
 
   it('calls nodeStore.getNodeById with the id prop on mount', async () => {

--- a/ui/tests/containers/NodeDetails.test.ts
+++ b/ui/tests/containers/NodeDetails.test.ts
@@ -17,12 +17,17 @@ vi.mock('vue-router', () => ({
 }))
 
 describe('NodeDetails.vue', () => {
-  const mountComponent = (id = '42') => {
+  const mountComponent = (id = '42', loaded = false) => {
     const pinia = createTestingPinia({ stubActions: false })
     setActivePinia(pinia)
 
     const nodeStore = useNodeStore()
     nodeStore.getNodeById = vi.fn().mockResolvedValue(undefined)
+
+    if (loaded) {
+      nodeStore.node = { id: '42', label: 'srv-42' } as any
+      nodeStore.nodeLoaded = true
+    }
 
     const menuStore = useMenuStore()
     menuStore.mainMenu = { homeUrl: '/home', baseHref: '/base' } as any
@@ -53,8 +58,23 @@ describe('NodeDetails.vue', () => {
     vi.clearAllMocks()
   })
 
-  it('renders the four child components', async () => {
+  // node starts as {} in the store -- truthy, and undefined for every field -- so panels that
+  // read it must wait for a real one rather than render "Label: undefined" and
+  // element/rescan.jsp?node=undefined.
+  it('renders no node panels until the node has loaded', async () => {
     const { wrapper } = mountComponent()
+    await flushPromises()
+
+    expect(wrapper.findComponent({ name: 'NodeDetailsHeader' }).exists()).toBe(false)
+    expect(wrapper.findComponent({ name: 'NodeActionsDropdown' }).exists()).toBe(false)
+    expect(wrapper.findComponent({ name: 'NodeSnmpAttributes' }).exists()).toBe(false)
+    expect(wrapper.findComponent({ name: 'NodeCategoriesPanel' }).exists()).toBe(false)
+    expect(wrapper.findComponent({ name: 'NodeNotificationsPanel' }).exists()).toBe(false)
+    expect(wrapper.findComponent({ name: 'NodeAvailabilityGraph' }).exists()).toBe(false)
+  })
+
+  it('renders the four child components', async () => {
+    const { wrapper } = mountComponent('42', true)
     await flushPromises()
 
     expect(wrapper.findComponent({ name: 'BreadCrumbs' }).exists()).toBe(true)
@@ -69,7 +89,7 @@ describe('NodeDetails.vue', () => {
   })
 
   it('puts the node actions menu on the title row', async () => {
-    const { wrapper } = mountComponent()
+    const { wrapper } = mountComponent('42', true)
     await flushPromises()
 
     const header = wrapper.find('.header')

--- a/ui/tests/stores/eventStore.test.ts
+++ b/ui/tests/stores/eventStore.test.ts
@@ -1,0 +1,85 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useEventStore } from '@/stores/eventStore'
+import API from '@/services'
+import { Event } from '@/types'
+
+vi.mock('@/services', () => ({
+  default: {
+    getEvents: vi.fn()
+  }
+}))
+
+const event = { id: 101, severity: 'Major', logMessage: 'msg' } as unknown as Event
+
+describe('eventStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  describe('getEvents', () => {
+    it('publishes the fetched page into events/totalCount', async () => {
+      vi.mocked(API.getEvents).mockResolvedValue({ event: [event], totalCount: 1, count: 1, offset: 0 })
+      const store = useEventStore()
+
+      await store.getEvents({ limit: 5, offset: 0 })
+
+      expect(store.events).toEqual([event])
+      expect(store.totalCount).toBe(1)
+    })
+  })
+
+  describe('getEventsForExport', () => {
+    it('returns the fetched events', async () => {
+      vi.mocked(API.getEvents).mockResolvedValue({ event: [event], totalCount: 1, count: 1, offset: 0 })
+      const store = useEventStore()
+
+      await expect(store.getEventsForExport({ limit: 0, offset: 0 })).resolves.toEqual([event])
+    })
+
+    // A download runs its own query; publishing the result into the store would replace the
+    // page the events table is showing.
+    it('leaves the currently displayed page untouched', async () => {
+      const displayed = { id: 7 } as unknown as Event
+      vi.mocked(API.getEvents).mockResolvedValue({ event: [event], totalCount: 500, count: 500, offset: 0 })
+      const store = useEventStore()
+      store.events = [displayed]
+      store.totalCount = 1
+
+      await store.getEventsForExport({ limit: 0, offset: 0 })
+
+      expect(store.events).toEqual([displayed])
+      expect(store.totalCount).toBe(1)
+    })
+
+    it('returns an empty list when the request fails', async () => {
+      vi.mocked(API.getEvents).mockResolvedValue(false)
+      const store = useEventStore()
+
+      await expect(store.getEventsForExport({ limit: 0, offset: 0 })).resolves.toEqual([])
+    })
+  })
+})

--- a/ui/tests/stores/eventStore.test.ts
+++ b/ui/tests/stores/eventStore.test.ts
@@ -66,4 +66,37 @@ describe('eventStore', () => {
       expect(store.totalCount).toBe(1)
     })
   })
+
+  // Fired per node id as the user moves between nodes, and per page as the paginator moves:
+  // a page-2-then-page-3 click can land page 2's rows under page 3's paginator state.
+  describe('stale responses', () => {
+    it('discards a response a newer request has superseded', async () => {
+      const deferredPage = <T>() => {
+        let resolve: (value: T) => void = () => undefined
+        const promise = new Promise<T>((r) => {
+          resolve = r
+        })
+
+        return { promise, resolve }
+      }
+
+      const page2 = deferredPage<unknown>()
+      const page3 = deferredPage<unknown>()
+      vi.mocked(API.getEvents)
+        .mockImplementationOnce(() => page2.promise as never)
+        .mockImplementationOnce(() => page3.promise as never)
+      const store = useEventStore()
+
+      const page2Call = store.getEvents({ limit: 5, offset: 5 })
+      const page3Call = store.getEvents({ limit: 5, offset: 10 })
+
+      page3.resolve({ event: [{ id: 3 }], totalCount: 1, count: 1, offset: 10 })
+      await page3Call
+      page2.resolve({ event: [{ id: 2 }], totalCount: 9, count: 9, offset: 5 })
+      await page2Call
+
+      expect(store.events).toEqual([{ id: 3 }])
+      expect(store.totalCount).toBe(1)
+    })
+  })
 })

--- a/ui/tests/stores/eventStore.test.ts
+++ b/ui/tests/stores/eventStore.test.ts
@@ -40,6 +40,21 @@ describe('eventStore', () => {
     vi.clearAllMocks()
   })
 
+  describe('clearEvents', () => {
+    // The Node Details page clears these when its node fails to load: the events table fetches
+    // by node id on its own and only replaces its rows on a successful response.
+    it('empties the events and the count', () => {
+      const store = useEventStore()
+      store.events = [event]
+      store.totalCount = 1
+
+      store.clearEvents()
+
+      expect(store.events).toEqual([])
+      expect(store.totalCount).toBe(0)
+    })
+  })
+
   describe('getEvents', () => {
     it('publishes the fetched page into events/totalCount', async () => {
       vi.mocked(API.getEvents).mockResolvedValue({ event: [event], totalCount: 1, count: 1, offset: 0 })
@@ -49,37 +64,6 @@ describe('eventStore', () => {
 
       expect(store.events).toEqual([event])
       expect(store.totalCount).toBe(1)
-    })
-  })
-
-  describe('getEventsForExport', () => {
-    it('returns the fetched events', async () => {
-      vi.mocked(API.getEvents).mockResolvedValue({ event: [event], totalCount: 1, count: 1, offset: 0 })
-      const store = useEventStore()
-
-      await expect(store.getEventsForExport({ limit: 0, offset: 0 })).resolves.toEqual([event])
-    })
-
-    // A download runs its own query; publishing the result into the store would replace the
-    // page the events table is showing.
-    it('leaves the currently displayed page untouched', async () => {
-      const displayed = { id: 7 } as unknown as Event
-      vi.mocked(API.getEvents).mockResolvedValue({ event: [event], totalCount: 500, count: 500, offset: 0 })
-      const store = useEventStore()
-      store.events = [displayed]
-      store.totalCount = 1
-
-      await store.getEventsForExport({ limit: 0, offset: 0 })
-
-      expect(store.events).toEqual([displayed])
-      expect(store.totalCount).toBe(1)
-    })
-
-    it('returns an empty list when the request fails', async () => {
-      vi.mocked(API.getEvents).mockResolvedValue(false)
-      const store = useEventStore()
-
-      await expect(store.getEventsForExport({ limit: 0, offset: 0 })).resolves.toEqual([])
     })
   })
 })

--- a/ui/tests/stores/nodeListStore.test.ts
+++ b/ui/tests/stores/nodeListStore.test.ts
@@ -657,22 +657,6 @@ describe('useNodeListStore', () => {
       expect(store.allServiceTypes).toEqual([{ id: 1, name: 'HTTP' }, { id: 8, name: 'HTTPS' }])
     })
 
-    it('getServiceTypeById finds the service type with that id', async () => {
-      const store = useNodeListStore()
-      vi.mocked(API.getServiceTypes).mockResolvedValue([{ id: 1, name: 'HTTP' }, { id: 8, name: 'HTTPS' }])
-      await store.getServiceTypes()
-
-      expect(store.getServiceTypeById(8)).toEqual({ id: 8, name: 'HTTPS' })
-    })
-
-    it('getServiceTypeById returns undefined for an unknown id', async () => {
-      const store = useNodeListStore()
-      vi.mocked(API.getServiceTypes).mockResolvedValue([{ id: 1, name: 'HTTP' }])
-      await store.getServiceTypes()
-
-      expect(store.getServiceTypeById(99)).toBeUndefined()
-    })
-
     it('updateSelectedServices updates selectedServices and queryFilter', () => {
       const store = useNodeListStore()
       store.updateSelectedServices([{ _value: 8, _text: 'HTTPS' }])

--- a/ui/tests/stores/nodeListStore.test.ts
+++ b/ui/tests/stores/nodeListStore.test.ts
@@ -657,6 +657,22 @@ describe('useNodeListStore', () => {
       expect(store.allServiceTypes).toEqual([{ id: 1, name: 'HTTP' }, { id: 8, name: 'HTTPS' }])
     })
 
+    it('getServiceTypeById finds the service type with that id', async () => {
+      const store = useNodeListStore()
+      vi.mocked(API.getServiceTypes).mockResolvedValue([{ id: 1, name: 'HTTP' }, { id: 8, name: 'HTTPS' }])
+      await store.getServiceTypes()
+
+      expect(store.getServiceTypeById(8)).toEqual({ id: 8, name: 'HTTPS' })
+    })
+
+    it('getServiceTypeById returns undefined for an unknown id', async () => {
+      const store = useNodeListStore()
+      vi.mocked(API.getServiceTypes).mockResolvedValue([{ id: 1, name: 'HTTP' }])
+      await store.getServiceTypes()
+
+      expect(store.getServiceTypeById(99)).toBeUndefined()
+    })
+
     it('updateSelectedServices updates selectedServices and queryFilter', () => {
       const store = useNodeListStore()
       store.updateSelectedServices([{ _value: 8, _text: 'HTTPS' }])

--- a/ui/tests/stores/nodeStore.test.ts
+++ b/ui/tests/stores/nodeStore.test.ts
@@ -24,13 +24,14 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useNodeStore } from '@/stores/nodeStore'
 import API from '@/services'
-import { IpInterface, Outage, SnmpInterface } from '@/types'
+import { IpInterface, Node, Outage, SnmpInterface } from '@/types'
 
 vi.mock('@/services', () => ({
   default: {
     getSnmpInterfaces: vi.fn(),
     getIpInterfaces: vi.fn(),
-    getNodeOutages: vi.fn()
+    getNodeOutages: vi.fn(),
+    getNodeById: vi.fn()
   }
 }))
 
@@ -301,5 +302,59 @@ describe('nodeStore outage export', () => {
     const store = useNodeStore()
 
     await expect(store.getNodeOutagesForExport({ id: '144' })).resolves.toEqual([])
+  })
+})
+
+describe('nodeStore getNodeById', () => {
+  const node = { id: '42', label: 'srv-42' } as unknown as Node
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('publishes the fetched node and marks it loaded', async () => {
+    vi.mocked(API.getNodeById).mockResolvedValue(node)
+    const store = useNodeStore()
+
+    await store.getNodeById({ id: '42' } as Node)
+
+    expect(store.node).toEqual(node)
+    expect(store.nodeLoaded).toBe(true)
+  })
+
+  // The store is global and outlives the page. Without a reset, a second node's page renders
+  // the first node's label and ids until the new fetch lands.
+  it('clears the previous node before fetching another', async () => {
+    vi.mocked(API.getNodeById).mockResolvedValue(node)
+    const store = useNodeStore()
+    await store.getNodeById({ id: '42' } as Node)
+
+    let nodeDuringFetch: unknown
+    let loadedDuringFetch: unknown
+    vi.mocked(API.getNodeById).mockImplementation(async () => {
+      nodeDuringFetch = { ...store.node }
+      loadedDuringFetch = store.nodeLoaded
+      return { id: '99', label: 'srv-99' } as unknown as Node
+    })
+
+    await store.getNodeById({ id: '99' } as Node)
+
+    expect(nodeDuringFetch).toEqual({})
+    expect(loadedDuringFetch).toBe(false)
+    expect(store.node).toEqual({ id: '99', label: 'srv-99' })
+  })
+
+  // A failed fetch must not leave the previous node's data on screen, nor claim to be loaded.
+  it('leaves no node loaded when the request fails', async () => {
+    vi.mocked(API.getNodeById).mockResolvedValue(node)
+    const store = useNodeStore()
+    await store.getNodeById({ id: '42' } as Node)
+
+    vi.mocked(API.getNodeById).mockResolvedValue(false as never)
+    await store.getNodeById({ id: '99' } as Node)
+
+    expect(store.node).toEqual({})
+    expect(store.nodeLoaded).toBe(false)
   })
 })

--- a/ui/tests/stores/nodeStore.test.ts
+++ b/ui/tests/stores/nodeStore.test.ts
@@ -24,14 +24,15 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useNodeStore } from '@/stores/nodeStore'
 import API from '@/services'
-import { IpInterface, Node, Outage, SnmpInterface } from '@/types'
+import { IpInterface, Node, SnmpInterface } from '@/types'
 
 vi.mock('@/services', () => ({
   default: {
     getSnmpInterfaces: vi.fn(),
     getIpInterfaces: vi.fn(),
     getNodeOutages: vi.fn(),
-    getNodeById: vi.fn()
+    getNodeById: vi.fn(),
+    getNodeIpInterfaces: vi.fn()
   }
 }))
 
@@ -267,44 +268,6 @@ describe('useNodeStore', () => {
   })
 })
 
-describe('nodeStore outage export', () => {
-  const outage = { id: 2435, ipAddress: '10.0.0.44', serviceId: 3 } as unknown as Outage
-
-  beforeEach(() => {
-    setActivePinia(createPinia())
-    vi.clearAllMocks()
-  })
-
-  it('getNodeOutagesForExport returns the fetched outages', async () => {
-    vi.mocked(API.getNodeOutages).mockResolvedValue({ outage: [outage], totalCount: 1, count: 1, offset: 0 })
-    const store = useNodeStore()
-
-    await expect(store.getNodeOutagesForExport({ id: '144' })).resolves.toEqual([outage])
-  })
-
-  // A download runs its own query; publishing the result into the store would replace the
-  // page the outages table is showing.
-  it('getNodeOutagesForExport leaves the currently displayed page untouched', async () => {
-    const displayed = { id: 7 } as unknown as Outage
-    vi.mocked(API.getNodeOutages).mockResolvedValue({ outage: [outage], totalCount: 500, count: 500, offset: 0 })
-    const store = useNodeStore()
-    store.outages = [displayed]
-    store.outagesTotalCount = 1
-
-    await store.getNodeOutagesForExport({ id: '144' })
-
-    expect(store.outages).toEqual([displayed])
-    expect(store.outagesTotalCount).toBe(1)
-  })
-
-  it('getNodeOutagesForExport returns an empty list when the request fails', async () => {
-    vi.mocked(API.getNodeOutages).mockResolvedValue(false)
-    const store = useNodeStore()
-
-    await expect(store.getNodeOutagesForExport({ id: '144' })).resolves.toEqual([])
-  })
-})
-
 describe('nodeStore getNodeById', () => {
   const node = { id: '42', label: 'srv-42' } as unknown as Node
 
@@ -346,7 +309,7 @@ describe('nodeStore getNodeById', () => {
   })
 
   // A failed fetch must not leave the previous node's data on screen, nor claim to be loaded.
-  it('leaves no node loaded when the request fails', async () => {
+  it('leaves no node loaded when the request fails, and records the failure', async () => {
     vi.mocked(API.getNodeById).mockResolvedValue(node)
     const store = useNodeStore()
     await store.getNodeById({ id: '42' } as Node)
@@ -356,5 +319,102 @@ describe('nodeStore getNodeById', () => {
 
     expect(store.node).toEqual({})
     expect(store.nodeLoaded).toBe(false)
+    expect(store.nodeLoadFailed).toBe(true)
+  })
+
+  // The interface tables fetch by node id on their own, and only replace their rows on a
+  // successful response -- so a 404 for the node would otherwise leave the previous node's
+  // interfaces sitting under the new id.
+  it('clears the interfaces when the request fails', async () => {
+    vi.mocked(API.getNodeById).mockResolvedValue(false as never)
+    const store = useNodeStore()
+    store.ipInterfaces = [{ id: 'ip1' }] as never
+    store.ipInterfacesTotalCount = 1
+    store.snmpInterfaces = [{ id: 5 }] as never
+    store.snmpInterfacesTotalCount = 1
+
+    await store.getNodeById({ id: '99' } as Node)
+
+    expect(store.ipInterfaces).toEqual([])
+    expect(store.ipInterfacesTotalCount).toBe(0)
+    expect(store.snmpInterfaces).toEqual([])
+    expect(store.snmpInterfacesTotalCount).toBe(0)
+  })
+
+  // Everything this store holds is scoped to the node that failed to load, so none of it
+  // should stay on screen under an id that has no node. Events belong to their own store and
+  // are cleared by the page.
+  it('clears the outages and availability when the request fails', async () => {
+    vi.mocked(API.getNodeById).mockResolvedValue(false as never)
+    const store = useNodeStore()
+    store.outages = [{ id: 1 }] as never
+    store.outagesTotalCount = 1
+    store.availability = { availability: 98.7 } as never
+
+    await store.getNodeById({ id: '99' } as Node)
+
+    expect(store.outages).toEqual([])
+    expect(store.outagesTotalCount).toBe(0)
+    expect(store.availability).toEqual({})
+  })
+
+  it('clears the failure flag when a later fetch succeeds', async () => {
+    vi.mocked(API.getNodeById).mockResolvedValue(false as never)
+    const store = useNodeStore()
+    await store.getNodeById({ id: '99' } as Node)
+
+    vi.mocked(API.getNodeById).mockResolvedValue(node)
+    await store.getNodeById({ id: '42' } as Node)
+
+    expect(store.nodeLoadFailed).toBe(false)
+    expect(store.nodeLoaded).toBe(true)
+  })
+})
+
+describe('nodeStore getNodeSnmpPrimaryInterface', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  // The node payload carries no interfaces, and the IP Interfaces table only holds its current
+  // page, so the address the Update SNMP action needs is asked for directly.
+  it('asks for the node SNMP-primary interface and keeps its address', async () => {
+    vi.mocked(API.getNodeIpInterfaces).mockResolvedValue({
+      ipInterface: [{ id: 'ip2', ipAddress: '10.0.0.44', snmpPrimary: 'P' }],
+      totalCount: 1, count: 1, offset: 0
+    } as never)
+    const store = useNodeStore()
+
+    await store.getNodeSnmpPrimaryInterface('42')
+
+    expect(API.getNodeIpInterfaces).toHaveBeenCalledWith('42', {
+      limit: 1,
+      offset: 0,
+      _s: 'snmpPrimary==P'
+    })
+    expect(store.snmpPrimaryIpAddress).toBe('10.0.0.44')
+  })
+
+  it('holds no address for a node with no SNMP-primary interface', async () => {
+    vi.mocked(API.getNodeIpInterfaces).mockResolvedValue({
+      ipInterface: [], totalCount: 0, count: 0, offset: 0
+    } as never)
+    const store = useNodeStore()
+    store.snmpPrimaryIpAddress = '10.0.0.1'
+
+    await store.getNodeSnmpPrimaryInterface('42')
+
+    expect(store.snmpPrimaryIpAddress).toBeUndefined()
+  })
+
+  it('holds no address when the request fails', async () => {
+    vi.mocked(API.getNodeIpInterfaces).mockResolvedValue(false as never)
+    const store = useNodeStore()
+    store.snmpPrimaryIpAddress = '10.0.0.1'
+
+    await store.getNodeSnmpPrimaryInterface('42')
+
+    expect(store.snmpPrimaryIpAddress).toBeUndefined()
   })
 })

--- a/ui/tests/stores/nodeStore.test.ts
+++ b/ui/tests/stores/nodeStore.test.ts
@@ -24,12 +24,13 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useNodeStore } from '@/stores/nodeStore'
 import API from '@/services'
-import { IpInterface, SnmpInterface } from '@/types'
+import { IpInterface, Outage, SnmpInterface } from '@/types'
 
 vi.mock('@/services', () => ({
   default: {
     getSnmpInterfaces: vi.fn(),
-    getIpInterfaces: vi.fn()
+    getIpInterfaces: vi.fn(),
+    getNodeOutages: vi.fn()
   }
 }))
 
@@ -262,5 +263,43 @@ describe('useNodeStore', () => {
 
       expect(store.nodeToIpInterfaceMap.size).toEqual(0)
     })
+  })
+})
+
+describe('nodeStore outage export', () => {
+  const outage = { id: 2435, ipAddress: '10.0.0.44', serviceId: 3 } as unknown as Outage
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('getNodeOutagesForExport returns the fetched outages', async () => {
+    vi.mocked(API.getNodeOutages).mockResolvedValue({ outage: [outage], totalCount: 1, count: 1, offset: 0 })
+    const store = useNodeStore()
+
+    await expect(store.getNodeOutagesForExport({ id: '144' })).resolves.toEqual([outage])
+  })
+
+  // A download runs its own query; publishing the result into the store would replace the
+  // page the outages table is showing.
+  it('getNodeOutagesForExport leaves the currently displayed page untouched', async () => {
+    const displayed = { id: 7 } as unknown as Outage
+    vi.mocked(API.getNodeOutages).mockResolvedValue({ outage: [outage], totalCount: 500, count: 500, offset: 0 })
+    const store = useNodeStore()
+    store.outages = [displayed]
+    store.outagesTotalCount = 1
+
+    await store.getNodeOutagesForExport({ id: '144' })
+
+    expect(store.outages).toEqual([displayed])
+    expect(store.outagesTotalCount).toBe(1)
+  })
+
+  it('getNodeOutagesForExport returns an empty list when the request fails', async () => {
+    vi.mocked(API.getNodeOutages).mockResolvedValue(false)
+    const store = useNodeStore()
+
+    await expect(store.getNodeOutagesForExport({ id: '144' })).resolves.toEqual([])
   })
 })

--- a/ui/tests/stores/nodeStore.test.ts
+++ b/ui/tests/stores/nodeStore.test.ts
@@ -32,7 +32,9 @@ vi.mock('@/services', () => ({
     getIpInterfaces: vi.fn(),
     getNodeOutages: vi.fn(),
     getNodeById: vi.fn(),
-    getNodeIpInterfaces: vi.fn()
+    getNodeIpInterfaces: vi.fn(),
+    getNodeSnmpInterfaces: vi.fn(),
+    getNodeAvailabilityPercentage: vi.fn()
   }
 }))
 
@@ -416,5 +418,170 @@ describe('nodeStore getNodeSnmpPrimaryInterface', () => {
     await store.getNodeSnmpPrimaryInterface('42')
 
     expect(store.snmpPrimaryIpAddress).toBeUndefined()
+  })
+})
+
+const deferred = <T>() => {
+  let resolve: (value: T) => void = () => undefined
+  const promise = new Promise<T>((r) => {
+    resolve = r
+  })
+
+  return { promise, resolve }
+}
+
+// Moving between nodes fires these off per node id; the responses can come back in any order.
+describe('nodeStore stale node responses', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('discards a node response a newer request has superseded', async () => {
+    const first = deferred<unknown>()
+    const second = deferred<unknown>()
+    vi.mocked(API.getNodeById)
+      .mockImplementationOnce(() => first.promise as never)
+      .mockImplementationOnce(() => second.promise as never)
+    const store = useNodeStore()
+
+    const firstCall = store.getNodeById({ id: '1' } as Node)
+    const secondCall = store.getNodeById({ id: '2' } as Node)
+
+    second.resolve({ id: '2', label: 'node-2' })
+    await secondCall
+    first.resolve({ id: '1', label: 'node-1' })
+    await firstCall
+
+    expect(store.node).toEqual({ id: '2', label: 'node-2' })
+    expect(store.nodeLoaded).toBe(true)
+  })
+
+  // The failure path wipes every panel's data, so a superseded failure must not fire at all.
+  it('discards a superseded failure rather than clearing the node that did load', async () => {
+    const first = deferred<unknown>()
+    const second = deferred<unknown>()
+    vi.mocked(API.getNodeById)
+      .mockImplementationOnce(() => first.promise as never)
+      .mockImplementationOnce(() => second.promise as never)
+    const store = useNodeStore()
+    store.outages = [{ id: 7 }] as never
+
+    const firstCall = store.getNodeById({ id: '1' } as Node)
+    const secondCall = store.getNodeById({ id: '2' } as Node)
+
+    second.resolve({ id: '2', label: 'node-2' })
+    await secondCall
+    first.resolve(false)
+    await firstCall
+
+    expect(store.node).toEqual({ id: '2', label: 'node-2' })
+    expect(store.nodeLoadFailed).toBe(false)
+    expect(store.outages).toEqual([{ id: 7 }])
+  })
+
+  // A stale address here builds admin/updateSnmp.jsp for an address that is not the node's.
+  it('discards an SNMP-primary response a newer request has superseded', async () => {
+    const first = deferred<unknown>()
+    const second = deferred<unknown>()
+    vi.mocked(API.getNodeIpInterfaces)
+      .mockImplementationOnce(() => first.promise as never)
+      .mockImplementationOnce(() => second.promise as never)
+    const store = useNodeStore()
+
+    const firstCall = store.getNodeSnmpPrimaryInterface('1')
+    const secondCall = store.getNodeSnmpPrimaryInterface('2')
+
+    second.resolve({ ipInterface: [{ ipAddress: '10.0.0.2' }], totalCount: 1, count: 1, offset: 0 })
+    await secondCall
+    first.resolve({ ipInterface: [{ ipAddress: '10.0.0.1' }], totalCount: 1, count: 1, offset: 0 })
+    await firstCall
+
+    expect(store.snmpPrimaryIpAddress).toBe('10.0.0.2')
+  })
+})
+
+// Same hazard in the panels' own fetches: they are fired per node id as the user moves between
+// nodes, and per page as the paginator moves.
+describe('nodeStore stale panel responses', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  interface OnceMock {
+    mockImplementationOnce: (fn: () => never) => OnceMock
+  }
+
+  const racePair = <T>(mock: OnceMock) => {
+    const first = deferred<T>()
+    const second = deferred<T>()
+    mock.mockImplementationOnce(() => first.promise as never)
+      .mockImplementationOnce(() => second.promise as never)
+
+    return { first, second }
+  }
+
+  it('discards superseded SNMP interfaces', async () => {
+    const { first, second } = racePair(vi.mocked(API.getNodeSnmpInterfaces) as never)
+    const store = useNodeStore()
+
+    const firstCall = store.getNodeSnmpInterfaces({ id: '1' })
+    const secondCall = store.getNodeSnmpInterfaces({ id: '2' })
+
+    second.resolve({ snmpInterface: [{ id: 2 }], totalCount: 1 } as never)
+    await secondCall
+    first.resolve({ snmpInterface: [{ id: 1 }], totalCount: 9 } as never)
+    await firstCall
+
+    expect(store.snmpInterfaces).toEqual([{ id: 2 }])
+    expect(store.snmpInterfacesTotalCount).toBe(1)
+  })
+
+  it('discards superseded IP interfaces', async () => {
+    const { first, second } = racePair(vi.mocked(API.getNodeIpInterfaces) as never)
+    const store = useNodeStore()
+
+    const firstCall = store.getNodeIpInterfaces({ id: '1' })
+    const secondCall = store.getNodeIpInterfaces({ id: '2' })
+
+    second.resolve({ ipInterface: [{ id: 'ip2' }], totalCount: 1 } as never)
+    await secondCall
+    first.resolve({ ipInterface: [{ id: 'ip1' }], totalCount: 9 } as never)
+    await firstCall
+
+    expect(store.ipInterfaces).toEqual([{ id: 'ip2' }])
+    expect(store.ipInterfacesTotalCount).toBe(1)
+  })
+
+  it('discards superseded outages', async () => {
+    const { first, second } = racePair(vi.mocked(API.getNodeOutages) as never)
+    const store = useNodeStore()
+
+    const firstCall = store.getNodeOutages({ id: '1' })
+    const secondCall = store.getNodeOutages({ id: '2' })
+
+    second.resolve({ outage: [{ id: 2 }], totalCount: 1 } as never)
+    await secondCall
+    first.resolve({ outage: [{ id: 1 }], totalCount: 9 } as never)
+    await firstCall
+
+    expect(store.outages).toEqual([{ id: 2 }])
+    expect(store.outagesTotalCount).toBe(1)
+  })
+
+  it('discards superseded availability', async () => {
+    const { first, second } = racePair(vi.mocked(API.getNodeAvailabilityPercentage) as never)
+    const store = useNodeStore()
+
+    const firstCall = store.getNodeAvailabilityPercentage('1')
+    const secondCall = store.getNodeAvailabilityPercentage('2')
+
+    second.resolve({ availability: 22 } as never)
+    await secondCall
+    first.resolve({ availability: 11 } as never)
+    await firstCall
+
+    expect(store.availability).toEqual({ availability: 22 })
   })
 })


### PR DESCRIPTION
# NMS-20031: Vue Node Details screen

Continuing work that brings the Vue Node Details page up to parity with the legacy JSP node page
(`element/node.jsp`), so we can replace the current JSP-based UI.

## What the page shows

**Title row** — "Node Details for _node-label_", with a node actions menu on the right
offering the same links the legacy page did: events, alarms, outages,
assets, metadata, hardware inventory, availability, site status, resource graphs,
rescan, admin, SNMP update, schedule an outage, topology map, and node link
details. Site status and SNMP update appear only when the node has the data they need — a
building, and an SNMP-primary interface.

**Status badges** — node status, label, ID and monitoring location. Status is
color-coded: active reads as success, deleted as danger, unknown as neutral.

**SNMP Attributes** — name, sys object ID, location, contact and description.

**Surveillance Category Memberships** — the node's categories, with an edit
action for admins that opens the category admin screen for this node.

**Notifications** — links to the current user's outstanding and acknowledged
notifications for this node, plus a link to the Notifications page.

**Availability** — availability over the last 24 hours for the node, each of its
interfaces, and each monitored service, with the timeline graphics from the
legacy page. The `XXX` in the interface and service rows is a placeholder for
status icons still to come; this panel is being reworked in a subsequent PR.

**Node Interfaces** — IP and SNMP interfaces in tabs. More work to be done on these in a subsequent PR.

**Recent Events** — paginated, with a link to the full event list for this node
and CSV/JSON download.

**Recent Outages** — paginated, with a link to the full outage list for this node
(showing both current and resolved) and CSV/JSON download. Each row links out to
the outage, its interface and its service; lost and regained times are shown as
dates, and an outage that has not been resolved yet has its lost time flagged.

## Downloads

The events and outages panels can both export what they are showing as CSV or
JSON, covering the full record rather than only the visible columns. The rows are
already on hand, so a download uses that data instead of making another API request,
and so the file always agrees with the table. The user can change the rows-per-page
to get more or less data; exporting a node's entire history is left to
the Events and Outages pages (not yet implemented - will be done as part of converting
those pages to Vue).

The CSV neutralises anything a spreadsheet would run as a formula, since event
messages arrive from traps and syslog, and gives nested values their own columns
rather than a blob of JSON in one cell.

## When the node changes, or cannot be loaded

The page keeps one component instance as the user moves between nodes, so every
panel follows the node id rather than reading it once — otherwise a table would
keep showing one node while the links beside it pointed at another.

A node that cannot be fetched — e.g. a 404 for an id that does not exist — clears
all data from any previous node. The panels that describe a node are held
back until there is one, the heading reads "Node Details for N/A", and the
interfaces, outages, events and availability are cleared. A fetch still in
flight is treated as different from one that failed.

We will revisit this in a subsequent PR, e.g. using skeletons and spinners which loading
and a different display for empty or errored state.

## Node list

The per-row actions menu picks up the new node link details action, so the node
list and the Node Details page now offer the same set, including the
SNMP-primary-aware SNMP update link.

## Also in here

- The node asset record is now fully typed, which tidied up some latitude and
  longitude handling in the map components.
- A few `Outage` fields were corrected to match what the API actually sends.
- The panels share one card component, and the two download implementations share
  one helper, rather than each panel carrying its own copy.
- The node action links now live in one place instead of two lists that had
  drifted apart.

## Testing

Unit tests cover each panel, the download and link building, and the store
additions — including the empty and missing-data cases (no categories, no
outages, an outage with no interface or an unrecognised service, a node with no
building, a node that fails to load, and moving between nodes). The full `ui`
suite, lint and type check pass.

## Follow-ups, not in this PR

- The Availability panel is being reworked, including the status icons its `XXX`
  placeholders stand in for. The bar graphs will be rendered client-side.
- SNMP interface ordering, shading
- `useRole` caches the auth store at module level, which makes role-dependent
  component tests order-dependent. Worked around in the tests here; the
  composable itself should be fixed.
- Icon-button actions could eventually move into `OnmsCard` instead of the Node Details
  card component.
- Downloading a node's complete event and outage history belongs on the Events
  and Outages pages. We will implement that as part of the Vue rewrite.
- The node list's own CSV export still quotes only on commas, escapes no
embedded quotes, and does not guard against formulas — unlike the events and
outages export added here.
- We need better handling when REST data is not available, or is slow to populate. Perhaps spinners on each
panel or something similar.
- Better date display, ideally on 2 lines (date/time). Tricky because user can customize it.
- Various other panels that only display when certain data is available or options are selected.
- We expect to rearrange the panels, perhaps add tabs, etc.

## Screenshots

### Vue Node Details - top section

<img width="1441" height="1023" alt="view-node-details-1" src="https://github.com/user-attachments/assets/384e35a8-d5e5-4a28-a44a-b79cb9b7b227" />


### Vue Node Details - bottom section

<img width="1457" height="1130" alt="view-node-details-2" src="https://github.com/user-attachments/assets/285bd2d6-201a-480a-831b-d921dce7de2a" />


### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20031
