### PR TITLE
NMS-20321: Resolve OpenAPI schemas from the JSON wire names, not bean property names

### DIFF
--- a/opennms-openapi-docs/pom.xml
+++ b/opennms-openapi-docs/pom.xml
@@ -288,6 +288,28 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-core-asl</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-mapper-asl</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-jaxb-annotations</artifactId>
+      <scope>provided</scope>
+      <exclusions>
+        <!-- Banned; jakarta.xml.bind-api above supplies the javax.xml.bind package. -->
+        <exclusion>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>io.swagger.core.v3</groupId>
       <artifactId>swagger-annotations</artifactId>
       <version>${swaggerVersion}</version>

--- a/opennms-openapi-docs/src/main/java/org/opennms/openapi/OpenApiDocGenerator.java
+++ b/opennms-openapi-docs/src/main/java/org/opennms/openapi/OpenApiDocGenerator.java
@@ -36,6 +36,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
+import io.swagger.v3.core.converter.ModelConverters;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.jaxrs2.Reader;
 import io.swagger.v3.oas.integration.SwaggerConfiguration;
@@ -58,6 +59,10 @@ public final class OpenApiDocGenerator {
 
     /** AbstractStaticOpenApiResource substitutes the caller's base URI for this. */
     public static final String BASE_URI_PLACEHOLDER = "__OPENNMS_BASE_URI__";
+
+    static {
+        ModelConverters.getInstance().addConverter(new WireFormatModelResolver());
+    }
 
     public enum Api {
         V1("OpenNMS V1 RESTful API",

--- a/opennms-openapi-docs/src/main/java/org/opennms/openapi/WireFormatModelResolver.java
+++ b/opennms-openapi-docs/src/main/java/org/opennms/openapi/WireFormatModelResolver.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to The OpenNMS Group, Inc (TOG) under one or more
+ * contributor license agreements.  See the LICENSE.md file
+ * distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * TOG licenses this file to You under the GNU Affero General
+ * Public License Version 3 (the "License") or (at your option)
+ * any later version.  You may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at:
+ *
+ *      https://www.gnu.org/licenses/agpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ */
+package org.opennms.openapi;
+
+import java.lang.reflect.Type;
+
+import org.codehaus.jackson.annotate.JsonBackReference;
+import org.codehaus.jackson.annotate.JsonIgnore;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.annotate.JsonValue;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyName;
+import com.fasterxml.jackson.databind.cfg.MapperConfig;
+import com.fasterxml.jackson.databind.introspect.Annotated;
+import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
+import com.fasterxml.jackson.databind.introspect.NopAnnotationIntrospector;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
+
+import io.swagger.v3.core.jackson.ModelResolver;
+import io.swagger.v3.core.util.Json;
+
+/**
+ * Resolves schemas the way the webapp serialises JSON.
+ *
+ * The ReST endpoints go through the Jackson 1 JacksonJaxbJsonProvider, so property names and
+ * visibility follow the Jackson 1 ({@code org.codehaus}) and JAXB annotations: {@code meta-data}
+ * rather than {@code metaData}, {@code XmlAccessorType} deciding which getters appear,
+ * {@code XmlElementWrapper} naming the property, Jackson 1 {@code @JsonIgnore} hiding one.
+ * Swagger's stock resolver reads only the Jackson 2 annotations, which the model classes do not
+ * carry, and documents bean names.
+ */
+final class WireFormatModelResolver extends ModelResolver {
+
+    WireFormatModelResolver() {
+        super(jaxbAwareMapper());
+    }
+
+    private static ObjectMapper jaxbAwareMapper() {
+        final ObjectMapper mapper = Json.mapper().copy();
+        // Jackson annotations before JAXB, as in the provider's default (JACKSON, JAXB) order.
+        mapper.setAnnotationIntrospector(AnnotationIntrospector.pair(
+                AnnotationIntrospector.pair(
+                        mapper.getSerializationConfig().getAnnotationIntrospector(),
+                        new Jackson1AnnotationIntrospector()),
+                new WrapperNamingJaxbIntrospector(mapper.getTypeFactory())));
+        return mapper;
+    }
+
+    /**
+     * The stock implementation reaches findJsonValueAccessor reflectively and, if that throws,
+     * falls back to BeanDescription.findJsonValueMethod, which Jackson 2.22 removed. Calling it
+     * directly surfaces the real introspection error instead of a NoSuchMethodError.
+     */
+    @Override
+    protected Type findJsonValueType(final BeanDescription beanDesc) {
+        final AnnotatedMember accessor = beanDesc.findJsonValueAccessor();
+        return accessor == null ? null : accessor.getType();
+    }
+
+    /**
+     * The Jackson 1 annotations the provider honours at runtime, read through the Jackson 2
+     * introspector API. Serialization-side only: the documents describe what the server emits.
+     * Root names are left out on purpose, see {@link WrapperNamingJaxbIntrospector#findRootName}.
+     */
+    private static final class Jackson1AnnotationIntrospector extends NopAnnotationIntrospector {
+        private static final long serialVersionUID = 1L;
+
+        /** Back references are never written, and swagger does not consult findReferenceType. */
+        @Override
+        public boolean hasIgnoreMarker(final AnnotatedMember m) {
+            final JsonIgnore ignore = m.getAnnotation(JsonIgnore.class);
+            return (ignore != null && ignore.value()) || m.hasAnnotation(JsonBackReference.class);
+        }
+
+        @Override
+        public JsonIgnoreProperties.Value findPropertyIgnoralByName(final MapperConfig<?> config, final Annotated a) {
+            final org.codehaus.jackson.annotate.JsonIgnoreProperties ignored =
+                    a.getAnnotation(org.codehaus.jackson.annotate.JsonIgnoreProperties.class);
+            return ignored == null ? null : JsonIgnoreProperties.Value.forIgnoredProperties(ignored.value());
+        }
+
+        @Override
+        public PropertyName findNameForSerialization(final Annotated a) {
+            final JsonProperty property = a.getAnnotation(JsonProperty.class);
+            if (property == null) {
+                return null;
+            }
+            return property.value().isEmpty() ? PropertyName.USE_DEFAULT : PropertyName.construct(property.value());
+        }
+
+        @Override
+        public Boolean hasAsValue(final Annotated a) {
+            final JsonValue value = a.getAnnotation(JsonValue.class);
+            return value == null ? null : value.value();
+        }
+    }
+
+    /**
+     * Jackson 1 took the XmlElementWrapper name as the property name outright. Jackson 2's
+     * USE_WRAPPER_NAME_AS_PROPERTY_NAME renames after collection, so two wrapped lists sharing an
+     * XmlElement name collide before the rename (AlarmStatistics has four "alarm" wrappers).
+     */
+    private static final class WrapperNamingJaxbIntrospector extends JaxbAnnotationIntrospector {
+        private static final long serialVersionUID = 1L;
+
+        WrapperNamingJaxbIntrospector(final TypeFactory typeFactory) {
+            super(typeFactory);
+        }
+
+        @Override
+        public PropertyName findNameForSerialization(final Annotated a) {
+            final PropertyName wrapper = super.findWrapperName(a);
+            return wrapper != null && wrapper.hasSimpleName() ? wrapper : super.findNameForSerialization(a);
+        }
+
+        @Override
+        public PropertyName findNameForDeserialization(final Annotated a) {
+            final PropertyName wrapper = super.findWrapperName(a);
+            return wrapper != null && wrapper.hasSimpleName() ? wrapper : super.findNameForDeserialization(a);
+        }
+
+        @Override
+        public PropertyName findWrapperName(final Annotated a) {
+            return null;
+        }
+
+        /**
+         * Swagger names a schema after the root name when the introspector supplies one, and
+         * XmlRootElement names repeat across classes ("node", "alarm"), so keep the class names.
+         */
+        @Override
+        public PropertyName findRootName(final AnnotatedClass ac) {
+            return null;
+        }
+    }
+}

--- a/opennms-openapi-docs/src/test/java/org/opennms/openapi/OpenApiDocsContentTest.java
+++ b/opennms-openapi-docs/src/test/java/org/opennms/openapi/OpenApiDocsContentTest.java
@@ -59,6 +59,10 @@ public class OpenApiDocsContentTest {
         // org.opennms.features.measurements.rest
         assertHasPath(document, "/measurements");
 
+        // WireFormatModelResolver: JAXB names on the wire, not bean names
+        assertSchemaProperty(document, "RequisitionNode", "meta-data", true);
+        assertSchemaProperty(document, "RequisitionNode", "metaData", false);
+
         assertPathCountAtLeast(document, "v1", 180);
     }
 
@@ -81,6 +85,8 @@ public class OpenApiDocsContentTest {
         // org.opennms.features.geolocation.rest
         assertHasPath(document, "/geolocation");
 
+        assertSchemaProperty(document, "OnmsMonitoringLocation", "location-name", true);
+
         assertPathCountAtLeast(document, "v2", 200);
     }
 
@@ -99,6 +105,13 @@ public class OpenApiDocsContentTest {
     private static void assertBasicAuth(final JsonNode document) {
         assertEquals("http", document.at("/components/securitySchemes/basicAuth/type").asText());
         assertEquals("basic", document.at("/components/securitySchemes/basicAuth/scheme").asText());
+    }
+
+    private static void assertSchemaProperty(final JsonNode document, final String schema, final String property,
+                                             final boolean expected) {
+        final JsonNode node = document.at("/components/schemas/" + schema + "/properties/" + property);
+        assertEquals(schema + (expected ? " should document " : " should not document ") + property,
+                expected, node.isObject());
     }
 
     private static void assertHasPath(final JsonNode document, final String path) {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/TrapdConfigurationResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/TrapdConfigurationResource.java
@@ -30,12 +30,14 @@ import javax.ws.rs.core.Response;
 import org.opennms.core.config.api.ConfigurationResource;
 import org.opennms.core.config.api.ConfigurationResourceException;
 import org.opennms.netmgt.config.TrapdConfig;
+import org.opennms.netmgt.config.trapd.TrapdConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
@@ -64,6 +66,7 @@ public class TrapdConfigurationResource {
             @ApiResponse(responseCode = "200", description = "The current trapd configuration.",
                     content = {
                             @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = TrapdConfiguration.class),
                                     examples = @ExampleObject(value = """
                                             {
                                               "threads": 0,
@@ -78,6 +81,7 @@ public class TrapdConfigurationResource {
                                               "use-address-from-varbind": null
                                             }""")),
                             @Content(mediaType = MediaType.APPLICATION_XML,
+                                    schema = @Schema(implementation = TrapdConfiguration.class),
                                     examples = @ExampleObject(value = """
                                             <?xml version="1.0" encoding="UTF-8"?>
                                             <trapd-configuration xmlns="http://xmlns.opennms.org/xsd/config/trapd"


### PR DESCRIPTION
This registers a resolver in opennms-openapi-docs that introspects with the Jackson 1 annotations first and JAXB second, matching the provider's runtime order, and applies Jackson 1's wrapper-name rule. One endpoint referenced the wrong type outright and is corrected alongside: /config/trapd now points at TrapdConfiguration, the object on the wire, rather than the TrapdConfig interface.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20321
