### PR TITLE
NMS-20309: Vue UI dashboard panels for the legacy Charts

### DIFF
--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/ChartRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/ChartRestService.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.opennms.core.db.DataSourceFactory;
+import org.opennms.netmgt.config.ChartConfigFactory;
+import org.opennms.netmgt.config.charts.BarChart;
+import org.opennms.netmgt.config.charts.Rgb;
+import org.opennms.netmgt.config.charts.SeriesDef;
+import org.opennms.netmgt.config.charts.SubTitle;
+import org.opennms.netmgt.model.OnmsSeverity;
+import org.opennms.web.rest.v2.api.ChartRestApi;
+import org.opennms.web.rest.v2.model.ChartDataDto;
+import org.opennms.web.rest.v2.model.ChartSummaryDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * Serves the bar charts of chart-configuration.xml as data, so the dashboard
+ * can draw them client-side. The queries are the ones the legacy charts page
+ * rendered through JFreeChart; nothing here is writable.
+ */
+@Service
+public class ChartRestService implements ChartRestApi {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ChartRestService.class);
+
+    // the only sub-label class the legacy config ships; it maps numeric severities to names
+    private static final String SEVERITY_SUB_LABELS = "org.opennms.web.charts.SeveritySubLabels";
+
+    @Override
+    public Response getCharts() {
+        try {
+            final List<ChartSummaryDto> summaries = new ArrayList<>();
+            for (final BarChart chart : configuredCharts()) {
+                summaries.add(fill(new ChartSummaryDto(), chart));
+            }
+            return Response.ok(summaries).build();
+        } catch (final IOException e) {
+            LOG.error("Unable to read the chart configuration", e);
+            return Response.serverError().build();
+        }
+    }
+
+    @Override
+    public Response getChart(final String name) {
+        try {
+            final Optional<BarChart> chart = configuredCharts().stream()
+                    .filter(c -> c.getName() != null && c.getName().equals(name))
+                    .findFirst();
+            if (chart.isEmpty()) {
+                return Response.status(Status.NOT_FOUND).build();
+            }
+            return Response.ok(evaluate(chart.get())).build();
+        } catch (final IOException e) {
+            LOG.error("Unable to read the chart configuration", e);
+            return Response.serverError().build();
+        } catch (final SQLException e) {
+            LOG.error("Unable to run the queries of chart '{}'", name, e);
+            return Response.serverError().build();
+        }
+    }
+
+    private static Collection<BarChart> configuredCharts() throws IOException {
+        synchronized (ChartConfigFactory.class) {
+            ChartConfigFactory.init();
+            ChartConfigFactory.getInstance().update();
+            return ChartConfigFactory.getInstance().getConfiguration().getBarChartCollection();
+        }
+    }
+
+    private static <T extends ChartSummaryDto> T fill(final T dto, final BarChart chart) {
+        dto.setName(chart.getName());
+        dto.setTitle(chart.getTitle() == null ? chart.getName() : chart.getTitle().getValue());
+        dto.setSubTitle(chart.getSubTitleCollection().stream()
+                .map(SubTitle::getTitle)
+                .filter(t -> t != null && t.getValue() != null)
+                .map(t -> t.getValue())
+                .findFirst()
+                .orElse(null));
+        dto.setDomainAxisLabel(chart.getDomainAxisLabel());
+        dto.setRangeAxisLabel(chart.getRangeAxisLabel());
+        return dto;
+    }
+
+    private static ChartDataDto evaluate(final BarChart chart) throws SQLException {
+        final ChartDataDto dto = fill(new ChartDataDto(), chart);
+        // category order is first appearance across the series, as JFreeChart's dataset did
+        final Map<String, ChartDataDto.Category> categories = new LinkedHashMap<>();
+        final List<Map<String, Number>> valuesBySeries = new ArrayList<>();
+        final boolean severityLabels = chart.getSubLabelClass().map(SEVERITY_SUB_LABELS::equals).orElse(false);
+
+        try (Connection conn = DataSourceFactory.getInstance().getConnection()) {
+            for (final SeriesDef def : chart.getSeriesDefCollection()) {
+                final Map<String, Number> values = new LinkedHashMap<>();
+                try (Statement statement = conn.createStatement();
+                     ResultSet rs = statement.executeQuery(def.getJdbcDataSet().getSql())) {
+                    final int columns = rs.getMetaData().getColumnCount();
+                    while (rs.next()) {
+                        final String key = String.valueOf(rs.getObject(1));
+                        final Object value = columns > 1 ? rs.getObject(2) : null;
+                        values.put(key, value instanceof Number ? (Number) value : null);
+                        categories.computeIfAbsent(key, k -> new ChartDataDto.Category(k, severityLabels ? severityLabel(k) : k));
+                    }
+                }
+                valuesBySeries.add(values);
+                final ChartDataDto.Series series = new ChartDataDto.Series();
+                series.setName(def.getSeriesName());
+                series.setColor(def.getRgb().map(ChartRestService::hex).orElse(null));
+                dto.getSeries().add(series);
+            }
+        }
+
+        dto.getCategories().addAll(categories.values());
+        for (int i = 0; i < dto.getSeries().size(); i++) {
+            final Map<String, Number> values = valuesBySeries.get(i);
+            final List<Number> aligned = new ArrayList<>();
+            for (final String key : categories.keySet()) {
+                aligned.add(values.get(key));
+            }
+            dto.getSeries().get(i).setValues(aligned);
+        }
+        return dto;
+    }
+
+    private static String severityLabel(final String key) {
+        try {
+            return OnmsSeverity.get(Integer.parseInt(key)).getLabel();
+        } catch (final RuntimeException e) {
+            return key;
+        }
+    }
+
+    private static String hex(final Rgb rgb) {
+        return String.format("#%02x%02x%02x",
+                rgb.getRed().getRgbColor(), rgb.getGreen().getRgbColor(), rgb.getBlue().getRgbColor());
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/ChartRestApi.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/api/ChartRestApi.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2.api;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Path("charts")
+@Tag(name = "Charts", description = "Bar charts configured in chart-configuration.xml, as data. API V2")
+public interface ChartRestApi {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "List the configured charts.",
+            description = "Returns the name, title and axis labels of every bar chart in chart-configuration.xml.",
+            operationId = "getCharts"
+    )
+    Response getCharts();
+
+    @GET
+    @Path("{name}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Get a configured chart's data.",
+            description = "Runs the chart's series queries and returns the categories and one value series per series definition, or 404 for an unknown chart name.",
+            operationId = "getChart"
+    )
+    Response getChart(@PathParam("name") String name);
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/ChartDataDto.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/ChartDataDto.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "ChartData", description = "A configured bar chart with its series queries evaluated.")
+public class ChartDataDto extends ChartSummaryDto {
+
+    @Schema(name = "ChartCategory", description = "One domain-axis category: the query's key and the label to show for it.")
+    public static class Category {
+        private String key;
+        private String label;
+
+        public Category() {
+        }
+
+        public Category(final String key, final String label) {
+            this.key = key;
+            this.label = label;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public void setKey(final String key) {
+            this.key = key;
+        }
+
+        public String getLabel() {
+            return label;
+        }
+
+        public void setLabel(final String label) {
+            this.label = label;
+        }
+    }
+
+    @Schema(name = "ChartSeries", description = "One series: a value per category, in category order; null where the query returned no row.")
+    public static class Series {
+        private String name;
+        private String color;
+        private List<Number> values = new ArrayList<>();
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(final String name) {
+            this.name = name;
+        }
+
+        public String getColor() {
+            return color;
+        }
+
+        public void setColor(final String color) {
+            this.color = color;
+        }
+
+        public List<Number> getValues() {
+            return values;
+        }
+
+        public void setValues(final List<Number> values) {
+            this.values = values;
+        }
+    }
+
+    private List<Category> categories = new ArrayList<>();
+    private List<Series> series = new ArrayList<>();
+
+    public List<Category> getCategories() {
+        return categories;
+    }
+
+    public void setCategories(final List<Category> categories) {
+        this.categories = categories;
+    }
+
+    public List<Series> getSeries() {
+        return series;
+    }
+
+    public void setSeries(final List<Series> series) {
+        this.series = series;
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/ChartSummaryDto.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/model/ChartSummaryDto.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "ChartSummary", description = "A bar chart configured in chart-configuration.xml.")
+public class ChartSummaryDto {
+
+    private String name;
+    private String title;
+    private String subTitle;
+    private String domainAxisLabel;
+    private String rangeAxisLabel;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(final String title) {
+        this.title = title;
+    }
+
+    public String getSubTitle() {
+        return subTitle;
+    }
+
+    public void setSubTitle(final String subTitle) {
+        this.subTitle = subTitle;
+    }
+
+    public String getDomainAxisLabel() {
+        return domainAxisLabel;
+    }
+
+    public void setDomainAxisLabel(final String domainAxisLabel) {
+        this.domainAxisLabel = domainAxisLabel;
+    }
+
+    public String getRangeAxisLabel() {
+        return rangeAxisLabel;
+    }
+
+    public void setRangeAxisLabel(final String rangeAxisLabel) {
+        this.rangeAxisLabel = rangeAxisLabel;
+    }
+}

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/ChartRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/ChartRestServiceIT.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.web.rest.v2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.ws.rs.core.MediaType;
+
+import org.apache.commons.io.FileUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opennms.core.db.DataSourceFactory;
+import org.opennms.core.test.ConfigurationTestUtils;
+import org.opennms.core.test.MockLogAppender;
+import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.core.test.rest.AbstractSpringJerseyRestTestCase;
+import org.opennms.netmgt.dao.DatabasePopulator;
+import org.opennms.test.JUnitConfigurationEnvironment;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+@RunWith(OpenNMSJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration(locations = {
+        "classpath:/META-INF/opennms/applicationContext-soa.xml",
+        "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
+        "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml",
+        "classpath:/META-INF/opennms/applicationContext-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-mockConfigManager.xml",
+        "classpath*:/META-INF/opennms/component-service.xml",
+        "classpath*:/META-INF/opennms/component-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
+        "classpath:/META-INF/opennms/mockEventIpcManager.xml",
+        "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/META-INF/opennms/applicationContext-postgresJsonStore.xml",
+        "classpath:/applicationContext-rest-test.xml"
+})
+@JUnitConfigurationEnvironment(systemProperties = "org.opennms.timeseries.strategy=integration")
+@JUnitTemporaryDatabase
+public class ChartRestServiceIT extends AbstractSpringJerseyRestTestCase {
+
+    // the shipped configuration, so the three legacy charts are what gets exercised
+    private static final File SHIPPED_CHART_CONFIG = new File("../opennms-base-assembly/src/main/filtered/etc/chart-configuration.xml");
+
+    @Autowired
+    private DatabasePopulator m_databasePopulator;
+
+    private static boolean s_populated = false;
+    private String m_onmsHome;
+
+    public ChartRestServiceIT() {
+        super(CXF_REST_V2_CONTEXT_PATH);
+    }
+
+    @Override
+    protected void beforeServletStart() throws Exception {
+        MockLogAppender.setupLogging();
+        final File etc = new File("target/test-work-dir-charts/etc");
+        etc.mkdirs();
+        m_onmsHome = etc.getParent();
+        FileUtils.copyFile(SHIPPED_CHART_CONFIG, new File(etc, "chart-configuration.xml"));
+        System.setProperty("opennms.home", m_onmsHome);
+        ConfigurationTestUtils.setRelativeHomeDirectory(m_onmsHome);
+    }
+
+    // context initialization can repoint opennms.home at opennms-base-assembly
+    @Override
+    protected void afterServletStart() throws Exception {
+        System.setProperty("opennms.home", m_onmsHome);
+        ConfigurationTestUtils.setRelativeHomeDirectory(m_onmsHome);
+        if (!s_populated) {
+            m_databasePopulator.populateDatabase();
+            s_populated = true;
+        }
+        seedNode();
+    }
+
+    private static int jdbcNodeCount() throws Exception {
+        try (Connection conn = DataSourceFactory.getInstance().getConnection();
+             Statement statement = conn.createStatement();
+             ResultSet rs = statement.executeQuery("select count(*) from node")) {
+            rs.next();
+            return rs.getInt(1);
+        }
+    }
+
+    // the chart queries run on the service's own JDBC connection, which does not
+    // see the populator's uncommitted Hibernate rows; commit one node through JDBC,
+    // once per temporary database
+    private static void seedNode() throws Exception {
+        try (Connection conn = DataSourceFactory.getInstance().getConnection();
+             Statement statement = conn.createStatement()) {
+            try (ResultSet rs = statement.executeQuery("select count(*) from node where nodelabel = 'chart-it'")) {
+                rs.next();
+                if (rs.getInt(1) > 0) {
+                    return;
+                }
+            }
+            statement.executeUpdate("insert into node (nodeid, location, nodecreatetime, nodelabel, nodetype)"
+                    + " values (nextval('nodenxtid'), 'Default', now(), 'chart-it', 'A')");
+        }
+    }
+
+    private String getJson(final String url) throws Exception {
+        final MockHttpServletRequest request = createRequest(GET, url);
+        request.addHeader("Accept", MediaType.APPLICATION_JSON);
+        return sendRequest(request, 200);
+    }
+
+    @Test
+    public void testListsTheShippedCharts() throws Exception {
+        final JSONArray charts = new JSONArray(getJson("/charts"));
+        final List<String> names = new ArrayList<>();
+        final List<String> titles = new ArrayList<>();
+        for (int i = 0; i < charts.length(); i++) {
+            names.add(charts.getJSONObject(i).getString("name"));
+            titles.add(charts.getJSONObject(i).getString("title"));
+        }
+        assertTrue(names.toString(), names.containsAll(List.of("sample-bar-chart", "sample-bar-chart2", "sample-bar-chart3")));
+        assertTrue(titles.toString(), titles.containsAll(List.of("Alarms", "Last 7 Days Outages", "Node Inventory")));
+        final JSONObject alarms = charts.getJSONObject(names.indexOf("sample-bar-chart"));
+        assertEquals("Severity Chart", alarms.getString("subTitle"));
+        assertEquals("Severity", alarms.getString("domainAxisLabel"));
+        assertEquals("Count", alarms.getString("rangeAxisLabel"));
+    }
+
+    @Test
+    public void testNodeInventoryCountsThePopulatedDatabase() throws Exception {
+        final JSONObject chart = new JSONObject(getJson("/charts/sample-bar-chart3"));
+        assertEquals("Node Inventory", chart.getString("title"));
+        final JSONArray categories = chart.getJSONArray("categories");
+        final List<String> keys = new ArrayList<>();
+        for (int i = 0; i < categories.length(); i++) {
+            keys.add(categories.getJSONObject(i).getString("key"));
+            assertEquals(keys.get(i), categories.getJSONObject(i).getString("label"));
+        }
+        assertEquals(List.of("Nodes", "Interfaces", "Services"), keys);
+
+        // each series populates only its own category; the other slots are null
+        final JSONArray series = chart.getJSONArray("series");
+        assertEquals(3, series.length());
+        final JSONObject nodes = series.getJSONObject(0);
+        assertEquals("Nodes", nodes.getString("name"));
+        assertEquals("#ff0000", nodes.getString("color"));
+        final JSONArray values = nodes.getJSONArray("values");
+        assertEquals(3, values.length());
+        assertTrue("expected the seeded node to be counted, JDBC sees " + jdbcNodeCount() + " nodes but the chart reported " + values.get(0), values.getInt(0) > 0);
+        assertTrue(values.isNull(1));
+        assertTrue(values.isNull(2));
+    }
+
+    @Test
+    public void testSeverityChartLabelsItsCategories() throws Exception {
+        final JSONObject chart = new JSONObject(getJson("/charts/sample-bar-chart"));
+        final JSONArray series = chart.getJSONArray("series");
+        assertEquals(2, series.length());
+        assertEquals("Events", series.getJSONObject(0).getString("name"));
+        assertEquals("Alarms", series.getJSONObject(1).getString("name"));
+        final JSONArray categories = chart.getJSONArray("categories");
+        for (int i = 0; i < categories.length(); i++) {
+            final JSONObject category = categories.getJSONObject(i);
+            final int severity = Integer.parseInt(category.getString("key"));
+            assertTrue(severity > 4);
+            assertNotNull(category.getString("label"));
+            assertTrue(category.getString("label"), !category.getString("label").equals(category.getString("key")));
+        }
+    }
+
+    @Test
+    public void testUnknownChartIs404() throws Exception {
+        sendRequest(GET, "/charts/no-such-chart", 404);
+    }
+}

--- a/ui/src/components/Dashboard/PanelOptionsDialog.vue
+++ b/ui/src/components/Dashboard/PanelOptionsDialog.vue
@@ -97,6 +97,26 @@ License.
         </small>
       </div>
 
+      <div
+        v-else-if="isChartPanel"
+        class="opts__field"
+      >
+        <label class="opts__label">Chart</label>
+        <OnmsSelect
+          v-model="chartName"
+          :options="chartChoices"
+          optionLabel="title"
+          optionValue="name"
+          :placeholder="chartChoices.length ? 'Select a chart' : 'No charts configured'"
+          :disabled="!chartChoices.length"
+          class="opts__control"
+          data-test="chart-select"
+        />
+        <small class="opts__hint">
+          Any bar chart defined in <code>etc/chart-configuration.xml</code> can be shown here.
+        </small>
+      </div>
+
 
     </div>
 
@@ -116,7 +136,9 @@ License.
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
-import { OnmsDialog, OnmsTextarea, OnmsInputText, OnmsButton } from '@opennms/onms-ui'
+import { OnmsDialog, OnmsTextarea, OnmsInputText, OnmsButton, OnmsSelect } from '@opennms/onms-ui'
+import type { ChartSummary } from '@/types/charts'
+import { getCharts } from '@/services/chartService'
 import type { DashboardPanel, PanelHeightMode } from '@/types/dashboard'
 import { getPanelDefinition } from './registry'
 import { useDashboardStore } from '@/stores/dashboardStore'
@@ -139,6 +161,11 @@ const heightMode = ref<PanelHeightMode>('auto')
 const shade = ref(false)
 const notesText = ref('')
 const htmlUrl = ref('')
+const chartName = ref('')
+const chartChoices = ref<ChartSummary[]>([])
+
+// every chart panel type shares one component; the type only picks the default
+const isChartPanel = computed(() => props.panel.type.startsWith('chart-'))
 
 // panels that support optional severity row shading (legacy-style)
 const SHADEABLE = ['pending-situations', 'nodes-with-alarms', 'availability']
@@ -169,6 +196,12 @@ const syncFromPanel = () => {
   shade.value = !!props.panel.options?.shade
   notesText.value = String(props.panel.options?.text ?? '')
   htmlUrl.value = String(props.panel.options?.url ?? '')
+  chartName.value = String(props.panel.options?.chart ?? '')
+  if (isChartPanel.value) {
+    getCharts().then((charts) => {
+      chartChoices.value = charts ?? []
+    })
+  }
 }
 
 watch(
@@ -194,6 +227,9 @@ const apply = () => {
   }
   if (props.panel.type === 'html-content') {
     opts.url = htmlUrl.value.trim()
+  }
+  if (isChartPanel.value) {
+    opts.chart = chartName.value
   }
   store.setPanelOptions(props.panel.id, opts)
   visibleModel.value = false

--- a/ui/src/components/Dashboard/panels/ConfiguredChartPanel.vue
+++ b/ui/src/components/Dashboard/panels/ConfiguredChartPanel.vue
@@ -1,0 +1,269 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+<!--
+  Dashboard panel drawing one bar chart from etc/chart-configuration.xml, the
+  data the legacy Charts page rendered through JFreeChart. Which chart is the
+  `chart` panel option; the registry seeds it for the three shipped charts.
+  Styled like the Resource Graphs: soft grid, HTML legend under the plot.
+-->
+<template>
+  <div
+    ref="rootRef"
+    class="configured-chart"
+  >
+    <div class="configured-chart__canvas">
+      <canvas ref="canvasRef" />
+    </div>
+    <div
+      :id="legendId"
+      class="configured-chart__legend"
+    />
+    <p
+      v-if="loading"
+      class="configured-chart__muted"
+    >
+      Loading…
+    </p>
+    <p
+      v-else-if="!chartName"
+      class="configured-chart__muted"
+    >
+      No chart selected. Pick one in the panel options.
+    </p>
+    <p
+      v-else-if="failed"
+      class="configured-chart__muted"
+    >
+      Unable to load the chart.
+    </p>
+    <p
+      v-else-if="isEmpty"
+      class="configured-chart__muted"
+    >
+      No data for this chart.
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import Chart from 'chart.js/auto'
+import type { Plugin } from 'chart.js'
+import type { PanelComponentProps } from '@/types/dashboard'
+import type { ChartData } from '@/types/charts'
+import { getChart } from '@/services/chartService'
+import HtmlLegendPlugin from '@/components/Resources/plugins/HtmlLegendPlugin'
+
+const props = defineProps<PanelComponentProps>()
+
+// series without a configured color take these, in order
+const FALLBACK_COLORS = ['#3b82f6', '#f97316', '#22c55e', '#a855f7', '#ef4444', '#14b8a6']
+
+const rootRef = ref<HTMLElement | null>(null)
+const canvasRef = ref<HTMLCanvasElement | null>(null)
+const loading = ref(true)
+const failed = ref(false)
+const data = ref<ChartData | null>(null)
+let chart: Chart<'bar', (number | null)[], string> | null = null
+let resizeObserver: ResizeObserver | null = null
+let themeObserver: MutationObserver | null = null
+
+const chartName = computed(() => String(props.options?.chart ?? '').trim())
+const isEmpty = computed(() => !data.value || data.value.categories.length === 0)
+const legendId = computed(() => `configured-chart-legend-${props.panelId}`)
+
+// Chart.js defaults its text to a dark gray that vanishes on the dark theme
+const textColor = (): string => {
+  const el = rootRef.value
+  if (el) {
+    const c = getComputedStyle(el).getPropertyValue('--p-text-color').trim()
+    if (c) {
+      return c
+    }
+  }
+  return '#333333'
+}
+
+// the configured colors are the legacy chart's saturated primaries; a translucent
+// fill under a solid edge keeps their meaning (severity yellow/red) without the glare
+const withAlpha = (hex: string, alpha: number): string => {
+  const m = /^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex)
+  if (!m) {
+    return hex
+  }
+  return `rgba(${parseInt(m[1], 16)}, ${parseInt(m[2], 16)}, ${parseInt(m[3], 16)}, ${alpha})`
+}
+
+// the value above each bar, as the legacy chart printed it
+const valueLabels = (color: string): Plugin<'bar'> => ({
+  id: 'configuredChartValues',
+  afterDatasetsDraw(c) {
+    const ctx = c.ctx
+    ctx.save()
+    ctx.font = '600 11px OpenSans, Helvetica, Arial, sans-serif'
+    ctx.fillStyle = color
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'bottom'
+    c.data.datasets.forEach((dataset, i) => {
+      if (!c.isDatasetVisible(i)) {
+        return
+      }
+      c.getDatasetMeta(i).data.forEach((bar, j) => {
+        const value = dataset.data[j]
+        if (value === null || value === undefined) {
+          return
+        }
+        ctx.fillText(String(value), bar.x, bar.y - 3)
+      })
+    })
+    ctx.restore()
+  }
+})
+
+// the Resource Graphs legend, pointed at this panel's own container
+const legendFor = (containerID: string): Plugin<'bar'> => ({
+  id: HtmlLegendPlugin.id,
+  afterUpdate: (c, args) => HtmlLegendPlugin.afterUpdate(c, args, { containerID })
+})
+
+const render = () => {
+  chart?.destroy()
+  chart = null
+  const legend = document.getElementById(legendId.value)
+  if (legend) {
+    legend.innerHTML = ''
+  }
+  const canvas = canvasRef.value
+  if (!canvas || !data.value || isEmpty.value) {
+    return
+  }
+  const color = textColor()
+  const axisTitle = (text?: string | null) => ({ display: !!text, text: text ?? '', color, font: { size: 12 }})
+  chart = new Chart(canvas, {
+    type: 'bar',
+    data: {
+      labels: data.value.categories.map(c => c.label),
+      datasets: data.value.series.map((s, i) => {
+        const base = s.color ?? FALLBACK_COLORS[i % FALLBACK_COLORS.length]
+        return {
+          label: s.name,
+          data: s.values,
+          backgroundColor: withAlpha(base, 0.7),
+          borderColor: base,
+          borderWidth: 1.5,
+          borderRadius: 4,
+          maxBarThickness: 48,
+          categoryPercentage: 0.7,
+          barPercentage: 0.85
+        }
+      })
+    },
+    plugins: [legendFor(legendId.value), valueLabels(color)],
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      animation: false,
+      layout: { padding: { top: 16 }},
+      plugins: {
+        legend: { display: false }
+      },
+      scales: {
+        x: { title: axisTitle(data.value.domainAxisLabel), ticks: { color }, grid: { display: false, drawBorder: false }},
+        y: {
+          beginAtZero: true,
+          title: axisTitle(data.value.rangeAxisLabel),
+          ticks: { color, precision: 0, maxTicksLimit: 6 },
+          grid: { color: 'rgba(128, 128, 128, 0.18)', borderDash: [4, 4], drawBorder: false }
+        }
+      }
+    }
+  })
+}
+
+const load = async () => {
+  if (!chartName.value) {
+    data.value = null
+    loading.value = false
+    render()
+    return
+  }
+  loading.value = true
+  const result = await getChart(chartName.value)
+  failed.value = result === null
+  data.value = result
+  loading.value = false
+  await nextTick()
+  render()
+}
+
+onMounted(() => {
+  load()
+  if (rootRef.value) {
+    resizeObserver = new ResizeObserver(() => chart?.resize())
+    resizeObserver.observe(rootRef.value)
+  }
+  themeObserver = new MutationObserver(render)
+  themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+})
+
+watch(() => props.refreshTick, load)
+watch(chartName, load)
+
+onBeforeUnmount(() => {
+  resizeObserver?.disconnect()
+  resizeObserver = null
+  themeObserver?.disconnect()
+  themeObserver = null
+  chart?.destroy()
+  chart = null
+})
+</script>
+
+<style scoped lang="scss">
+@import '@/styles/onms-typography';
+
+.configured-chart {
+  height: 100%;
+  min-height: 12rem;
+  display: flex;
+  flex-direction: column;
+
+  &__canvas {
+    flex: 1 1 auto;
+    min-height: 0;
+    position: relative;
+  }
+
+  &__legend {
+    @include onms-body-small;
+    text-align: center;
+    margin-top: 0.25rem;
+  }
+
+  &__muted {
+    margin: 0.25rem 0 0;
+    font-size: 0.85rem;
+    color: var(--p-text-muted-color, #6b7280);
+    text-align: center;
+  }
+}
+</style>

--- a/ui/src/components/Dashboard/registry.ts
+++ b/ui/src/components/Dashboard/registry.ts
@@ -51,7 +51,23 @@ export interface PanelDefinition {
   // not offered in the "Add panel" picker; still renders if a layout references
   // it (dev/debug panels like 'sample')
   hidden?: boolean
+  // seeded into a new panel's options, for types that are one component
+  // configured several ways (the shipped charts)
+  defaultOptions?: Record<string, unknown>
 }
+
+const configuredChart = (type: string, title: string, chart: string, category: PanelDefinition['category']): PanelDefinition => ({
+  type,
+  title,
+  category,
+  defaultHeightMode: 'fixed',
+  component: defineAsyncComponent(() => import('./panels/ConfiguredChartPanel.vue')),
+  defaultSize: { w: 4, h: 5 },
+  minSize: { w: 3, h: 4 },
+  defaultOptions: { chart },
+  renamable: true,
+  collapsible: true
+})
 
 export const panelRegistry: Record<string, PanelDefinition> = {
   'pending-situations': {
@@ -208,6 +224,10 @@ export const panelRegistry: Record<string, PanelDefinition> = {
     renamable: true,
     collapsible: true
   },
+  // the three charts of the legacy Charts page, from etc/chart-configuration.xml
+  'chart-alarms': configuredChart('chart-alarms', 'Charts - Alarms', 'sample-bar-chart', 'status'),
+  'chart-outages': configuredChart('chart-outages', 'Charts - Last 7 Day Outages', 'sample-bar-chart2', 'status'),
+  'chart-node-inventory': configuredChart('chart-node-inventory', 'Charts - Node Inventory', 'sample-bar-chart3', 'inventory'),
   'html-content': {
     type: 'html-content',
     defaultHeightMode: 'fixed',

--- a/ui/src/services/chartService.ts
+++ b/ui/src/services/chartService.ts
@@ -1,0 +1,43 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+import { v2 } from './axiosInstances'
+import type { ChartData, ChartSummary } from '@/types/charts'
+
+// null on failure, as opposed to an empty list, so panels can tell a fetch
+// failure from a configuration without charts
+export const getCharts = async (): Promise<ChartSummary[] | null> => {
+  try {
+    const resp = await v2.get('/charts')
+    return resp.status === 204 || !Array.isArray(resp.data) ? [] : (resp.data as ChartSummary[])
+  } catch (_err) {
+    return null
+  }
+}
+
+export const getChart = async (name: string): Promise<ChartData | null> => {
+  try {
+    const resp = await v2.get(`/charts/${encodeURIComponent(name)}`)
+    return resp.data as ChartData
+  } catch (_err) {
+    return null
+  }
+}

--- a/ui/src/stores/dashboardStore.ts
+++ b/ui/src/stores/dashboardStore.ts
@@ -208,7 +208,7 @@ export const useDashboardStore = defineStore('dashboardStore', {
         filterOverride: null,
         timeframeOverride: null,
         refreshSeconds: null,
-        options: {}
+        options: { ...(def.defaultOptions ?? {}) }
       })
       this.isDirty = true
     },

--- a/ui/src/types/charts.ts
+++ b/ui/src/types/charts.ts
@@ -1,0 +1,47 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+// Wire shapes of /api/v2/charts: the bar charts of etc/chart-configuration.xml
+// with their series queries evaluated server-side.
+export interface ChartSummary {
+  name: string
+  title: string
+  subTitle?: string | null
+  domainAxisLabel?: string | null
+  rangeAxisLabel?: string | null
+}
+
+export interface ChartCategory {
+  key: string
+  label: string
+}
+
+export interface ChartSeries {
+  name: string
+  color?: string | null
+  // one slot per category, null where the series' query returned no row for it
+  values: (number | null)[]
+}
+
+export interface ChartData extends ChartSummary {
+  categories: ChartCategory[]
+  series: ChartSeries[]
+}

--- a/ui/tests/components/Dashboard/ConfiguredChartPanel.test.ts
+++ b/ui/tests/components/Dashboard/ConfiguredChartPanel.test.ts
@@ -1,0 +1,123 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const chartInstances: { config: any; destroy: () => void; resize: () => void }[] = []
+vi.mock('chart.js/auto', () => ({
+  default: class {
+    config: any
+    destroy = vi.fn()
+    resize = vi.fn()
+    constructor(_canvas: unknown, config: any) {
+      this.config = config
+      chartInstances.push(this)
+    }
+  }
+}))
+const getChart = vi.fn()
+vi.mock('@/services/chartService', () => ({ getChart: (...args: unknown[]) => getChart(...args) }))
+
+import ConfiguredChartPanel from '@/components/Dashboard/panels/ConfiguredChartPanel.vue'
+
+const alarms = {
+  name: 'sample-bar-chart', title: 'Alarms', subTitle: 'Severity Chart', domainAxisLabel: 'Severity', rangeAxisLabel: 'Count',
+  categories: [{ key: '5', label: 'Minor' }, { key: '6', label: 'Major' }],
+  series: [{ name: 'Events', color: '#ffff00', values: [185, 175] }, { name: 'Alarms', color: null, values: [11, null] }]
+}
+
+const mountWith = (options: Record<string, unknown>, refreshTick = 0) => mount(ConfiguredChartPanel, {
+  props: {
+    panelId: 'p1',
+    options,
+    filter: { categories: [], nodeQuery: '' } as any,
+    timeframe: { key: 'last24h' } as any,
+    refreshTick
+  }
+})
+
+describe('ConfiguredChartPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    chartInstances.length = 0
+    ;(globalThis as any).ResizeObserver = class {
+      observe() {} disconnect() {}
+    }
+  })
+
+  it('draws the chart named in the options as grouped bars with the configured colors', async () => {
+    getChart.mockResolvedValue(alarms)
+    mountWith({ chart: 'sample-bar-chart' })
+    await flushPromises()
+
+    expect(getChart).toHaveBeenCalledWith('sample-bar-chart')
+    expect(chartInstances).toHaveLength(1)
+    const config = chartInstances[0].config
+    expect(config.type).toBe('bar')
+    expect(config.data.labels).toEqual(['Minor', 'Major'])
+    expect(config.data.datasets.map((d: any) => d.label)).toEqual(['Events', 'Alarms'])
+    // the configured color edges the bar and fills it translucently
+    expect(config.data.datasets[0].borderColor).toBe('#ffff00')
+    expect(config.data.datasets[0].backgroundColor).toBe('rgba(255, 255, 0, 0.7)')
+    // a series without a configured color still gets one
+    expect(config.data.datasets[1].borderColor).toMatch(/^#/)
+    // the legend is rendered as HTML under the plot, not by Chart.js
+    expect(config.options.plugins.legend.display).toBe(false)
+    expect(config.plugins.map((p: any) => p.id)).toEqual(['htmlLegend', 'configuredChartValues'])
+    expect(config.data.datasets[1].data).toEqual([11, null])
+    expect(config.options.scales.x.title.text).toBe('Severity')
+    expect(config.options.scales.y.title.text).toBe('Count')
+  })
+
+  it('says when the chart cannot be loaded, has no data, or is not selected', async () => {
+    getChart.mockResolvedValue(null)
+    let w = mountWith({ chart: 'sample-bar-chart' })
+    await flushPromises()
+    expect(w.text()).toContain('Unable to load the chart')
+    expect(chartInstances).toHaveLength(0)
+
+    getChart.mockResolvedValue({ ...alarms, categories: [], series: [] })
+    w = mountWith({ chart: 'sample-bar-chart' })
+    await flushPromises()
+    expect(w.text()).toContain('No data for this chart')
+
+    w = mountWith({})
+    await flushPromises()
+    expect(w.text()).toContain('No chart selected')
+    expect(getChart).toHaveBeenCalledTimes(2)
+  })
+
+  it('refetches on the refresh tick and when the chart option changes', async () => {
+    getChart.mockResolvedValue(alarms)
+    const w = mountWith({ chart: 'sample-bar-chart' })
+    await flushPromises()
+    await w.setProps({ refreshTick: 1 })
+    await flushPromises()
+    expect(getChart).toHaveBeenCalledTimes(2)
+    expect(chartInstances[0].destroy).toHaveBeenCalled()
+
+    await w.setProps({ options: { chart: 'sample-bar-chart3' }})
+    await flushPromises()
+    expect(getChart).toHaveBeenLastCalledWith('sample-bar-chart3')
+  })
+})

--- a/ui/tests/services/chartService.test.ts
+++ b/ui/tests/services/chartService.test.ts
@@ -1,0 +1,54 @@
+///
+/// Licensed to The OpenNMS Group, Inc (TOG) under one or more
+/// contributor license agreements.  See the LICENSE.md file
+/// distributed with this work for additional information
+/// regarding copyright ownership.
+///
+/// TOG licenses this file to You under the GNU Affero General
+/// Public License Version 3 (the "License") or (at your option)
+/// any later version.  You may not use this file except in
+/// compliance with the License.  You may obtain a copy of the
+/// License at:
+///
+///      https://www.gnu.org/licenses/agpl-3.0.txt
+///
+/// Unless required by applicable law or agreed to in writing,
+/// software distributed under the License is distributed on an
+/// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+/// either express or implied.  See the License for the specific
+/// language governing permissions and limitations under the
+/// License.
+///
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getChart, getCharts } from '@/services/chartService'
+import { v2 } from '@/services/axiosInstances'
+
+vi.mock('@/services/axiosInstances', () => ({
+  v2: { get: vi.fn() }
+}))
+
+describe('chartService', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('lists the configured charts and treats no content as an empty list', async () => {
+    vi.mocked(v2.get).mockResolvedValue({ status: 200, data: [{ name: 'sample-bar-chart', title: 'Alarms' }] })
+    expect(await getCharts()).toEqual([{ name: 'sample-bar-chart', title: 'Alarms' }])
+    expect(v2.get).toHaveBeenCalledWith('/charts')
+
+    vi.mocked(v2.get).mockResolvedValue({ status: 204, data: '' })
+    expect(await getCharts()).toEqual([])
+  })
+
+  it('fetches one chart by name, encoded, and returns null when it is missing', async () => {
+    const chart = { name: 'a b', title: 'A', categories: [], series: [] }
+    vi.mocked(v2.get).mockResolvedValue({ status: 200, data: chart })
+    expect(await getChart('a b')).toEqual(chart)
+    expect(v2.get).toHaveBeenCalledWith('/charts/a%20b')
+
+    vi.mocked(v2.get).mockRejectedValue(new Error('404'))
+    expect(await getChart('nope')).toBeNull()
+    vi.mocked(v2.get).mockRejectedValue(new Error('500'))
+    expect(await getCharts()).toBeNull()
+  })
+})

--- a/ui/tests/stores/dashboardStore.test.ts
+++ b/ui/tests/stores/dashboardStore.test.ts
@@ -91,6 +91,16 @@ describe('useDashboardStore', () => {
     expect(store.isDirty).toBe(true)
   })
 
+  it('addPanel seeds the options a chart panel type is pinned to', () => {
+    store.addPanel('chart-node-inventory')
+    const added = store.layout.panels[store.layout.panels.length - 1]
+    expect(added.options).toEqual({ chart: 'sample-bar-chart3' })
+
+    // and leaves other panels with the empty options they had before
+    store.addPanel('notes')
+    expect(store.layout.panels[store.layout.panels.length - 1].options).toEqual({})
+  })
+
   it('addPanel ignores unknown panel types', () => {
     const before = store.layout.panels.length
     store.addPanel('no-such-panel')


### PR DESCRIPTION
Makes the three charts of the legacy Charts page available as panels in the Vue dashboard's Add Panel picker (NMS-20309).

The charts stay data-driven from `etc/chart-configuration.xml`, so admin-defined charts work too and nothing about the legacy page changes in this PR.

- New read-only `GET /api/v2/charts` and `GET /api/v2/charts/{name}` run the configured series queries and return categories plus one value series per series definition, with severity keys labelled as before.
- One `ConfiguredChartPanel` draws the chart with Chart.js in the Resource Graphs style: translucent bars edged in the configured color, value labels, soft grid, shared HTML legend.
- Three registry entries, "Charts - Alarms", "Charts - Last 7 Day Outages" and "Charts - Node Inventory", pin the shipped charts through a new `defaultOptions` seed; the panel options dialog can switch a panel to any configured chart.
- The Charts page and its menu entry are untouched.
- `ChartRestServiceIT` covers the list, the severity labels, the inventory counts and the 404; UI tests cover the service, the panel and the option seeding.
