### PR TITLE
NMS-20318: Drop the Guava 17/21 features and update wsman to 1.3.3

### DIFF
--- a/container/features/pom.xml
+++ b/container/features/pom.xml
@@ -394,10 +394,7 @@
                           <feature>fst</feature>
                           <feature>guava</feature>
                           <feature>guava-dependencies</feature>
-                          <feature>guava17</feature>
                           <feature>guava18</feature>
-                          <feature>guava21</feature>
-                          <feature>guava31</feature>
                           <feature>jackson-core</feature>
                           <feature>jackson-dataformat-xml</feature>
                           <feature>jackson-dataformat-yaml</feature>

--- a/container/features/src/main/resources/features-core.xml
+++ b/container/features/src/main/resources/features-core.xml
@@ -152,26 +152,13 @@
     </feature>
 
     <!-- don't rely on dependency="true" for things that want specific versions -->
-    <feature name="guava17" version="17.0" description="Google :: Guava">
-        <bundle>mvn:com.google.guava/guava/17.0</bundle>
-    </feature>
-
     <!-- don't rely on dependency="true" for things that want specific versions -->
     <feature name="guava18" version="18.0" description="Google :: Guava">
         <bundle>mvn:com.google.guava/guava/18.0</bundle>
     </feature>
 
     <!-- don't rely on dependency="true" for things that want specific versions -->
-    <feature name="guava21" version="21.0" description="Google :: Guava">
-        <bundle>mvn:com.google.guava/guava/21.0</bundle>
-    </feature>
-
     <!-- don't rely on dependency="true" for things that want specific versions -->
-    <feature name="guava31" version="31.1" description="Google :: Guava">
-        <feature prerequisite="true">guava-dependencies</feature>
-        <bundle start-level="${earlyStartLevel}">mvn:com.google.guava/guava/31.1-jre</bundle>
-    </feature>
-
     <!-- don't rely on dependency="true" for things that want specific versions -->
     <feature name="guava32" version="32.1" description="Google :: Guava">
         <feature prerequisite="true">guava-dependencies</feature>

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -816,7 +816,7 @@
         <bundle>wrap:mvn:xmlpull/xmlpull/1.1.3.1$Bundle-SymbolicName=xmlpull&amp;Bundle-Version=1.1.3.1</bundle>
     </feature>
     <feature name="wsman-integration" version="${project.version}" description="OpenNMS :: Features :: WS-Man Integration">
-        <feature>guava17</feature>
+        <feature>guava</feature>
         <feature>javax.servlet</feature>
         <feature version="${cxfVersion}">cxf-jaxws</feature>
         <feature version="${cxfVersion}">cxf-ws-addr</feature>
@@ -1571,8 +1571,7 @@
     <feature name="opennms-jest" version="${project.version}" description="OpenNMS :: Features :: Jest :: Feature definition">
         <details>Feature definition for Jest (ElasticSearch Java ReST Client)</details>
         <feature>commons-codec</feature>
-        <!-- TODO: what does it actually need? -->
-        <feature>guava21</feature>
+        <feature>guava</feature>
         <bundle>mvn:com.google.code.gson/gson/${jestGsonVersion}</bundle>
         <bundle>wrap:mvn:org.apache.httpcomponents/httpcore-nio/${httpcoreVersion}</bundle>
         <bundle>mvn:org.opennms.features.jest/org.opennms.features.jest.client/${project.version}</bundle>

--- a/opennms-full-assembly/pom.xml
+++ b/opennms-full-assembly/pom.xml
@@ -347,7 +347,6 @@
                 <feature>dnsjava</feature>
                 <feature>dropwizard-metrics</feature>
                 <feature>fop</feature>
-                <feature>guava17</feature>
                 <feature>guava</feature>
                 <feature>hibernate36</feature>
                 <feature>hibernate-validator4</feature>

--- a/pom.xml
+++ b/pom.xml
@@ -1846,7 +1846,7 @@
     <xmlsecVersion>2.3.4</xmlsecVersion>
     <xstreamVersion>1.4.20</xstreamVersion>
     <wsdl4jVersion>1.6.3</wsdl4jVersion>
-    <wsmanVersion>1.2.3</wsmanVersion>
+    <wsmanVersion>1.3.3</wsmanVersion>
     <zookeeperVersion>3.7.2</zookeeperVersion>
     <zstdJniVersion>1.5.2-1</zstdJniVersion>
     <minaSshdVersion>2.12.1</minaSshdVersion>


### PR DESCRIPTION


### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20318

