### PR TITLE
NMS-20308: Fix Sentinel dropwizard-metrics version range in featuresProcessing

### DIFF
--- a/features/container/sentinel/src/main/internal/features-processing.xml
+++ b/features/container/sentinel/src/main/internal/features-processing.xml
@@ -283,9 +283,9 @@
     <bundle replacement="mvn:org.codehaus.jettison/jettison/${jettisonVersion}"
             originalUri="mvn:org.codehaus.jettison/jettison/[1,${jettisonVersion})" mode="maven" />
     <bundle replacement="mvn:io.dropwizard.metrics/metrics-core/${dropwizardMetricsVersion}"
-            originalUri="mvn:io.dropwizard.metrics/metrics-core/[3,${dropwizardMetricsVersion})" mode="maven" />
+            originalUri="mvn:io.dropwizard.metrics/metrics-core/[3,10)" mode="maven" />
     <bundle replacement="mvn:io.dropwizard.metrics/metrics-jvm/${dropwizardMetricsVersion}"
-            originalUri="mvn:io.dropwizard.metrics/metrics-jvm/[3,${dropwizardMetricsVersion})" mode="maven" />
+            originalUri="mvn:io.dropwizard.metrics/metrics-jvm/[3,10)" mode="maven" />
     <bundle replacement="wrap:mvn:org.dom4j/dom4j/${dom4jVersion}"
             originalUri="mvn:dom4j/dom4j/[0,${dom4jVersion})" mode="maven" />
     <bundle replacement="mvn:org.jolokia/jolokia-osgi/${jolokiaVersion}"


### PR DESCRIPTION
This issue causes Sentinel smoke tests to fail (on `release-2025.x` branch).

Widen the range to also catch CXF's own bundled dropwizard-metrics version.

### All Contributors

* [x] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20308

