### PR TITLE
NMS-20320: Replace the JAXB 2.2 implementation bundle with jaxb-runtime

### DIFF
--- a/container/karaf/src/main/internal/features-processing.xml
+++ b/container/karaf/src/main/internal/features-processing.xml
@@ -4,6 +4,13 @@
   xmlns:f="http://karaf.apache.org/xmlns/features/v1.6.0"
 >
 
+  <bundleReplacements>
+    <!-- the Camel feature repository still pins the JAXB 2.2 implementation; use the runtime we already ship -->
+    <bundle originalUri="mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-impl/[2,3)"
+            replacement="mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-runtime/2.3.2_1"
+            mode="maven"/>
+  </bundleReplacements>
+
   <featureReplacements>
     <replacement mode="replace">
       <feature name="activemq-client" description="ActiveMQ client libraries" version="${activemqVersion}">

--- a/container/shared/src/main/internal/features-processing.xml
+++ b/container/shared/src/main/internal/features-processing.xml
@@ -4,6 +4,13 @@
   xmlns:f="http://karaf.apache.org/xmlns/features/v1.6.0"
 >
 
+  <bundleReplacements>
+    <!-- the Camel feature repository still pins the JAXB 2.2 implementation; use the runtime we already ship -->
+    <bundle originalUri="mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-impl/[2,3)"
+            replacement="mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-runtime/2.3.2_1"
+            mode="maven"/>
+  </bundleReplacements>
+
   <featureReplacements>
     <replacement mode="replace">
       <feature name="activemq-client" description="ActiveMQ client libraries" version="${activemqVersion}">

--- a/features/minion/core/repository/src/assembly/repo.xml
+++ b/features/minion/core/repository/src/assembly/repo.xml
@@ -10,6 +10,10 @@
       <outputDirectory></outputDirectory>
       <fileMode>0644</fileMode>
       <directoryMode>0755</directoryMode>
+      <excludes>
+        <exclude>**/*jaxb-impl*/2.2.11_1</exclude>
+        <exclude>**/*jaxb-impl*/2.2.11_1/*</exclude>
+      </excludes>
     </fileSet>
   </fileSets>
 </assembly>

--- a/features/minion/repository/src/assembly/repo.xml
+++ b/features/minion/repository/src/assembly/repo.xml
@@ -13,6 +13,8 @@
       <excludes>
         <exclude>**/jettison/1.3.*</exclude>
         <exclude>**/jettison/1.3.*/*</exclude>
+        <exclude>**/*jaxb-impl*/2.2.11_1</exclude>
+        <exclude>**/*jaxb-impl*/2.2.11_1/*</exclude>
       </excludes>
     </fileSet>
   </fileSets>

--- a/features/sentinel/repository/src/assembly/repo.xml
+++ b/features/sentinel/repository/src/assembly/repo.xml
@@ -10,6 +10,10 @@
       <outputDirectory></outputDirectory>
       <fileMode>0644</fileMode>
       <directoryMode>0755</directoryMode>
+      <excludes>
+        <exclude>**/*jaxb-impl*/2.2.11_1</exclude>
+        <exclude>**/*jaxb-impl*/2.2.11_1/*</exclude>
+      </excludes>
     </fileSet>
   </fileSets>
 </assembly>

--- a/opennms-full-assembly/src/assembly/components/osgi.xml
+++ b/opennms-full-assembly/src/assembly/components/osgi.xml
@@ -25,6 +25,8 @@
         <exclude>**/sshd-*/2.8.0/*</exclude>
         <exclude>**/*xstream*/1.4.8_1</exclude>
         <exclude>**/*xstream*/1.4.8_1/*</exclude>
+        <exclude>**/*jaxb-impl*/2.2.11_1</exclude>
+        <exclude>**/*jaxb-impl*/2.2.11_1/*</exclude>
         <exclude>%regex[.*org\/bouncycastle\/(bcprov|bctls|bcutil|bcpkix)-jdk18on\/1.7[56]\/?.*]</exclude>
         <exclude>org/ops4j/pax/logging/pax-logging-log4j2/1.10.2</exclude>
         <exclude>org/ops4j/pax/logging/pax-logging-log4j2/1.10.2/*</exclude>


### PR DESCRIPTION




### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20320

